### PR TITLE
docs: Update macOS building from source instructions

### DIFF
--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -124,7 +124,12 @@ On OS X, required Qt 5 libraries and utilities can be easily installed with `Hom
 
 ::
 
-    brew install qt5
+    cd CopyQ
+    git -C "utils/github/homebrew" init .
+    git -C "utils/github/homebrew" add .
+    git -C "utils/github/homebrew" commit -m "Initial"
+    brew tap copyq/kde utils/github/homebrew/
+    brew install qt5 copyq/kde/kf5-knotifications
 
 Build with the following commands:
 


### PR DESCRIPTION
I was trying to follow the macOS build from source instructions but wasn't able to compile. Thankfully we can follow pretty much the same steps as in the github actions method :)