### PR TITLE
Fix cmake errors on eg. nixos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 
 # Qt modules
 if (WITH_QT5)
+    find_package(Qt5 REQUIRED COMPONENTS Network Svg Xml Script)
     qt5_use_modules(copyq Widgets Network Svg Xml Script ${copyq_Qt5_Modules})
 else()
     set(QT_USE_QTNETWORK TRUE)


### PR DESCRIPTION
When trying to package copyq for nix cmake couldn't find all qt modules, see
https://github.com/NixOS/nixpkgs/issues/26160 for a similar issue with kdenlive. Not well versed in cmake, but this seems like a reasonable fix. (love copyq btw :)