### PR TITLE
Add option to disable restoring window geometry

### DIFF
--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -160,6 +160,11 @@ struct open_windows_on_current_screen : Config<bool> {
     static Value defaultValue() { return true; }
 };
 
+struct restore_geometry : Config<bool> {
+    static QString name() { return "restore_geometry"; }
+    static Value defaultValue() { return true; }
+};
+
 struct transparency_focused : Config<int> {
     static QString name() { return "transparency_focused"; }
     static Value value(Value v) { return qBound(0, v, 100); }

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -356,6 +356,8 @@ void ConfigurationManager::initOptions()
     bind<Config::row_index_from_one>();
 
     bind<Config::tabs>();
+
+    bind<Config::restore_geometry>();
 }
 
 template <typename Config, typename Widget>

--- a/src/gui/windowgeometryguard.cpp
+++ b/src/gui/windowgeometryguard.cpp
@@ -38,11 +38,18 @@ bool openOnCurrentScreen()
     return AppConfig().option<Config::open_windows_on_current_screen>();
 }
 
+bool isRestoreGeometryEnabled()
+{
+    return AppConfig().option<Config::restore_geometry>();
+}
+
 } // namespace
 
 void WindowGeometryGuard::create(QWidget *window)
 {
-    new WindowGeometryGuard(window);
+    static const bool enabled = isRestoreGeometryEnabled();
+    if (enabled)
+        new WindowGeometryGuard(window);
 }
 
 bool WindowGeometryGuard::eventFilter(QObject *, QEvent *event)


### PR DESCRIPTION
Restoring window geometry can be disabled with following command:

    copyq config restore_geometry false

Application restart is needed after changing the option.