### PR TITLE
Allow editing other text formats

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1229,8 +1229,9 @@ bool ClipboardBrowser::openEditor(const QModelIndex &index)
         return true;
 
     if ( !m_sharedData->editor.trimmed().isEmpty() ) {
-        if ( data.contains(mimeText) ) {
-            auto itemEditor = new ItemEditor( data[mimeText].toByteArray(), mimeText, m_sharedData->editor, this );
+        const QString text = getTextData(data);
+        if ( !text.isNull() ) {
+            auto itemEditor = new ItemEditor( text.toUtf8(), mimeText, m_sharedData->editor, this );
             itemEditor->setIndex(index);
             if ( startEditor(itemEditor) )
                 return true;

--- a/src/item/clipboarditem.cpp
+++ b/src/item/clipboarditem.cpp
@@ -132,18 +132,16 @@ QVariant ClipboardItem::data(int role) const
     switch(role) {
     case Qt::DisplayRole:
     case Qt::EditRole:
-        if ( m_data.contains(mimeText) )
-            return getTextData(m_data);
-        if ( m_data.contains(mimeUriList) )
-            return getTextData(m_data, mimeUriList);
-        break;
+        return getTextData(m_data);
 
     case contentType::data:
         return m_data; // copy-on-write, so this should be fast
     case contentType::hash:
         return dataHash();
     case contentType::hasText:
-        return m_data.contains(mimeText) || m_data.contains(mimeUriList);
+        return m_data.contains(mimeText)
+            || m_data.contains(mimeTextUtf8)
+            || m_data.contains(mimeUriList);
     case contentType::hasHtml:
         return m_data.contains(mimeHtml);
     case contentType::text:

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -238,12 +238,9 @@ ItemEditorWidget *ItemDelegate::createCustomEditor(
         text = index.data(contentType::notes).toString();
     } else {
         const QVariantMap data = m_sharedData->itemFactory->data(index);
-        if ( !data.contains(mimeText) )
-            return nullptr;
-
         text = getTextData(data, mimeHtml);
         if (text.isEmpty()) {
-            text = getTextData(data, mimeText);
+            text = getTextData(data);
         } else {
             hasHtml = true;
         }

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -34,6 +34,7 @@ class Scriptable final : public QObject
     Q_OBJECT
     Q_PROPERTY(QJSValue inputSeparator READ getInputSeparator WRITE setInputSeparator)
     Q_PROPERTY(QJSValue mimeText READ getMimeText CONSTANT)
+    Q_PROPERTY(QJSValue mimeTextUtf8 READ getMimeTextUtf8 CONSTANT)
     Q_PROPERTY(QJSValue mimeHtml READ getMimeHtml CONSTANT)
     Q_PROPERTY(QJSValue mimeUriList READ getMimeUriList CONSTANT)
     Q_PROPERTY(QJSValue mimeWindowTitle READ getMimeWindowTitle CONSTANT)
@@ -117,6 +118,7 @@ public:
     void installObject(QObject *fromObj, const QMetaObject *metaObject, QJSValue &toObject);
 
     QJSValue getMimeText() const { return mimeText; }
+    QJSValue getMimeTextUtf8() const { return mimeTextUtf8; }
     QJSValue getMimeHtml() const { return mimeHtml; }
     QJSValue getMimeUriList() const { return mimeUriList; }
     QJSValue getMimeWindowTitle() const { return mimeWindowTitle; }


### PR DESCRIPTION
Prefer opening editor with "text/plain;charset=utf-8" before trying "text/plain".

Try also "text/uri-list" if "text/plain" is not available.