### PR TITLE
Allow setting precise window geometry

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -156,6 +156,18 @@ unlike in GUI, where row numbers start from 1 by default.
 
    The new window position and size will not be stored for ``show()``.
 
+.. js:function:: windowPosition(x, y)
+
+   Set main window position.
+
+   The new window position will be also stored for ``show()``.
+
+.. js:function:: windowSize(width, height)
+
+   Set main window size.
+
+   The new window size will be also stored for ``show()``.
+
 .. js:function:: hide()
 
    Hides main window.

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -11,6 +11,8 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("showAt", "showAt(x, y, [width, height])", "Shows main window with given geometry.");
     addDocumentation("showAt", "showAt()", "Shows main window under mouse cursor.");
     addDocumentation("showAt", "showAt(x, y, width, height, tabName)", "Shows tab with given geometry.");
+    addDocumentation("windowPosition", "windowPosition(x, y)", "Set main window position.");
+    addDocumentation("windowSize", "windowSize(width, height)", "Set main window size.");
     addDocumentation("hide", "hide()", "Hides main window.");
     addDocumentation("toggle", "toggle() -> bool", "Shows or hides main window.");
     addDocumentation("menu", "menu()", "Opens context menu.");

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -1037,6 +1037,28 @@ void Scriptable::showAt()
         m_proxy->showBrowserAt(tabName, rect);
 }
 
+QJSValue Scriptable::windowPosition()
+{
+    m_skipArguments = 2;
+    int x = -1;
+    int y = -1;
+    if ( !toInt(argument(0), &x) || !toInt(argument(1), &y) )
+        return throwError(argumentError());
+    m_proxy->setWindowPosition(x, y);
+    return {};
+}
+
+QJSValue Scriptable::windowSize()
+{
+    m_skipArguments = 2;
+    int w = -1;
+    int h = -1;
+    if ( !toInt(argument(0), &w) || !toInt(argument(1), &h) )
+        return throwError(argumentError());
+    m_proxy->setWindowSize(w, h);
+    return {};
+}
+
 void Scriptable::hide()
 {
     m_skipArguments = 0;

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -170,6 +170,8 @@ public slots:
 
     void show();
     void showAt();
+    QJSValue windowPosition();
+    QJSValue windowSize();
     void hide();
     QJSValue toggle();
     QJSValue menu();

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -615,8 +615,8 @@ void setGeometryWithoutSave(QWidget *window, QRect geometry)
             ? QCursor::pos()
             : geometry.topLeft();
 
-    const int w = pointsToPixels(geometry.width(), window);
-    const int h = pointsToPixels(geometry.height(), window);
+    const int w = geometry.width();
+    const int h = geometry.height();
     if (w > 0 && h > 0)
         window->resize(w, h);
 
@@ -1076,6 +1076,18 @@ bool ScriptableProxy::showWindowAt(QRect rect)
     INVOKE(showWindowAt, (rect));
     setGeometryWithoutSave(m_wnd, rect);
     return showWindow();
+}
+
+void ScriptableProxy::setWindowPosition(int x, int y)
+{
+    INVOKE2(setWindowPosition, (x, y));
+    m_wnd->move(x, y);
+}
+
+void ScriptableProxy::setWindowSize(int w, int h)
+{
+    INVOKE2(setWindowSize, (w, h));
+    m_wnd->resize(w, h);
 }
 
 bool ScriptableProxy::pasteToCurrentWindow()
@@ -2081,9 +2093,9 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
         else if (value.name == ".style")
             styleSheet = value.value.toString();
         else if (value.name == ".height")
-            geometry.setHeight( pointsToPixels(value.value.toInt()) );
+            geometry.setHeight( value.value.toInt() );
         else if (value.name == ".width")
-            geometry.setWidth( pointsToPixels(value.value.toInt()) );
+            geometry.setWidth( value.value.toInt() );
         else if (value.name == ".x")
             geometry.setX(value.value.toInt());
         else if (value.name == ".y")

--- a/src/scriptable/scriptableproxy.h
+++ b/src/scriptable/scriptableproxy.h
@@ -107,6 +107,8 @@ public slots:
     void close();
     bool showWindow();
     bool showWindowAt(QRect rect);
+    void setWindowPosition(int x, int y);
+    void setWindowSize(int w, int h);
     bool pasteToCurrentWindow();
     bool copyFromCurrentWindow();
 


### PR DESCRIPTION
Adds `windowSize()` and `windowPosition()` script functions to set the main window size and position (without showing the window).

Fixes #2101