### PR TITLE
Open image editor instead of empty internal one

### DIFF
--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -241,6 +241,8 @@ ItemEditorWidget *ItemDelegate::createCustomEditor(
         text = getTextData(data, mimeHtml);
         if (text.isEmpty()) {
             text = getTextData(data);
+            if (text.isNull())
+                return nullptr;
         } else {
             hasHtml = true;
         }


### PR DESCRIPTION
Edit action on an image item, opens image editor instead of internal editor if the item does not contain any text.