### PR TITLE
Add emacsclient example editor command for Windows

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -317,6 +317,7 @@ temporary file (and removes the file).
 
 Here is the correct command to use for some editors::
 
+    emacsclientw.exe --alternate-editor="" %1
     gvim --nofork %1
     sublime_text --wait %1
     code --wait %1


### PR DESCRIPTION
This example (for Windows) assumes
- that copyq shares the same HOME environment variable as your normal emacs installation
- that emacsclientw.exe and runemacs.exe are on the PATH (in copyq environment)
- that the emacs server is setup

(tested with emacs & copyq installed via scoop and a starter script setting HOME in the environment before starting copyq)