### PR TITLE
Windows: Show window where cursor is

### DIFF
--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -123,6 +123,7 @@ Source: "{#Root}\plugins\*itempinned.dll"; DestDir: "{app}\plugins"; Components:
 Source: "{#Root}\bearer\*.dll"; DestDir: "{app}\bearer"; Components: program; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#Root}\imageformats\*.dll"; DestDir: "{app}\imageformats"; Components: program; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#Root}\platforms\*.dll"; DestDir: "{app}\platforms"; Components: program; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#Root}\styles\*.dll"; DestDir: "{app}\styles"; Components: program; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#Root}\*.dll"; DestDir: "{app}"; Components: program; Flags: ignoreversion
 
 [Icons]


### PR DESCRIPTION
Is it possible to have the window be created where the cursor (either mouse or text cursor) is? Ditto does this well but CopyQ has many more features that I like.