### PR TITLE
Separate binaries for GUI and console on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ CMakeCache.txt
 # Generated Visual Studio files
 Debug/
 Release/
-Win*/
 *.sln
 *.suo
 *.*sdf

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,3 @@
-# Qt modules
-if (WITH_QT5)
-    set(copyq_Qt5_Modules Widgets Network Svg Xml Script)
-else()
-    set(QT_USE_QTNETWORK TRUE)
-    set(QT_USE_QTSVG TRUE)
-    set(QT_USE_QTXML TRUE)
-    set(QT_USE_QTSCRIPT TRUE)
-endif()
-
 # Project files
 file(GLOB copyq_SOURCES
     *.cpp
@@ -123,26 +113,55 @@ endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 
-add_executable(copyq WIN32
+set(copyq_COMPILE
     ${copyq_SOURCES}
     ${copyq_MOC}
     ${copyq_FORMS_HEADERS}
     ${copyq_RESOURCES_RCC}
-    ${copyq_RC}
     ${copyq_QM}
     )
 
 if (WIN32)
+    # Create separate binaries for GUI and console under Windows.
+
+    # GUI (copyq.exe)
+    add_executable(copyq WIN32 ${copyq_COMPILE} ${copyq_RC})
     set_target_properties(copyq PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
+
+    # console (copyq.com)
+    add_executable(copyqcon platform/win/main.cpp)
+    set_target_properties(copyqcon PROPERTIES OUTPUT_NAME "copyq" SUFFIX ".com")
+
+    # Qt modules for console app
+    if (WITH_QT5)
+        qt5_use_modules(copyqcon Widgets Network Svg Xml Script)
+    else()
+        include(${QT_USE_FILE})
+    endif()
+
+    # link console app
+    target_link_libraries(copyqcon ${QT_LIBRARIES})
+
+    # install console app
+    install(TARGETS copyqcon DESTINATION bin)
+else()
+    # Single binary for console and GUI.
+    add_executable(copyq ${copyq_COMPILE})
 endif()
 
+# Qt modules
 if (WITH_QT5)
-    qt5_use_modules(copyq ${copyq_Qt5_Modules})
+    qt5_use_modules(copyq Widgets Network Svg Xml Script)
 else()
+    set(QT_USE_QTNETWORK TRUE)
+    set(QT_USE_QTSVG TRUE)
+    set(QT_USE_QTXML TRUE)
+    set(QT_USE_QTSCRIPT TRUE)
     include(${QT_USE_FILE})
 endif()
 
+# link
 target_link_libraries(copyq ${QT_LIBRARIES} ${copyq_LIBRARIES})
 
+# install
 install(TARGETS copyq DESTINATION bin)
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,10 +29,6 @@
 #include <QFile>
 #include <QScriptEngine>
 
-#ifdef Q_OS_WIN
-#include <windows.h>
-#endif
-
 #ifdef HAS_TESTS
 #  include "tests/tests.h"
 #  include <QTest>

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -1,0 +1,106 @@
+/*
+    Copyright (c) 2013, Lukas Holecek <hluk@email.cz>
+
+    This file is part of CopyQ.
+
+    CopyQ is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CopyQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CopyQ.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QProcess>
+#include <QThread>
+
+namespace {
+
+/**
+ * Redirect console input to other process.
+ */
+class ConsoleReader : public QThread {
+public:
+    explicit ConsoleReader(QProcess *process)
+        : m_process(process)
+    {
+    }
+
+    void run()
+    {
+        QFile fin;
+        fin.open(stdin, QIODevice::ReadOnly);
+        m_process->write( fin.readAll() );
+        m_process->closeWriteChannel();
+    }
+
+private:
+    QProcess *m_process;
+};
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    /* Execute .exe file instead of this .com file.
+     * Redirect stdin from this .com process to .exe process.
+     * Redirect stdout and stderr from .exe process to this .com process (e.g. current console).
+     */
+    QCoreApplication app(argc, argv);
+    QStringList args = app.arguments();
+    QString cmd = args.takeFirst();
+
+    QFile ferr;
+    ferr.open(stderr, QIODevice::WriteOnly);
+
+    // *.com -> *.exe
+    if ( !cmd.endsWith(".com", Qt::CaseInsensitive) ) {
+        ferr.write( QObject::tr("ERROR: Unexpected binary file name!\n").toLocal8Bit() );
+        return 1;
+    }
+    cmd.replace(cmd.size() - 3, 3, "exe");
+
+    // Pass arguments and execute the *.exe file.
+    QProcess p;
+    p.start(cmd, args);
+    if ( !p.waitForStarted(-1) ) {
+        ferr.write( QObject::tr("ERROR: Failed to start \"%1\"!\n")
+                    .arg(cmd).toLocal8Bit() );
+        return 1;
+    }
+
+    // Redirect stdin.
+    ConsoleReader reader(&p);
+    reader.start();
+
+    // Read stderr and stdout.
+    QFile fout;
+    fout.open(stdout, QIODevice::WriteOnly);
+
+    while ( p.waitForReadyRead(-1) ) {
+        fout.write( p.readAllStandardOutput() );
+        ferr.write( p.readAllStandardError() );
+        fout.flush();
+        ferr.flush();
+        if (p.state() != QProcess::Running)
+            break;
+    }
+
+    p.waitForFinished(-1);
+    if ( p.error() != QProcess::UnknownError ) {
+        ferr.write( p.errorString().toLocal8Bit() );
+        ferr.write("\n");
+    }
+
+    reader.terminate();
+
+    return p.exitCode();
+}

--- a/src/platform/win/winplatform.cmake
+++ b/src/platform/win/winplatform.cmake
@@ -2,7 +2,7 @@
 set(copyq_RC copyq.rc)
 
 file(GLOB copyq_SOURCES ${copyq_SOURCES}
-    platform/win/*.cpp
+    platform/win/winplatform.cpp
     ../qxt/qxtglobalshortcut_win.cpp
     )
 


### PR DESCRIPTION
Drawbacks:
- Compile time is twice as long.
- This creates two binaries with similar size (console app is just missing the icon).

Advantages:
- Basically just: no code needs to be changed.

Any critic is welcome :).

EDIT: I've solved the binary size and compilation time with the other main() in src/platform/main.cpp (as mentioned in comments).
