### PR TITLE
Set hard-limit to native notification text length

### DIFF
--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -59,7 +59,7 @@ struct notification_position : Config<int> {
 
 struct clipboard_notification_lines : Config<int> {
     static QString name() { return "clipboard_notification_lines"; }
-    static Value value(Value v) { return qBound(0, v, 10000); }
+    static Value value(Value v) { return qBound(0, v, 100); }
 };
 
 struct notification_horizontal_offset : Config<int> {

--- a/src/gui/notificationnative/notificationnative.cpp
+++ b/src/gui/notificationnative/notificationnative.cpp
@@ -32,6 +32,17 @@
 namespace {
 
 constexpr auto componentName = "copyq";
+constexpr auto maxTitleLength = 10000;
+constexpr auto maxBodyLength = 100000;
+constexpr auto maxLines = 100;
+
+QString limitLength(const QString &text, int maxLength)
+{
+    QString result = text.left(maxLength).split('\n').mid(0, maxLines).join('\n');
+    if (result.length() < text.length())
+        result.append("\n…");
+    return result;
+}
 
 QPixmap defaultIcon()
 {
@@ -107,15 +118,16 @@ NotificationNative::~NotificationNative()
 
 void NotificationNative::setTitle(const QString &title)
 {
-    m_title = title;
+    m_title = limitLength(title, maxTitleLength);
 }
 
 void NotificationNative::setMessage(const QString &msg, Qt::TextFormat format)
 {
-    if (format == Qt::PlainText)
-        m_message = msg.toHtmlEscaped();
-    else
-        m_message = msg;
+    m_message = limitLength(msg, maxBodyLength);
+
+    if (format == Qt::PlainText) {
+        m_message = m_message.toHtmlEscaped();
+    }
 }
 
 void NotificationNative::setPixmap(const QPixmap &pixmap)

--- a/src/ui/configtabnotifications.ui
+++ b/src/ui/configtabnotifications.ui
@@ -187,7 +187,7 @@ Set to -1 to keep visible until clicked.</string>
 Set to 0 to disable.</string>
             </property>
             <property name="maximum">
-             <number>9999</number>
+             <number>100</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Large text can cause some native notifications services to get stuck.