### PR TITLE
Windows: Fix installing in 64bit path

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -204,11 +204,11 @@ On Windows (in PowerShell):
 
 .. code-block:: powershell
 
-    & 'C:\Program Files (X86)\CopyQ\copyq.exe' exit
+    & 'C:\Program Files\CopyQ\copyq.exe' exit
     $env:COPYQ_LOG_LEVEL = 'DEBUG'
     $env:COPYQ_LOG_FILE = [Environment]::GetFolderPath("MyDocuments") + '\copyq.log'
     echo "Logs will be written to $env:COPYQ_LOG_FILE"
-    & 'C:\Program Files (X86)\CopyQ\copyq.exe'
+    & 'C:\Program Files\CopyQ\copyq.exe'
 
 How to preserve the order of copied items when copying or pasting multiple items?
 ---------------------------------------------------------------------------------

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -35,7 +35,7 @@ console/terminal application (PowerShell or cmd).
 
   .. code-block:: powershell
 
-    & 'C:\Program Files (x86)\CopyQ\copyq.exe' help | Write-Output
+    & 'C:\Program Files\CopyQ\copyq.exe' help | Write-Output
 
 .. seealso::
 

--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -35,6 +35,10 @@ UsePreviousLanguage=no
 
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
+
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+
 AllowNoIcons=yes
 LicenseFile={#Source}\LICENSE
 OutputDir={#Output}

--- a/utils/appveyor/after_build.sh
+++ b/utils/appveyor/after_build.sh
@@ -135,18 +135,18 @@ appveyor PushArtifact "$installer" -DeploymentName "CopyQ Setup"
 
 # Test installer
 cmd " /c $installer /VERYSILENT /SUPPRESSMSGBOXES"
-"C:/Program Files (x86)/CopyQ/copyq.exe" --version
+"C:/Program Files/CopyQ/copyq.exe" --version
 
 # Test installer can close the app safely
 (
     # Wait for CopyQ to start
-    "C:/Program Files (x86)/CopyQ/copyq.exe" ""
+    "C:/Program Files/CopyQ/copyq.exe" ""
     cmd " /c $installer /VERYSILENT /SUPPRESSMSGBOXES"
     echo "Installation finished"
 ) &
 installer_pid=$!
 export COPYQ_LOG_LEVEL=DEBUG
-"C:/Program Files (x86)/CopyQ/copyq.exe"
+"C:/Program Files/CopyQ/copyq.exe"
 wait "$installer_pid"
 
 gpgconf --kill all


### PR DESCRIPTION
The default install location for the 64bit app should be
"C:\Program Files".

Fixes #1792