### PR TITLE
Update installer script

### DIFF
--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -1,25 +1,42 @@
-﻿; 1. Open this file with Inno Setup with Unicode support and preprocessor.
+; 1. Open this file with Inno Setup with Unicode support and preprocessor.
 ; 2. Change "#defines" below (or see below how to use COPYQ_INNO_SETUP environment variable).
 ; 3. Compile "setup.exe".
 
 ; Path for output installation file
-#define Output "."
+#define Output         "."
+#define MyAppName      "CopyQ"
+#define MyAppNameMin   "copy"
+#define MyAppCopyright "Lukas Holecek"
 
 [Setup]
 AppId={{9DF1F443-EA0B-4C75-A4D3-767A7783228E}
-AppName=CopyQ
+AppName={#MyAppName}
 AppVersion={#AppVersion}
-AppVerName=CopyQ {#AppVersion}
-AppPublisher=Lukas Holecek
+AppVerName={#MyAppName} {#AppVersion}
+
+AppCopyright=(c) {#MyAppCopyright}
+AppPublisher={#MyAppCopyright}
+
 AppPublisherURL=http://hluk.github.io/CopyQ/
 AppSupportURL=http://hluk.github.io/CopyQ/
 AppUpdatesURL=http://hluk.github.io/CopyQ/
-DefaultDirName={pf}\CopyQ
-DefaultGroupName=CopyQ
+
+VersionInfoDescription={#MyAppName} installer
+VersionInfoProductName={#MyAppName} {#AppVersion}
+VersionInfoVersion={#AppVersion}
+
+UninstallDisplayName={#MyAppName} {#AppVersion}
+UninstallDisplayIcon={#Root}\copyq.exe
+
+WizardStyle=Modern
+UsePreviousLanguage=no
+
+DefaultDirName={pf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile={#Source}\LICENSE
 OutputDir={#Output}
-OutputBaseFilename=copyq-{#AppVersion}-setup
+OutputBaseFilename={#MyAppNameMin}-{#AppVersion}-setup
 Compression=lzma
 SolidCompression=yes
 SetupIconFile={#Source}\src\images\icon.ico
@@ -27,12 +44,6 @@ WizardImageFile=logo.bmp
 WizardSmallImageFile=logo-small.bmp
 CloseApplications=force
 
-VersionInfoDescription=CopyQ installer
-VersionInfoProductName=CopyQ {#AppVersion}
-VersionInfoVersion={#AppVersion}
-UninstallDisplayName=CopyQ {#AppVersion}
-UninstallDisplayIcon={#Root}\copyq.exe
-AppCopyright=(c) Lukas Holecek
 
 [Languages]
 Name: en; MessagesFile: "compiler:Default.isl"

--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -3,10 +3,12 @@
 ; 3. Compile "setup.exe".
 
 ; Path for output installation file
-#define Output         "."
-#define MyAppName      "CopyQ"
-#define MyAppNameMin   "copy"
-#define MyAppCopyright "Lukas Holecek"
+#define Output                   "."
+#define MyAppName                "CopyQ"
+#define MyAppNameMin             "copyq"
+#define MyAppCopyright           "Lukas Holecek"
+#define MyAppCopyrightStartYear  "2009"
+#define MyAppCopyrightEndYear    GetDateTimeString('yyyy','','')
 
 [Setup]
 AppId={{9DF1F443-EA0B-4C75-A4D3-767A7783228E}
@@ -14,7 +16,7 @@ AppName={#MyAppName}
 AppVersion={#AppVersion}
 AppVerName={#MyAppName} {#AppVersion}
 
-AppCopyright=(c) {#MyAppCopyright}
+AppCopyright={#MyAppCopyright} {#MyAppCopyrightStartingYear}-{#MyAppCopyright}
 AppPublisher={#MyAppCopyright}
 
 AppPublisherURL=http://hluk.github.io/CopyQ/
@@ -43,7 +45,6 @@ SetupIconFile={#Source}\src\images\icon.ico
 WizardImageFile=logo.bmp
 WizardSmallImageFile=logo-small.bmp
 CloseApplications=force
-
 
 [Languages]
 Name: en; MessagesFile: "compiler:Default.isl"

--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -16,7 +16,7 @@ AppName={#MyAppName}
 AppVersion={#AppVersion}
 AppVerName={#MyAppName} {#AppVersion}
 
-AppCopyright={#MyAppCopyright} {#MyAppCopyrightStartingYear}-{#MyAppCopyright}
+AppCopyright={#MyAppCopyright} {#MyAppCopyrightStartYear}-{#MyAppCopyrightEndYear}
 AppPublisher={#MyAppCopyright}
 
 AppPublisherURL=http://hluk.github.io/CopyQ/


### PR DESCRIPTION
@hluk 

More use of varables instead fixed text (ex. "CopyQ")
Use of Modern style
Disable "Usepreviouslanguage" setting to enable if new language added in new version will be detected.
Separated setting group with newline for better clearance

Note: for Copyright message could be ok for you
- to remove "(c)" not necessary because Copyright is field name
- to add at the end a starting copyright year/ending copyright year=current year? 
Which is for you your starting copyright year?