### PR TITLE
platform/x11: correct autostart boolean value type

### DIFF
--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -220,7 +220,7 @@ void X11Platform::setAutostartEnabled(bool enable)
     desktopFile2.write("Exec=" + cmd.toUtf8() + "\n");
 
     desktopFile2.write("Hidden=");
-    desktopFile2.write(enable ? "False" : "True");
+    desktopFile2.write(enable ? "false" : "true");
     desktopFile2.write("\n");
 
     desktopFile2.write("X-GNOME-Autostart-enabled=");


### PR DESCRIPTION
According to the [desktop-entry-spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s04.html), a boolean value must be either `true` or `false` (in lowercase).