### PR TITLE
Update build instructions to fix build error on macOS

### DIFF
--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -93,8 +93,8 @@ Build with the following commands.
 ::
 
     /usr/local/opt/qt5/bin/qmake
-    make copyq.app
+    make CopyQ.app
 
-This will produce a self-contained application bundle ``copyq.app``
+This will produce a self-contained application bundle ``CopyQ.app``
 which can then be copied or moved into ``/Applications``.
 


### PR DESCRIPTION
Fixed the app name as it seems to be case sensitive.

This change fixes the following error:
$ make copyq.app
make: *** No rule to make target `copyq.app'.  Stop.