### PR TITLE
Add scriptable Settings object

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1669,6 +1669,50 @@ Types
 
    To open file in different modes, use same open methods as for `File`.
 
+.. js:class:: Settings
+
+   Reads and writes INI configuration files. Wrapper for QSettings Qt class.
+
+   See `QSettings <https://doc.qt.io/qt-5/qsettings.html>`__.
+
+   .. code-block:: js
+
+       // Open INI file
+       var configPath = Dir().homePath() + '/copyq.ini'
+       var settings = new Settings(configPath)
+
+       // Save an option
+       settings.setValue('option1', 'test')
+
+       // Store changes to the config file now instead of at the end of
+       // executing the script
+       settings.sync()
+
+       // Read the option value
+       var value = settings.value('option1')
+
+   Working with arrays:
+
+   .. code-block:: js
+
+       // Write array
+       var settings = new Settings(configPath)
+       settings.beginWriteArray('array1')
+       settings.setArrayIndex(0)
+       settings.setValue('some_option', 1)
+       settings.setArrayIndex(1)
+       settings.setValue('some_option', 2)
+       settings.endArray()
+       settings.sync()
+
+       // Read array
+       var settings = new Settings(configPath)
+       const arraySize = settings.beginReadArray('array1')
+       for (var i = 0; i < arraySize; i++) {
+           settings.setArrayIndex(i);
+           print('Index ' + i + ': ' + settings.value('some_option') + '\n')
+       }
+
 .. js:class:: Item
 
    Object with MIME types of an item.

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -175,6 +175,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("File", "File", "Wrapper for QFile Qt class.");
     addDocumentation("Dir", "Dir", "Wrapper for QDir Qt class.");
     addDocumentation("TemporaryFile", "TemporaryFile", "Wrapper for QTemporaryFile Qt class.");
+    addDocumentation("Settings", "Settings", "Reads and writes INI configuration files. Wrapper for QSettings Qt class.");
     addDocumentation("Item", "Item", "Object with MIME types of an item.");
     addDocumentation("ItemSelection", "ItemSelection", "List of items from given tab.");
     addDocumentation("FinishedCommand", "FinishedCommand", "Properties of finished command.");

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -40,6 +40,7 @@
 #include "scriptable/scriptablefile.h"
 #include "scriptable/scriptableitemselection.h"
 #include "scriptable/scriptableproxy.h"
+#include "scriptable/scriptablesettings.h"
 #include "scriptable/scriptabletemporaryfile.h"
 
 #include <QApplication>
@@ -708,6 +709,7 @@ Scriptable::Scriptable(
     addScriptableClass(&ScriptableDir::staticMetaObject, QStringLiteral("Dir"), m_engine);
     addScriptableClass(&ScriptableItemSelection::staticMetaObject, QStringLiteral("ItemSelection"), m_engine,
                        QStringLiteral("global._initItemSelection = "));
+    addScriptableClass(&ScriptableSettings::staticMetaObject, QStringLiteral("Settings"), m_engine);
 }
 
 QJSValue Scriptable::argumentsArray() const

--- a/src/scriptable/scriptablesettings.cpp
+++ b/src/scriptable/scriptablesettings.cpp
@@ -1,0 +1,32 @@
+/*
+    Copyright (c) 2022, Lukas Holecek <hluk@email.cz>
+
+    This file is part of CopyQ.
+
+    CopyQ is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CopyQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CopyQ.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "scriptablesettings.h"
+
+ScriptableSettings::ScriptableSettings()
+    : QObject()
+    , m_settings()
+{
+}
+
+ScriptableSettings::ScriptableSettings(const QString &fileName)
+    : QObject()
+    , m_settings(fileName, QSettings::IniFormat)
+{
+}

--- a/src/scriptable/scriptablesettings.h
+++ b/src/scriptable/scriptablesettings.h
@@ -1,0 +1,58 @@
+/*
+    Copyright (c) 2022, Lukas Holecek <hluk@email.cz>
+
+    This file is part of CopyQ.
+
+    CopyQ is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    CopyQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CopyQ.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SCRIPTABLESETTINGS_H
+#define SCRIPTABLESETTINGS_H
+
+#include <QJSValue>
+#include <QObject>
+#include <QSettings>
+
+class ScriptableSettings final : public QObject
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE explicit ScriptableSettings();
+    Q_INVOKABLE explicit ScriptableSettings(const QString &fileName);
+
+public slots:
+    QStringList allKeys() { return m_settings.allKeys(); }
+    void beginGroup(const QString &prefix) { m_settings.beginGroup(prefix); }
+    QJSValue beginReadArray(const QString &prefix) { return m_settings.beginReadArray(prefix); }
+    void beginWriteArray(const QString &prefix, int size = -1) { m_settings.beginWriteArray(prefix, size); }
+    QStringList childGroups() { return m_settings.childGroups(); }
+    QStringList childKeys() { return m_settings.childKeys(); }
+    void clear() { m_settings.clear(); }
+    QJSValue contains(const QString &key) { return m_settings.contains(key); }
+    void endArray() { m_settings.endArray(); }
+    void endGroup() { m_settings.endGroup(); }
+    QJSValue fileName() { return m_settings.fileName(); }
+    QJSValue group() { return m_settings.group(); }
+    QJSValue isWritable() { return m_settings.isWritable(); }
+    void remove(const QString &key) { m_settings.remove(key); }
+    void setArrayIndex(int i) { m_settings.setArrayIndex(i); }
+    void setValue(const QString &key, const QJSValue &value) { m_settings.setValue(key, value.toVariant()); }
+    void sync() { m_settings.sync(); }
+    QVariant value(const QString &key, const QJSValue &defaultValue = QJSValue()) { return m_settings.value(key, defaultValue.toVariant()); }
+
+private:
+    QSettings m_settings;
+};
+
+#endif // SCRIPTABLESETTINGS_H

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -155,6 +155,7 @@ private slots:
     void classTemporaryFile();
     void classItemSelection();
     void classItemSelectionGetCurrent();
+    void classSettings();
     void calledWithInstance();
 
     void pipingCommands();


### PR DESCRIPTION
This is wrapper for QSettings Qt class.

Usage:

    // Open INI file
    var configPath = Dir().homePath() + '/copyq.ini'
    var settings = new Settings(configPath)

    // Save an option
    settings.setValue('option1', 'test')

    // Store changes to the config file now instead of at the end of
    // executing the script
    settings.sync()

    // Read the option value
    var value = settings.value('option1')

Fixes #1964