### PR TITLE
Focus on MainWindow

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -707,13 +707,13 @@ void MainWindow::showWindow()
     }
     c->scrollTo( c->currentIndex() );
     c->setFocus();
+    QApplication::setActiveWindow(this);
 
     createPlatformNativeInterface()->raiseWindow(winId());
 }
 
 void MainWindow::toggleVisible()
 {
-    // FIXME: focus window if not focused
     if ( isVisible() ) {
         close();
     } else {


### PR DESCRIPTION
When initiate toggle_shortcut, mainwindow appears, but without focus. I spend about 2 hours to fix this error. And with this fix, it working perfectly for me! 

Thanks for the best clipboard manager, and for quality of source code.

What other bugs are still not being fixed? What can I help you with patch?

PS I propose to create file with authors, what do you think about it? 
