### PR TITLE
Avoid accessing clipboard from password managers

### DIFF
--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -57,7 +57,6 @@ ClipboardMonitor::ClipboardMonitor(const QStringList &formats)
     m_formats.append({mimeOwner, mimeWindowTitle, mimeItemNotes, mimeHidden});
     m_formats.removeDuplicates();
 
-    m_clipboard->startMonitoring(m_formats);
     connect( m_clipboard.get(), &PlatformClipboard::changed,
              this, &ClipboardMonitor::onClipboardChanged );
 
@@ -72,10 +71,9 @@ ClipboardMonitor::ClipboardMonitor(const QStringList &formats)
         COPYQ_LOG("Disabling selection monitoring");
         m_clipboard->setMonitoringEnabled(ClipboardMode::Selection, false);
     }
-
-    onClipboardChanged(ClipboardMode::Selection);
 #endif
-    onClipboardChanged(ClipboardMode::Clipboard);
+
+    m_clipboard->startMonitoring(m_formats);
 }
 
 void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)

--- a/src/platform/dummy/dummyclipboard.cpp
+++ b/src/platform/dummy/dummyclipboard.cpp
@@ -4,8 +4,10 @@
 
 #include "common/common.h"
 #include "common/log.h"
+#include "common/mimetypes.h"
 
 #include <QGuiApplication>
+#include <QMimeData>
 #include <QStringList>
 
 QClipboard::Mode modeToQClipboardMode(ClipboardMode mode)
@@ -25,6 +27,8 @@ void DummyClipboard::startMonitoring(const QStringList &)
 {
     connect(QGuiApplication::clipboard(), &QClipboard::changed,
             this, &DummyClipboard::onClipboardChanged);
+
+    onClipboardChanged(QClipboard::Clipboard);
 }
 
 QVariantMap DummyClipboard::data(ClipboardMode mode, const QStringList &formats) const
@@ -40,19 +44,36 @@ void DummyClipboard::setData(ClipboardMode mode, const QVariantMap &dataMap)
     QGuiApplication::clipboard()->setMimeData( createMimeData(dataMap), modeToQClipboardMode(mode) );
 }
 
+const QMimeData *DummyClipboard::rawMimeData(ClipboardMode mode) const
+{
+    return QGuiApplication::clipboard()->mimeData( modeToQClipboardMode(mode) );
+}
+
 const QMimeData *DummyClipboard::mimeData(ClipboardMode mode) const
 {
     const auto modeText = mode == ClipboardMode::Clipboard ? "clipboard" : "selection";
 
-    COPYQ_LOG_VERBOSE( QString("Getting %1 data.").arg(modeText) );
-    const QMimeData *data = QGuiApplication::clipboard()->mimeData( modeToQClipboardMode(mode) );
+    COPYQ_LOG_VERBOSE( QStringLiteral("Getting %1 data").arg(modeText) );
+    const QMimeData *data = rawMimeData(mode);
 
-    if (data)
-        COPYQ_LOG_VERBOSE( QString("Got %1 data.").arg(modeText) );
-    else
-        log( QString("Null data in %1.").arg(modeText), LogError );
+    if (!data) {
+        log( QStringLiteral("Null data in %1").arg(modeText), LogError );
+        return nullptr;
+    }
 
+    if (isHidden(*data)) {
+        log( QStringLiteral("Hidding secret %1 data").arg(modeText) );
+        return nullptr;
+    }
+
+    COPYQ_LOG_VERBOSE( QStringLiteral("Got %1 data").arg(modeText) );
     return data;
+}
+
+bool DummyClipboard::isHidden(const QMimeData &data) const
+{
+    const QByteArray passwordManagerHint = data.data(QStringLiteral("x-kde-passwordManagerHint"));
+    return passwordManagerHint == QByteArrayLiteral("secret");
 }
 
 void DummyClipboard::onChanged(int mode)

--- a/src/platform/dummy/dummyclipboard.h
+++ b/src/platform/dummy/dummyclipboard.h
@@ -28,7 +28,10 @@ public:
 
     bool isSelectionSupported() const override { return false; }
 
+    bool isHidden(const QMimeData &data) const override;
+
 protected:
+    virtual const QMimeData *rawMimeData(ClipboardMode mode) const;
     virtual void onChanged(int mode);
     void onClipboardChanged(QClipboard::Mode mode);
 

--- a/src/platform/mac/macclipboard.h
+++ b/src/platform/mac/macclipboard.h
@@ -13,6 +13,11 @@ public:
 
     QByteArray clipboardOwner() override;
 
+    bool isHidden(const QMimeData &data) const override;
+
+protected:
+    void onChanged(int mode) override;
+
 private:
     void clipboardTimeout();
 

--- a/src/platform/platformclipboard.h
+++ b/src/platform/platformclipboard.h
@@ -40,6 +40,8 @@ public:
 
     virtual bool isSelectionSupported() const = 0;
 
+    virtual bool isHidden(const QMimeData &data) const = 0;
+
 signals:
     /// Notifies about clipboard changes.
     void changed(ClipboardMode mode);

--- a/src/platform/win/winplatformclipboard.h
+++ b/src/platform/win/winplatformclipboard.h
@@ -12,8 +12,10 @@ class WinPlatformClipboard final : public DummyClipboard
 public:
     void startMonitoring(const QStringList &) override;
 
-private:
-    void checkClipboard();
+    bool isHidden(const QMimeData &data) const override;
+
+protected:
+    void onChanged(int) override;
 
     DWORD m_lastClipboardSequenceNumber = -1;
 };

--- a/src/platform/x11/x11platformclipboard.h
+++ b/src/platform/x11/x11platformclipboard.h
@@ -24,11 +24,10 @@ public:
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
 
-    const QMimeData *mimeData(ClipboardMode mode) const override;
-
     bool isSelectionSupported() const override { return m_selectionSupported; }
 
 protected:
+    const QMimeData *rawMimeData(ClipboardMode mode) const override;
     void onChanged(int mode) override;
 
 private:

--- a/src/tests/testinterface.h
+++ b/src/tests/testinterface.h
@@ -6,6 +6,7 @@
 #include "common/clipboardmode.h"
 
 #include <QStringList>
+#include <QVariantMap>
 
 #include <memory>
 
@@ -57,6 +58,9 @@ public:
 
     /// Waits on client output.
     virtual QByteArray waitOnOutput(const QStringList &arguments, const QByteArray &stdoutExpected) = 0;
+
+    /// Set clipboard through monitor process.
+    virtual void setClipboard(const QVariantMap &data, ClipboardMode mode = ClipboardMode::Clipboard) = 0;
 
     /// Set clipboard through monitor process.
     virtual QByteArray setClipboard(

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -290,6 +290,8 @@ private slots:
 
     void startServerAndRunCommand();
 
+    void avoidStoringPasswords();
+
 private:
     void clearServerErrors();
     int run(const QStringList &arguments, QByteArray *stdoutData = nullptr,


### PR DESCRIPTION
Disallows viewing and pasting secret clipboard content copied from
password managers.

Most clipboard managers should be supported.

The clipboard is ignored if it contains following data:
- "Clipboard Viewer Ignore" on Windows
- "application/x-nspasteboard-concealed-type" on macOS
- "x-kde-passwordManagerHint" with "secret" value on Linux

Fixes #2282, #2495