### PR TITLE
Update basic-usage.rst

### DIFF
--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -7,7 +7,7 @@ First Start
 -----------
 
 To start CopyQ, double-click the program icon or run command ``copyq``.
-This starts the graphical interface which can be accessed from the tray.
+This starts the graphical interface which can be accessed from the tray (NOTE: on OS X the tray defaults to the top-right of the screen and is not to be confused with Launchpad).
 Click the tray icon to show application window or right-click the tray icon and select "Show/Hide" or run ``copyq show`` command.
 
 The central element in the application window is **list with clipboard history**.


### PR DESCRIPTION
To people new to OSX, the "tray" is assumed to be Launchpad (which it isn't).  Clicking the icon from Launchpad and/or Finder does not open any windows or provide any feedback.  Unless you catch that there's a new tiny icon in the tray, one assumes that the app just isn't working.  I wonder how many people have been confused by this and abandoned the app . . .