### PR TITLE
List config() with current values for each option

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -3084,8 +3084,13 @@ QString MainWindow::configDescription()
     QStringList options = configurationManager.options();
     options.sort();
     QString opts;
-    for (const auto &option : options)
-        opts.append( option + "\n  " + configurationManager.optionToolTip(option).replace('\n', "\n  ") + '\n' );
+    AppConfig appConfig;
+    configurationManager.loadSettings(&appConfig);
+    for (const auto &option : options) {
+        const QString description = configurationManager.optionToolTip(option).replace('\n', "\n  ");
+        const QString value = configurationManager.optionValue(option).toString().replace('\n', "\\n");
+        opts.append( QStringLiteral("%1=%2\n  %3\n").arg(option, value, description) );
+    }
     return opts;
 }
 


### PR DESCRIPTION
Example of new `copyq config` output:

```
...
clipboard_notification_lines=3
  Number of lines to show for new clipboard content.

  Set to 0 to disable.
clipboard_tab=&clipboard
  Name of tab that will automatically store new clipboard content.

  Leave empty to disable automatic storing.
close_on_unfocus=false
  Close main window when other application has focus
...
```

Fixes #412