### PR TITLE
Fix drag-moving items to other tabs

### DIFF
--- a/src/gui/tabbar.cpp
+++ b/src/gui/tabbar.cpp
@@ -183,10 +183,12 @@ void TabBar::dropEvent(QDropEvent *event)
 {
     int tabIndex = dropItemsTabIndex(*event, *this);
 
-    if ( tabIndex != -1 )
+    if ( tabIndex != -1 ) {
+        acceptDrag(event);
         emit dropItems( tabName(tabIndex), event->mimeData() );
-    else
+    } else {
         QTabBar::dropEvent(event);
+    }
 }
 
 void TabBar::tabInserted(int index)


### PR DESCRIPTION
With tab bar, items were always copied to the target tab and never removed from the source tab.

Fixes #1246