### PR TITLE
itemsync: Fix updating items in-place

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1775,7 +1775,7 @@ Types
        for (var index = 0; index < sel.length; ++index) {
            var item = sel.itemAtIndex(index);
            item[mimeItemNotes] = 'Contains needle';
-           sel.setItemAtIndex(item);
+           sel.setItemAtIndex(index, item);
        }
 
    Example - selection with new items only:

--- a/plugins/itemsync/filewatcher.h
+++ b/plugins/itemsync/filewatcher.h
@@ -30,6 +30,11 @@ extern const QLatin1String mimePrivatePrefix;
 extern const QLatin1String mimeOldBaseName;
 extern const QLatin1String mimeHashPrefix;
 
+enum class UpdateType {
+    Inserted,
+    Changed,
+};
+
 struct FileFormat {
     bool isValid() const { return !extensions.isEmpty(); }
     QStringList extensions;
@@ -98,9 +103,10 @@ private:
 
     QList<QPersistentModelIndex> indexList(int first, int last);
 
-    void saveItems(int first, int last);
+    void saveItems(int first, int last, UpdateType updateType);
 
-    bool renameMoveCopy(const QDir &dir, const QList<QPersistentModelIndex> &indexList);
+    bool renameMoveCopy(
+        const QDir &dir, const QList<QPersistentModelIndex> &indexList, UpdateType updateType);
 
     void updateDataAndWatchFile(
             const QDir &dir, const BaseNameExtensions &baseNameWithExts,


### PR DESCRIPTION
Fixes creating duplicate item clones when adding a tag for example.

Fixes #2355