### PR TITLE
Update outdated gpg4win-vanilla recommendation

### DIFF
--- a/docs/password-protection.rst
+++ b/docs/password-protection.rst
@@ -18,9 +18,9 @@ Configuration dialog) may prompt you to install
 `GnuPG <http://www.gnupg.org/>`__:
 
 -  For Windows you can use `Chocolatey <https://chocolatey.org/install>`__ to
-   install `Gpg4win Vanilla <https://chocolatey.org/packages/gpg4win-vanilla>`__::
+   install `Gpg4win <https://chocolatey.org/packages/gpg4win>`__::
 
-       choco install gpg4win-vanilla
+       choco install gpg4win
 
 -  For Linux install ``gpg`` command line utility. It's usually provided
    by ``gnupg`` package but the package name may differ on some


### PR DESCRIPTION
gpg4win-vanilla's description recommends gpg4win >= v3.0. 
gpg4win-vanilla is no longer maintained, with its last update on Oct. 2019.
See the package details: https://community.chocolatey.org/packages/gpg4win-vanilla