### PR TITLE
Fix installation instructions in documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ choco install copyq
 On OS X you can use [Homebrew](https://brew.sh/) to install the app.
 
 ```bash
-brew cask install copyq
+brew install --cask copyq
 ```
 
 ### Debian 10+, Ubuntu 18.04+, and their derivatives

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ b. On **OS X**, you can use `Homebrew <https://brew.sh/>`__ to install the app.
 
 .. code-block:: bash
 
-    brew cask install copyq
+    brew install --cask copyq
 
 On Debian unstable, **Debian 10+**, **Ubuntu 18.04+** and later derivatives can
 install stable version from official repositories:


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. Just fix `README.md` and `docs/installation.rst`.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103122456-af630000-46c3-11eb-9bf1-38be979e35bc.png)
