### PR TITLE
Add Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds a Dependabot configuration that will auto-update GitHub action versions.

Currently, at least one GitHub action, `actions/checkout@v2` is no longer current. If this PR merges, Dependabot will begin opening PRs to update action versions to the latest versions (in this example, it would update `actions/checkout` to version 3).

Let me know if anything is needed to make this commit or PR meet community or project standards.

Thanks for your work on CopyQ!