### PR TITLE
Windows: Fix screen number check

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -110,8 +110,16 @@ void restoreWindowGeometry(QWidget *w, bool openOnCurrentScreen)
     QByteArray geometry = geometryOptionValue(optionName + tag).toByteArray();
 
     // If geometry for screen resolution doesn't exist, use last saved one.
-    if (geometry.isEmpty())
+    if (geometry.isEmpty()) {
         geometry = geometryOptionValue(optionName).toByteArray();
+
+        // If geometry for the screen doesn't exist, move window to the middle of the screen.
+        if (geometry.isEmpty()) {
+            const QRect availableGeometry = QApplication::desktop()->availableGeometry(QCursor::pos());
+            w->move( availableGeometry.center() - w->rect().center() );
+            geometry = w->saveGeometry();
+        }
+    }
 
     if (w->saveGeometry() != geometry) {
         w->restoreGeometry(geometry);


### PR DESCRIPTION
On Windows 10 with Qt 5 screens are numbered from 0.

Fixes #616