### PR TITLE
Wayland: Avoid deleting clipboard data while accessing it

### DIFF
--- a/src/platform/x11/systemclipboard/waylandclipboard.cpp
+++ b/src/platform/x11/systemclipboard/waylandclipboard.cpp
@@ -337,8 +337,10 @@ public:
 
     ~DataControlSource()
     {
-        delete m_mimeData;
-        m_mimeData = nullptr;
+        if (m_mimeData) {
+            m_mimeData->deleteLater();
+            m_mimeData = nullptr;
+        }
         if ( isInitialized() )
             destroy();
     }


### PR DESCRIPTION
Fixes SIGSEGV when accessing data that is being deleted in another thread.