### PR TITLE
Use static text and icon for Toggle Clipboard Storing menu item

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -567,7 +567,6 @@ MainWindow::MainWindow(const ClipboardBrowserSharedPtr &sharedData, QWidget *par
     , m_trayMenu( new TrayMenu(this) )
     , m_tray(nullptr)
     , m_toolBar(new ToolBar(this))
-    , m_actionToggleClipboardStoring()
     , m_sharedData(sharedData)
     , m_menu( new TrayMenu(this) )
     , m_menuMaxItemCount(-1)
@@ -801,9 +800,7 @@ void MainWindow::createMenu()
     createAction( Actions::File_ProcessManager, &MainWindow::showProcessManagerDialog, menu );
 
     // - enable/disable
-    m_actionToggleClipboardStoring = createAction( Actions::File_ToggleClipboardStoring,
-                                                   &MainWindow::toggleClipboardStoring, menu );
-    updateMonitoringActions();
+    createAction( Actions::File_ToggleClipboardStoring, &MainWindow::toggleClipboardStoring, menu );
 
     // - separator
     menu->addSeparator();
@@ -1385,17 +1382,6 @@ void MainWindow::updateWindowTransparency(bool mouseOver)
 {
     int opacity = 100 - (mouseOver || isActiveWindow() ? m_options.transparencyFocused : m_options.transparency);
     setWindowOpacity(opacity / 100.0);
-}
-
-void MainWindow::updateMonitoringActions()
-{
-    if ( !m_actionToggleClipboardStoring.isNull() ) {
-        m_actionToggleClipboardStoring->setIcon(
-                    getIcon("", m_clipboardStoringDisabled ? IconCheck : IconBan));
-        m_actionToggleClipboardStoring->setText( m_clipboardStoringDisabled
-                                                 ? tr("&Enable Clipboard Storing")
-                                                 : tr("&Disable Clipboard Storing") );
-    }
 }
 
 ClipboardBrowserPlaceholder *MainWindow::getPlaceholder(int index) const
@@ -3324,14 +3310,11 @@ void MainWindow::disableClipboardStoring(bool disable)
     m_clipboardStoringDisabled = disable;
     emit disableClipboardStoringRequest(disable);
 
-    updateMonitoringActions();
-
     ::setSessionIconEnabled(!disable);
 
     updateIcon();
 
-    if (m_clipboardStoringDisabled)
-        runScript("setTitle(); showDataNotification()");
+    runScript("setTitle(); showDataNotification()");
 
     COPYQ_LOG( QString("Clipboard monitoring %1.")
                .arg(m_clipboardStoringDisabled ? "disabled" : "enabled") );

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -555,9 +555,6 @@ private:
 
     void updateWindowTransparency(bool mouseOver = false);
 
-    /** Update name and icon of "disable/enable monitoring" menu actions. */
-    void updateMonitoringActions();
-
     /** Return browser widget in given tab @a index. */
     ClipboardBrowserPlaceholder *getPlaceholder(int index) const;
 
@@ -647,7 +644,6 @@ private:
     MainWindowOptions m_options;
 
     bool m_clipboardStoringDisabled = false;
-    QPointer<QAction> m_actionToggleClipboardStoring;
 
     ClipboardBrowserSharedPtr m_sharedData;
 

--- a/src/gui/menuitems.cpp
+++ b/src/gui/menuitems.cpp
@@ -60,7 +60,7 @@ MenuItems menuItems()
     addMenuItem( items, Actions::File_ShowPreview, QObject::tr("&Show Preview"),
                  "show_item_preview", QObject::tr("F7"), "document-print-preview", IconEye );
     addMenuItem( items, Actions::File_ToggleClipboardStoring, QObject::tr("&Toggle Clipboard Storing"),
-                  "toggle_clipboard_storing", QObject::tr("Ctrl+Shift+X"), "" );
+                  "toggle_clipboard_storing", QObject::tr("Ctrl+Shift+X"), "", IconBan );
     addMenuItem( items, Actions::File_ProcessManager, QObject::tr("P&rocess Manager"),
                   "process_manager", QObject::tr("Ctrl+Shift+Z"), "system-search", IconGears );
     addMenuItem( items, Actions::File_Exit, QObject::tr("E&xit"), "exit", QObject::tr("Ctrl+Q"),

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2398,8 +2398,11 @@ void ScriptableProxy::setTitle(const QString &title)
     INVOKE2(setTitle, (title));
 
     if (title.isEmpty()) {
-        m_wnd->setWindowTitle(QString());
-        m_wnd->setTrayTooltip(QGuiApplication::applicationDisplayName());
+        const QString defaultTitle = isMonitoringEnabled()
+            ? QString()
+            : tr("*Clipboard Storing Disabled*", "Main window title if clipboard storing is disabled");
+        m_wnd->setWindowTitle(defaultTitle);
+        m_wnd->setTrayTooltip(defaultTitle);
     } else {
         m_wnd->setWindowTitle(title);
         m_wnd->setTrayTooltip(title);

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1512,9 +1512,11 @@ void Tests::commandCurrentWindowTitle()
 {
     RUN("disable", "");
 #ifdef Q_OS_MAC
-    WAIT_ON_OUTPUT("currentWindowTitle", "CopyQ\n");
+    WAIT_ON_OUTPUT("currentWindowTitle", "CopyQ - *Clipboard Storing Disabled*\n");
+#elif defined(Q_OS_WIN)
+    WAIT_ON_OUTPUT("currentWindowTitle", "*Clipboard Storing Disabled* - CopyQ-TEST\n");
 #else
-    WAIT_ON_OUTPUT("currentWindowTitle", "CopyQ-TEST\n");
+    WAIT_ON_OUTPUT("currentWindowTitle", "*Clipboard Storing Disabled* — CopyQ-TEST\n");
 #endif
     RUN("enable", "");
 }
@@ -2481,7 +2483,11 @@ void Tests::keysAndFocusing()
 #endif
 
     RUN("keys" << tabDialogLineEditId << "ESC", "");
-    WAIT_ON_OUTPUT("currentWindowTitle", "CopyQ-TEST\n");
+#ifdef Q_OS_WIN
+    WAIT_ON_OUTPUT("currentWindowTitle", "*Clipboard Storing Disabled* - CopyQ-TEST\n");
+#else
+    WAIT_ON_OUTPUT("currentWindowTitle", "*Clipboard Storing Disabled* — CopyQ-TEST\n");
+#endif
     RUN("enable", "");
 }
 


### PR DESCRIPTION
This fixes missing icon at app start.

Disabled clipboard storing is also indicated in main window title as "\*Clipboard Storing Disabled\*".

Fixes #2255