### PR TITLE
add prompting for useful info in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,5 +29,13 @@ If applicable, add screenshots to help explain your problem.
  - OS [e.g. Windows]
  - Desktop environment, window manager (if applicable)
 
+**Useful info**
+Provide the output of the following commands:
+```bash
+$ copyq info
+$ ls -ld ~/.config/copyq
+$ ls -l ~/.config/copyq/.copyq*
+```
+
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
I recently submitted a bug #1163  and was asked to provide the output of the commands this commit adds. Putting that in the bug report template will further streamline the process.