### PR TITLE
workaround / fix for issue #1526 (Copyq autostarts without tray icon)

### DIFF
--- a/shared/com.github.hluk.copyq.desktop.in
+++ b/shared/com.github.hluk.copyq.desktop.in
@@ -9,6 +9,7 @@ Terminal=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 X-KDE-UniqueApplet=true
+X-GNOME-Autostart-Delay=3
 Categories=Qt;KDE;Utility;
 GenericName[af]=Klipbord Program
 GenericName[ar]=أداة الحافظة
@@ -177,4 +178,3 @@ Comment[wa]=Ene ahesse d' istwere di coper/aclacper
 Comment[x-test]=xxA cut & paste history utilityxx
 Comment[zh_CN]=管理剪切和粘贴历史的工具
 Comment[zh_TW]=剪貼紀錄公用程式
-

--- a/shared/com.github.hluk.copyq.desktop.in
+++ b/shared/com.github.hluk.copyq.desktop.in
@@ -3,13 +3,14 @@ Name=CopyQ
 Exec=copyq
 Icon=${ICON_NAME}
 GenericName=Clipboard Manager
+# Workaround / fix for issue #1526 that prevents a proper autostart of the tray icon in GNOME
+X-GNOME-Autostart-Delay=3
 # The rest is taken from Klipper application.
 Type=Application
 Terminal=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 X-KDE-UniqueApplet=true
-X-GNOME-Autostart-Delay=3
 Categories=Qt;KDE;Utility;
 GenericName[af]=Klipbord Program
 GenericName[ar]=أداة الحافظة


### PR DESCRIPTION
A small and simple workaround / fix for this rather annoying bug :).

Fixes #1526 (Copyq autostarts without tray icon)