### PR TITLE
While searching, enable copy of the first element

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -764,6 +764,9 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
                 previousTab();
                 break;
             default:
+                if ( !c->hasFocus() )
+                    c->setFocus();
+
                 QMainWindow::keyPressEvent(event);
                 break;
         }


### PR DESCRIPTION
If the focus is on the searchbox, the first matching item in the list is already selected but it is not possible to copy this element via the default shortcut `CTRL + C`. `ENTER` would be an alternative to copy the first element but only if the `Paste to current window` option is disabled.
