### PR TITLE
Linux: Add build option to disable autostart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (UNIX AND NOT APPLE)
     set(BASH_COMPLETION_INSTALL_PREFIX "${DATA_INSTALL_PREFIX}/bash-completion/completions/" CACHE PATH "Install path for bash completions")
     set(ICON_NAME "copyq" CACHE STRING "Name for icon files")
     set(COPYQ_AUTOSTART_COMMAND "" CACHE STRING "Autostart command")
+    OPTION(COPYQ_AUTOSTART "Enable autostart option" ON)
 endif()
 
 set(CMAKE_AUTOMOC ON)
@@ -192,6 +193,10 @@ if (UNIX AND NOT APPLE)
     add_definitions( -DCOPYQ_TRANSLATION_PREFIX="${TRANSLATION_INSTALL_PREFIX}" )
     add_definitions( -DCOPYQ_BASH_COMPLETION_PREFIX="${BASH_COMPLETION_INSTALL_PREFIX}" )
     add_definitions( -DCOPYQ_ICON_NAME="${ICON_NAME}" )
+
+    if (COPYQ_AUTOSTART)
+        add_definitions( -DCOPYQ_AUTOSTART )
+    endif()
 
     if (COPYQ_AUTOSTART_COMMAND)
         add_definitions( -DCOPYQ_AUTOSTART_COMMAND="${COPYQ_AUTOSTART_COMMAND}" )

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -114,7 +114,7 @@ PlatformWindowPtr X11Platform::getCurrentWindow()
 
 bool X11Platform::canAutostart()
 {
-#ifdef COPYQ_DESKTOP_FILE
+#if defined(COPYQ_AUTOSTART) && defined(COPYQ_DESKTOP_FILE)
     return true;
 #else
     return false;
@@ -123,7 +123,7 @@ bool X11Platform::canAutostart()
 
 bool X11Platform::isAutostartEnabled()
 {
-#ifdef COPYQ_DESKTOP_FILE
+#if defined(COPYQ_AUTOSTART) && defined(COPYQ_DESKTOP_FILE)
     const QString filename = getDesktopFilename();
 
     QFile desktopFile(filename);
@@ -153,7 +153,7 @@ bool X11Platform::isAutostartEnabled()
 
 void X11Platform::setAutostartEnabled(bool enable)
 {
-#ifdef COPYQ_DESKTOP_FILE
+#if defined(COPYQ_AUTOSTART) && defined(COPYQ_DESKTOP_FILE)
     if ( isAutostartEnabled() == enable )
         return;
 


### PR DESCRIPTION
Autostart option should not be available for example for flatpack apps since it is handled by a background portal.

Fixes #2517