### PR TITLE
Fix handling of git GPG in Windows

### DIFF
--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -54,18 +54,6 @@ const QLatin1String dataFileHeaderV2("CopyQ_encrypted_tab v2");
 
 const int maxItemCount = 10000;
 
-struct KeyPairPaths {
-    KeyPairPaths()
-    {
-        const QString path = getConfigurationFilePath("");
-        sec = QDir::toNativeSeparators(path + ".sec");
-        pub = QDir::toNativeSeparators(path + ".pub");
-    }
-
-    QString sec;
-    QString pub;
-};
-
 bool waitOrTerminate(QProcess *p, int timeoutMs)
 {
     p->waitForStarted();
@@ -103,8 +91,7 @@ bool verifyProcess(QProcess *p, int timeoutMs = 30000)
     return true;
 }
 
-bool checkGpgExecutable(const QString &executable)
-{
+QString getGpgVersionOutput(const QString &executable) {
     QProcess p;
     p.start(executable, QStringList("--version"), QIODevice::ReadWrite);
     p.closeReadChannel(QProcess::StandardError);
@@ -112,9 +99,22 @@ bool checkGpgExecutable(const QString &executable)
     if ( !verifyProcess(&p, 5000) )
         return false;
 
-    const auto versionOutput = p.readAllStandardOutput();
+    return p.readAllStandardOutput();
+}
+
+bool checkGpgExecutable(const QString &executable)
+{
+    const auto versionOutput = getGpgVersionOutput(executable);
     return versionOutput.contains(" 2.");
 }
+
+#ifdef Q_OS_WIN
+bool checkUnixGpg(const QString &executable)
+{
+    static const auto unixGpg = getGpgVersionOutput(executable).contains("Home: /c/");
+    return unixGpg;
+}
+#endif
 
 QString findGpgExecutable()
 {
@@ -131,6 +131,25 @@ const QString &gpgExecutable()
     static const auto gpg = findGpgExecutable();
     return gpg;
 }
+
+struct KeyPairPaths {
+    KeyPairPaths()
+    {
+        const QString path = getConfigurationFilePath("");
+        sec = QDir::toNativeSeparators(path + ".sec");
+        pub = QDir::toNativeSeparators(path + ".pub");
+
+#ifdef Q_OS_WIN
+        if (checkUnixGpg(gpgExecutable())) {
+            pub.replace('\\', '/').replace(":", "").insert(0, '/');
+            sec.replace('\\', '/').replace(":", "").insert(0, '/');
+        }
+#endif
+    }
+
+    QString sec;
+    QString pub;
+};
 
 QStringList getDefaultEncryptCommandArguments(const QString &publicKeyPath)
 {

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -91,13 +91,15 @@ bool verifyProcess(QProcess *p, int timeoutMs = 30000)
     return true;
 }
 
+
+    falsefalse
 QString getGpgVersionOutput(const QString &executable) {
-    QProcess p;
+    false    QProcess p;
     p.start(executable, QStringList("--version"), QIODevice::ReadWrite);
     p.closeReadChannel(QProcess::StandardError);
 
     if ( !verifyProcess(&p, 5000) )
-        return false;
+        return QString();
 
     return p.readAllStandardOutput();
 }

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -91,10 +91,8 @@ bool verifyProcess(QProcess *p, int timeoutMs = 30000)
     return true;
 }
 
-
-    falsefalse
 QString getGpgVersionOutput(const QString &executable) {
-    false    QProcess p;
+    QProcess p;
     p.start(executable, QStringList("--version"), QIODevice::ReadWrite);
     p.closeReadChannel(QProcess::StandardError);
 

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -141,8 +141,8 @@ struct KeyPairPaths {
 
 #ifdef Q_OS_WIN
         if (checkUnixGpg(gpgExecutable())) {
-            pub.replace('\\', '/').replace(":", "").insert(0, '/');
-            sec.replace('\\', '/').replace(":", "").insert(0, '/');
+            pub = QDir::fromNativeSeparators(pub).replace(":", "").insert(0, '/');
+            sec = QDir::fromNativeSeparators(sec).replace(":", "").insert(0, '/');
         }
 #endif
     }


### PR DESCRIPTION
If CopyQ detect's the git bash gpg in path it will use it. However, this version of GPG expects unix paths instead of Windows. Trying to run it with Windows native paths cause it to hang for a lot of time, consuming 100% CPU.

This patch tried to detect whether the given version of GPG in Windows is a unix one, and if such, convert the key paths to unix