### PR TITLE
Do not ignore URLs when ignoring copied files

### DIFF
--- a/plugins/itemdata/itemdatasettings.ui
+++ b/plugins/itemdata/itemdatasettings.ui
@@ -96,7 +96,7 @@ text/richtext</string>
         </item>
         <item>
          <property name="text">
-          <string>List of URI (e.g. copied files)</string>
+          <string>List of URI (e.g. copied files, URLs)</string>
          </property>
          <property name="toolTip">
           <string notr="true">text/uri-list</string>

--- a/src/gui/addcommanddialog.cpp
+++ b/src/gui/addcommanddialog.cpp
@@ -127,6 +127,7 @@ void createGlobalShortcut(GlobalAction id, QList<Command> *commands)
 QList<Command> defaultCommands()
 {
     static const QRegExp reURL("^(https?|ftps?|file)://");
+    static const QRegExp reNotURL("^(?!(http|ftp)s?://)");
 
     QList<Command> commands;
     Command *c;
@@ -230,6 +231,7 @@ QList<Command> defaultCommands()
 
     c = newCommand(&commands);
     c->name = AddCommandDialog::tr("Ignore copied files");
+    c->re   = reNotURL;
     c->icon = QString(QChar(IconExclamationSign));
     c->input = mimeUriList;
     c->remove = true;


### PR DESCRIPTION
The "Ignore copied files" command ignored all entries that had a
text/uri-list format. Since a URL is a special case of a URI, in
some cases URLs were ignored. For example, when copying a URL from
Chromium's address bar, Chromium (but not Firefox) stores both
text/plain and text/uri-list mime types. These two are the same mime
types that Nautilus stores when copying a file and thus it is
impossible to distinguish between the two based on mime types alone.
Because of this, an extra regex condition is now added to ignore
only items that are not URLs.

It is easier to _not_ match a URL than to match a file in a
cross-platform way, so a negative look ahead regex is used to
exclude URLs.

Note that even if an address is displayed in Chromium's address bar
in simplified form, e.g.:

  hluk.github.io/CopyQ/

if it is copied to the clipboard containing the full form:

  http://hluk.github.io/CopyQ/

and thus the regex correctly matches.