### PR TITLE
Docs: Bump certifi from 2021.10.8 to 2022.12.7

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 Babel==2.9.1
-certifi==2021.10.8
+certifi==2022.12.7
 charset-normalizer==2.0.7
 docutils==0.17.1
 idna==3.3


### PR DESCRIPTION
Fixes a critical vulnerability.