### PR TITLE
invoke setFocus() and keyEvent()

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -792,8 +792,8 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         case Qt::Key_PageUp:
             if ( !c->hasFocus() )
                 c->setFocus();
-            else
-                c->keyEvent(event);
+            
+            c->keyEvent(event);
             break;
 
         case Qt::Key_Left:


### PR DESCRIPTION
If the searchbox is active the first item in the list is automatically selected. But if I want to select the second item in the list I have to press `Key_Down` twice. With this change the first `Key_Down` will set the focus and also select the second item in the list.
