### PR TITLE
Remove invalid doc for updateClipboardData(). 

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -999,19 +999,6 @@ omitted.
            setClipboardData();
        }
 
-.. js:function:: updateClipboardData()
-
-   Clears current clipboard data for tray menu, window title and notification.
-
-   Default implementation is:
-
-   .. code-block:: js
-
-       if (isClipboard()) {
-           setTitle();
-           hideDataNotification();
-       }
-
 .. js:function:: setTitle([title])
 
    Set main window title and tool tip.


### PR DESCRIPTION
updateClipboardData() documented twice. Remove the invalid doc -- validity based on the function definition in /src/scriptable/scriptable.cpp.