### PR TITLE
Allow copying items while searching

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
+          - os: macos-12
             buildname: macOS 10.15
             create_bundle: true
 

--- a/src/gui/filterlineedit.cpp
+++ b/src/gui/filterlineedit.cpp
@@ -425,9 +425,15 @@ void FilterLineEdit::loadSettings()
 
 void FilterLineEdit::keyPressEvent(QKeyEvent *ke)
 {
-    // Up/Down arrow keys should be passed to item list
+    // Up/Down arrow keys should be passed to the item list
     // (on OS X this moves text cursor to the beginning/end).
     if (ke->key() == Qt::Key_Down || ke->key() == Qt::Key_Up) {
+        ke->ignore();
+        return;
+    }
+
+    // If no text is selected, pass copy actions to the item list.
+    if ( selectionLength() == 0 && ke->matches(QKeySequence::Copy) ) {
         ke->ignore();
         return;
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2505,6 +2505,11 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 
     // Allow browsing items in search mode without focusing item list.
     if ( c && ui->searchBar->hasFocus() ) {
+        if ( event->matches(QKeySequence::Copy) && ui->searchBar->selectionLength() == 0 ) {
+            copyItems();
+            return;
+        }
+
         switch(key) {
             case Qt::Key_Down:
             case Qt::Key_Up:

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -2561,6 +2561,13 @@ void Tests::searchItemsAndSelect()
     RUN("keys" << filterEditId << "TAB" << clipboardBrowserId, "");
 }
 
+void Tests::searchItemsAndCopy()
+{
+    RUN("add" << "TEST_ITEM", "");
+    RUN("keys" << ":test" << "CTRL+C" << filterEditId, "");
+    WAIT_FOR_CLIPBOARD("TEST_ITEM");
+}
+
 void Tests::searchRowNumber()
 {
     RUN("add" << "d2" << "c" << "b2" << "a", "");

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -157,6 +157,7 @@ private slots:
     void deleteItems();
     void searchItems();
     void searchItemsAndSelect();
+    void searchItemsAndCopy();
     void searchRowNumber();
     void searchAccented();
     void copyItems();


### PR DESCRIPTION
Allows using Ctrl+C to copy items even if search entry box is focused unless it has a selection.

Fixes #2440