### PR TITLE
Fix tray window popup on multi-monitor

### DIFF
--- a/src/common/display.cpp
+++ b/src/common/display.cpp
@@ -56,11 +56,8 @@ int smallIconSize()
 
 QPoint toScreen(QPoint pos, QWidget *w)
 {
-    QWindow *window = w->windowHandle();
-    if (window)
-        window->setPosition(pos);
-    else
-        w->move(pos);
+	QWindow *window = w->windowHandle();
+    w->move(pos);
 
     const QRect availableGeometry = screenAvailableGeometry(*w);
     if ( !availableGeometry.isValid() )

--- a/src/common/display.cpp
+++ b/src/common/display.cpp
@@ -56,7 +56,7 @@ int smallIconSize()
 
 QPoint toScreen(QPoint pos, QWidget *w)
 {
-	QWindow *window = w->windowHandle();
+    QWindow *window = w->windowHandle();
     w->move(pos);
 
     const QRect availableGeometry = screenAvailableGeometry(*w);

--- a/src/gui/screen.cpp
+++ b/src/gui/screen.cpp
@@ -50,9 +50,6 @@ QRect screenGeometry(int i)
 
 QRect screenAvailableGeometry(const QWidget &w)
 {
-    if ( w.windowHandle() && w.windowHandle()->screen() )
-        return w.windowHandle()->screen()->availableGeometry();
-
 #if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
     auto screen = QGuiApplication::screenAt(w.pos());
     return screen ? screen->availableGeometry() : screenGeometry(0);


### PR DESCRIPTION
heya, me again!
I went through some of the code for the tray popup since it has an issue where it only sticks to the screen it was first shown on. I fixed that (`screen.cpp`) as it was reusing the previous screen, so it would only ever use the first one it used.
After that I did some more debugging and it seems that using `window->setPosition` seems to grab the previous position, so you have to show the menu twice in the same spot for it to get the correct coordinates. I removed that part of the code, and the menu now calculates the correct position for the usable area rather than sometimes using the one for the other monitor.

I've tested this on my PC, let me know if there's any issues on other setups. Thanks!