### PR TITLE
[commandhelp.cpp] "arguments" is array

### DIFF
--- a/src/scriptable/commandhelp.cpp
+++ b/src/scriptable/commandhelp.cpp
@@ -176,7 +176,7 @@ QList<CommandHelp> commandHelp()
             << CommandHelp()
             << CommandHelp("eval, -e",
                            Scriptable::tr("\nEvaluate ECMAScript program.\n"
-                                          "Arguments are accessible using with \"arguments(0..N)\"."))
+                                          "Arguments are accessible using with \"arguments[0..N]\"."))
                .addArg("[" + Scriptable::tr("SCRIPT") + "]")
                .addArg("[" + Scriptable::tr("ARGUMENTS") + "]...")
             << CommandHelp("session, -s, --session",


### PR DESCRIPTION
Use square brackets ("[", "]") instead of round brackets ("(", ")"), because "arguments" object is array (not function).

Also need fix all translated files.