### PR TITLE
Fix for build failure on OSX 10.11

### DIFF
--- a/src/platform/mac/macplatformwindow.mm
+++ b/src/platform/mac/macplatformwindow.mm
@@ -50,8 +50,8 @@ namespace {
 
         // 0x000008 is a hack to fix pasting in Emacs?
         // https://github.com/TermiT/Flycut/pull/18
-        CGEventSetFlags(VDown,kCGEventFlagMaskCommand|0x000008);
-        CGEventSetFlags(VUp,kCGEventFlagMaskCommand|0x000008);
+        CGEventSetFlags(VDown,CGEventFlags(kCGEventFlagMaskCommand|0x000008));
+        CGEventSetFlags(VUp,CGEventFlags(kCGEventFlagMaskCommand|0x000008));
 
         CGEventPost(kCGHIDEventTap, commandDown);
         CGEventPost(kCGHIDEventTap, VDown);


### PR DESCRIPTION
Added explicit casts to `CGEventFlags`.

Fixes #541.