### PR TITLE
Make translations work on OS X.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ copyq.pro.user
 *.pyc
 *.dmg
 /build
+*.qm

--- a/copyq.pro
+++ b/copyq.pro
@@ -21,12 +21,14 @@ TRANSLATIONS = \
     translations/copyq_zh_CN.ts
 
 macx {
+    # Package the CopyQ plugins into the app bundle
     package_plugins.commands = \
         mkdir -p copyq.app/Contents/PlugIns/copyq/ ; \
         cp plugins/*.dylib copyq.app/Contents/PlugIns/copyq/
     package_plugins.depends = sub-plugins sub-src
     QMAKE_EXTRA_TARGETS += package_plugins
 
+    # Package the Qt frameworks into the app bundle
     package_frameworks.commands = \
         test -e copyq.app/Contents/Frameworks/QtCore.framework \
         || $$dirname(QMAKE_QMAKE)/macdeployqt copyq.app
@@ -34,10 +36,20 @@ macx {
     package_frameworks.depends = sub-src sub-plugins package_plugins
     QMAKE_EXTRA_TARGETS += package_frameworks
 
-    bundle_mac.depends = package_frameworks package_plugins
-    bundle_mac.target = copyq.app
+    # Package the translations
+    package_translations.commands = \
+        $$dirname(QMAKE_QMAKE)/lrelease $$_PRO_FILE_PWD_/copyq.pro && \
+        mkdir -p copyq.app/Contents/Resources/translations && \
+        cp $$_PRO_FILE_PWD_/translations/*.qm copyq.app/Contents/Resources/translations
+    QMAKE_EXTRA_TARGETS += package_translations
+
+    # Rename to CopyQ.app to make it look better
+    bundle_mac.depends = package_frameworks package_plugins package_translations
+    bundle_mac.target = CopyQ.app
+    package_frameworks.commands = mv copyq.app CopyQ.app
     QMAKE_EXTRA_TARGETS += bundle_mac
 
+    # Create a dmg file
     dmg.commands = $$_PRO_FILE_PWD_/utils/create_dmg.sh
     dmg.depends = bundle_mac
     QMAKE_EXTRA_TARGETS += dmg

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -36,6 +36,8 @@
 #ifndef COPYQ_TRANSLATION_PREFIX
 #   ifdef Q_OS_WIN
 #       define COPYQ_TRANSLATION_PREFIX QCoreApplication::applicationDirPath() + "/translations"
+#   elif defined(Q_OS_MAC)
+#       define COPYQ_TRANSLATION_PREFIX QCoreApplication::applicationDirPath() + "/../Resources/translations"
 #   else
 #       define COPYQ_TRANSLATION_PREFIX ""
 #   endif

--- a/utils/create_dmg.sh
+++ b/utils/create_dmg.sh
@@ -5,7 +5,7 @@ set -e -x
 # Creates a .dmg file for CopyQ
 
 script_path=$(cd $(dirname $0); pwd)
-app_path=${1:-$(pwd)/copyq.app}
+app_path=${1:-$(pwd)/CopyQ.app}
 
 if ! python -c 'import Quartz' &>/dev/null || ! which dmgbuild &>/dev/null
 then
@@ -22,9 +22,8 @@ settings="${script_path}/../shared/dmg_settings.py"
 ! [[ -x "${binary}" ]] && echo "unable to execute ${binary}" && exit 1
 
 version=$(${binary} --version | grep 'CopyQ' | sed 's/.*v\([0-9.]*\) .*/\1/')
-stripped_version=$(echo "${version}" | sed 's/\.//g')
 
-dmg="${app_path}/../copyq${stripped_version}.dmg"
+dmg="${app_path}/../CopyQ-${version}.dmg"
 name="CopyQ ${version}"
 echo "Creating ${dmg} for \"${name}\""
 


### PR DESCRIPTION
- Make translations work on OS X
- Change the packaged app from `copyq.app` to `CopyQ.app`
