### PR TITLE
Increase item limit in each tab to 100,000

### DIFF
--- a/docs/backup.rst
+++ b/docs/backup.rst
@@ -1,3 +1,5 @@
+.. _backup:
+
 Backup
 ======
 
@@ -17,14 +19,21 @@ Back Up Manually
 ----------------
 
 To back up all the data, **exit the application** first and **copy
-the configuration directory**.
+the configuration directory** and **the data directory**.
 
-Path to configuration is usually:
+Path to the configuration is usually:
 
 -  Windows: ``%APPDATA%\copyq``
 -  Portable version for Windows: ``config`` sub-folder in unzipped
    application directory
 -  Linux: ``~/.config/copyq``
+
+Path to the data is usually:
+
+-  Windows: ``%APPDATA%\copyq\items``
+-  Portable version for Windows: ``items`` sub-folder in unzipped
+   application directory
+-  Linux: ``~/.local/share/copyq/copyq/items``
 
 To copy the configuration path to clipboard from CopyQ:
 
@@ -38,6 +47,8 @@ To copy the configuration path to clipboard from CopyQ:
     copy(dir.absolutePath())
 
 3. Click OK dialog button.
+
+To copy the data path, change ``'config'`` to ``'data'``.
 
 To restore the backup, exit the application and replace the
 configuration directory.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -97,6 +97,8 @@ then choose what to import back.
 
    Importing tabs and commands won't override existing tabs, and will create new ones.
 
+See also: :ref:`backup`
+
 .. _faq-disable-notifications:
 
 How to enable or disable displaying notification when clipboard changes?

--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -71,6 +71,40 @@ outside the application.
     $ COPYQ_SETTINGS_PATH=$HOME/copyq-settings copyq tab
     &clipboard
 
+Item Data Path
+--------------
+
+Item data path can be overridden with ``COPYQ_ITEM_DATA_PATH``
+environment variable.
+
+::
+
+    $ copyq info data
+    /home/user/.local/share/copyq/copyq
+
+    $ COPYQ_ITEM_DATA_PATH=$HOME/copyq-data copyq info data
+    /home/user/copyq-data/copyq/copyq.conf
+
+The directory contains data for items that exceeds 4096 bytes. The default
+threshold can be overridden with ``item_data_threshold`` option.
+
+::
+
+    $ copyq config item_data_threshold
+    4096
+
+To disable using the data directory and store everything into tab data files,
+set the threshold to a negative value. The tab data file will be updated only
+after the items in the tab change.
+
+::
+
+    $ copyq config item_data_threshold -1
+    -1
+
+Note: Using data directory ensure that the application is fast even if there
+are a lot of large items in tabs.
+
 Icon Color
 ----------
 

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -38,7 +38,7 @@ const QLatin1String dataFileHeaderV2("CopyQ_encrypted_tab v2");
 
 const QLatin1String configEncryptTabs("encrypt_tabs");
 
-const int maxItemCount = 10000;
+const int maxItemCount = 100'000;
 
 bool waitOrTerminate(QProcess *p, int timeoutMs)
 {

--- a/plugins/itemfakevim/itemfakevim.cpp
+++ b/plugins/itemfakevim/itemfakevim.cpp
@@ -754,7 +754,7 @@ QVariant ItemFakeVimLoader::icon() const
 
 void ItemFakeVimLoader::setEnabled(bool enabled)
 {
-    m_enabled = enabled;
+    ItemLoaderInterface::setEnabled(enabled);
     updateCurrentlyEnabledState();
 }
 
@@ -811,7 +811,7 @@ void ItemFakeVimLoader::updateCurrentlyEnabledState()
     if ( qobject_cast<QGuiApplication*>(qApp) == nullptr )
         return;
 
-    const bool enable = m_enabled && m_reallyEnabled;
+    const bool enable = isEnabled() && m_reallyEnabled;
     if (m_currentlyEnabled == enable)
         return;
 

--- a/plugins/itemfakevim/itemfakevim.h
+++ b/plugins/itemfakevim/itemfakevim.h
@@ -49,7 +49,6 @@ private:
 
     void wrapEditWidget(QObject *obj);
 
-    bool m_enabled = true;
     bool m_reallyEnabled = false;
     bool m_currentlyEnabled = false;
     QString m_sourceFileName;

--- a/plugins/itemsync/filewatcher.h
+++ b/plugins/itemsync/filewatcher.h
@@ -46,6 +46,11 @@ using BaseNameExtensionsList = QList<BaseNameExtensions>;
 
 using Hash = QByteArray;
 
+class SyncDataFile;
+QDataStream &operator<<(QDataStream &out, SyncDataFile value);
+QDataStream &operator>>(QDataStream &in, SyncDataFile &value);
+void registerSyncDataFileConverter();
+
 class FileWatcher final : public QObject {
 public:
     static QString getBaseName(const QModelIndex &index);
@@ -61,8 +66,15 @@ public:
 
     static Hash calculateHash(const QByteArray &bytes);
 
-    FileWatcher(const QString &path, const QStringList &paths, QAbstractItemModel *model,
-                int maxItems, const QList<FileFormat> &formatSettings, QObject *parent = nullptr);
+    FileWatcher(
+        const QString &path,
+        const QStringList &paths,
+        QAbstractItemModel *model,
+        int maxItems,
+        const QList<FileFormat> &formatSettings,
+        int itemDataThreshold,
+        QObject *parent = nullptr
+    );
 
     const QString &path() const { return m_path; }
 
@@ -127,6 +139,7 @@ private:
     QList<QPersistentModelIndex> m_batchIndexData;
     BaseNameExtensionsList m_fileList;
     int m_lastBatchIndex = -1;
+    int m_itemDataThreshold = -1;
 };
 
 #endif // FILEWATCHER_H

--- a/plugins/itemsync/itemsync.h
+++ b/plugins/itemsync/itemsync.h
@@ -158,6 +158,7 @@ private:
     ItemSyncTabPaths m_tabPaths;
     QStringList m_tabPathsSaved;
     QList<FileFormat> m_formatSettings;
+    int m_itemDataThreshold = -1;
 };
 
 #endif // ITEMSYNC_H

--- a/plugins/itemsync/tests/itemsynctests.cpp
+++ b/plugins/itemsync/tests/itemsynctests.cpp
@@ -3,6 +3,7 @@
 #include "itemsynctests.h"
 
 #include "common/mimetypes.h"
+#include "common/sleeptimer.h"
 #include "tests/test_utils.h"
 
 #include <QDir>
@@ -768,4 +769,44 @@ void ItemSyncTests::avoidDuplicateItemsAddedFromClipboard()
 
     TEST( m_test->setClipboard("one") );
     WAIT_ON_OUTPUT(args << "read(0,1,2,3)", "one,two,,");
+}
+
+void ItemSyncTests::saveLargeItem()
+{
+    const auto tab = testTab(1);
+    const auto args = Args("tab") << tab;
+
+    const auto script = R"(
+        write(0, [{
+            'text/plain': '1234567890'.repeat(10000),
+            'application/x-copyq-test-data': 'abcdefghijklmnopqrstuvwxyz'.repeat(10000),
+        }])
+        )";
+    RUN(args << script, "");
+
+    for (int i = 0; i < 2; ++i) {
+        RUN(args << "read(0).left(20)", "12345678901234567890");
+        RUN(args << "read(0).length", "100000\n");
+        RUN(args << "getItem(0)[mimeText].left(20)", "12345678901234567890");
+        RUN(args << "getItem(0)[mimeText].length", "100000\n");
+        RUN(args << "getItem(0)['application/x-copyq-test-data'].left(26)", "abcdefghijklmnopqrstuvwxyz");
+        RUN(args << "getItem(0)['application/x-copyq-test-data'].length", "260000\n");
+        RUN("unload" << tab, tab + "\n");
+    }
+
+    RUN("show" << tab, "");
+    RUN("keys" << clipboardBrowserId << keyNameFor(QKeySequence::Copy), "");
+    WAIT_ON_OUTPUT("clipboard().left(20)", "12345678901234567890");
+    RUN("clipboard('application/x-copyq-test-data').left(26)", "abcdefghijklmnopqrstuvwxyz");
+    RUN("clipboard('application/x-copyq-test-data').length", "260000\n");
+
+    const auto tab2 = testTab(2);
+    const auto args2 = Args("tab") << tab2;
+    RUN("show" << tab2, "");
+    waitFor(waitMsPasteClipboard);
+    RUN("keys" << clipboardBrowserId << keyNameFor(QKeySequence::Paste), "");
+    RUN(args2 << "read(0).left(20)", "12345678901234567890");
+    RUN(args2 << "read(0).length", "100000\n");
+    RUN(args << "getItem(0)['application/x-copyq-test-data'].left(26)", "abcdefghijklmnopqrstuvwxyz");
+    RUN(args << "getItem(0)['application/x-copyq-test-data'].length", "260000\n");
 }

--- a/plugins/itemsync/tests/itemsynctests.h
+++ b/plugins/itemsync/tests/itemsynctests.h
@@ -52,6 +52,8 @@ private slots:
 
     void avoidDuplicateItemsAddedFromClipboard();
 
+    void saveLargeItem();
+
 private:
     TestInterfacePtr m_test;
 };

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -7,6 +7,7 @@
 #include "common/log.h"
 #include "common/settings.h"
 #include "common/textdata.h"
+#include "item/serialize.h"
 #include "platform/platformnativeinterface.h"
 #ifdef Q_OS_UNIX
 #   include "platform/unix/unixsignalhandler.h"
@@ -120,6 +121,8 @@ App::App(QCoreApplication *application,
     , m_started(false)
     , m_closed(false)
 {
+    registerDataFileConverter();
+
     QObject::connect(m_app, &QCoreApplication::aboutToQuit, [this]() { exit(); });
 
 #ifdef Q_OS_UNIX

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -17,6 +17,7 @@
 #include <QDir>
 #include <QLibraryInfo>
 #include <QLocale>
+#include <QStandardPaths>
 #include <QTranslator>
 #include <QVariant>
 
@@ -148,6 +149,24 @@ App::App(QCoreApplication *application,
 
     QCoreApplication::setOrganizationName(session);
     QCoreApplication::setApplicationName(session);
+
+    if ( qEnvironmentVariableIsEmpty("COPYQ_ITEM_DATA_PATH") ) {
+        if ( !m_app->property("CopyQ_item_data_path").isValid() ) {
+            m_app->setProperty(
+                "CopyQ_item_data_path",
+                QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                + QLatin1String("/items"));
+        }
+    } else {
+        m_app->setProperty(
+            "CopyQ_item_data_path",
+#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
+            qEnvironmentVariable("COPYQ_ITEM_DATA_PATH")
+#else
+            QString::fromLocal8bit(qgetenv("COPYQ_ITEM_DATA_PATH"))
+#endif
+        );
+    }
 
 #ifdef HAS_TESTS
     initTests();

--- a/src/app/clipboardclient.cpp
+++ b/src/app/clipboardclient.cpp
@@ -9,6 +9,7 @@
 #include "common/common.h"
 #include "common/log.h"
 #include "common/textdata.h"
+#include "item/itemfactory.h"
 #include "platform/platformnativeinterface.h"
 #include "scriptable/scriptable.h"
 #include "scriptable/scriptableproxy.h"
@@ -114,9 +115,14 @@ void ClipboardClient::onConnectionFailed()
 
 void ClipboardClient::start(const QStringList &arguments)
 {
+    ItemFactory itemFactory;
+    itemFactory.loadPlugins();
+    QSettings settings;
+    itemFactory.loadItemFactorySettings(&settings);
+
     QJSEngine engine;
     ScriptableProxy scriptableProxy(nullptr, nullptr);
-    Scriptable scriptable(&engine, &scriptableProxy);
+    Scriptable scriptable(&engine, &scriptableProxy, &itemFactory);
 
     const auto serverName = clipboardServerName();
     ClientSocket socket(serverName);

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -23,6 +23,7 @@
 #include "gui/notificationbutton.h"
 #include "gui/notificationdaemon.h"
 #include "item/itemfactory.h"
+#include "item/itemstore.h"
 #include "item/serialize.h"
 #include "scriptable/scriptableproxy.h"
 
@@ -182,6 +183,8 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
         m_actionDataToSend.clear();
     });
 
+    initSingleShotTimer(&m_timerCleanItemFiles, 120000, this, &ClipboardServer::cleanDataFiles);
+
     initSingleShotTimer(&m_updateThemeTimer, 1000, this, [this](){
         AppConfig appConfig;
         loadSettings(&appConfig);
@@ -293,6 +296,7 @@ void ClipboardServer::onAboutToQuit()
     terminateClients(5000);
 
     m_wnd->saveTabs();
+    cleanDataFiles();
 }
 
 void ClipboardServer::onCommitData(QSessionManager &sessionManager)
@@ -461,6 +465,12 @@ void ClipboardServer::sendActionData(int actionId, const QByteArray &bytes)
         m_actionDataToSend[actionId] = bytes;
         m_timerClearUnsentActionData.start();
     }
+}
+
+void ClipboardServer::cleanDataFiles()
+{
+    COPYQ_LOG("Cleaning unused item files");
+    ::cleanDataFiles( m_wnd->tabs() );
 }
 
 void ClipboardServer::onClientNewConnection(const ClientSocketPtr &client)
@@ -633,6 +643,7 @@ bool ClipboardServer::eventFilter(QObject *object, QEvent *ev)
         if (state != Qt::ApplicationActive) {
             COPYQ_LOG( QStringLiteral("Saving items on application state change (%1)").arg(state) );
             m_wnd->saveTabs();
+            m_timerCleanItemFiles.start();
         }
     } else if (type == QEvent::ThemeChange) {
         if ( !m_updateThemeTimer.isActive() )

--- a/src/app/clipboardserver.h
+++ b/src/app/clipboardserver.h
@@ -118,6 +118,8 @@ private:
 
     void sendActionData(int actionId, const QByteArray &bytes);
 
+    void cleanDataFiles();
+
     Server *m_server = nullptr;
     MainWindow* m_wnd = nullptr;
     QPointer<Action> m_monitor;
@@ -135,6 +137,7 @@ private:
 
     QMap<int, QByteArray> m_actionDataToSend;
     QTimer m_timerClearUnsentActionData;
+    QTimer m_timerCleanItemFiles;
 
     struct ClientData {
         ClientData() = default;

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -13,7 +13,7 @@ QString defaultClipboardTabName();
 
 namespace Config {
 
-const int maxItems = 10000;
+const int maxItems = 100'000;
 
 template<typename ValueType>
 struct Config {
@@ -32,6 +32,15 @@ struct maxitems : Config<int> {
     static QString name() { return "maxitems"; }
     static Value defaultValue() { return 200; }
     static Value value(Value v) { return qBound(0, v, maxItems); }
+};
+
+struct item_data_threshold : Config<int> {
+    static QString name() { return "item_data_threshold"; }
+    static Value defaultValue() { return 1024; }
+    static const char *description() {
+        return "Maximum item data size in bytes to save in tab data file"
+               " (larger data are stored in separate files)";
+    }
 };
 
 struct clipboard_tab : Config<QString> {

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -175,7 +175,7 @@ void ConfigurationManager::initPluginWidgets(ItemFactory *itemFactory)
     for ( const auto &loader : itemFactory->loaders() ) {
         ItemOrderList::ItemPtr pluginItem(new PluginItem(loader));
         const QIcon icon = getIcon(loader->icon());
-        const auto state = itemFactory->isLoaderEnabled(loader)
+        const auto state = loader->isEnabled()
                 ? ItemOrderList::Checked
                 : ItemOrderList::Unchecked;
         m_tabItems->appendItem( loader->name(), icon, pluginItem, state );
@@ -285,6 +285,7 @@ void ConfigurationManager::initOptions()
     bind<Config::tray_tab>(m_tabTray->comboBoxMenuTab->lineEdit());
 
     /* other options */
+    bind<Config::item_data_threshold>();
     bind<Config::command_history_size>();
 #ifdef HAS_MOUSE_SELECTIONS
     /* X11 clipboard selection monitoring and synchronization */
@@ -542,7 +543,8 @@ void ConfigurationManager::apply(AppConfig *appConfig)
 
     for (int i = 0; i < m_tabItems->itemCount(); ++i) {
         const QString loaderId = m_tabItems->data(i).toString();
-        Q_ASSERT(!loaderId.isEmpty());
+        if ( loaderId.isEmpty() )
+            continue;
 
         pluginPriority.append(loaderId);
 

--- a/src/gui/notificationnative/notificationnative.cpp
+++ b/src/gui/notificationnative/notificationnative.cpp
@@ -22,7 +22,6 @@
 #include <QPainter>
 #include <QPointer>
 #include <QPushButton>
-#include <QStandardPaths>
 #include <QTextEdit>
 
 #include <knotifications_version.h>

--- a/src/item/itemfactory.h
+++ b/src/item/itemfactory.h
@@ -77,16 +77,6 @@ public:
     void setPluginPriority(const QStringList &pluginNames);
 
     /**
-     * Enable or disable instantiation of ItemWidget objects using @a loader.
-     */
-    void setLoaderEnabled(const ItemLoaderPtr &loader, bool enabled);
-
-    /**
-     * Return true if @a loader is enabled.
-     */
-    bool isLoaderEnabled(const ItemLoaderPtr &loader) const;
-
-    /**
      * Return true if no plugins were loaded.
      */
     bool hasLoaders() const { return !m_loaders.isEmpty(); }
@@ -135,9 +125,6 @@ private:
     /** Called if child ItemWidget destroyed. **/
     void loaderChildDestroyed(QObject *obj);
 
-    /** Return enabled plugins with dummy item loader. */
-    ItemLoaderList enabledLoaders(bool enabled = true) const;
-
     /** Calls ItemLoaderInterface::transform() for all plugins in reverse order. */
     ItemWidget *transformItem(ItemWidget *item, const QVariantMap &data);
 
@@ -149,7 +136,6 @@ private:
 
     ItemLoaderList m_loaders;
     ItemLoaderPtr m_dummyLoader;
-    ItemLoaderList m_disabledLoaders;
     QMap<QObject *, ItemLoaderPtr> m_loaderChildren;
 };
 

--- a/src/item/itemstore.cpp
+++ b/src/item/itemstore.cpp
@@ -13,7 +13,6 @@
 #include <QFile>
 #include <QSaveFile>
 #include <QSet>
-#include <QStandardPaths>
 
 namespace {
 
@@ -178,8 +177,8 @@ bool moveItems(const QString &oldId, const QString &newId)
 
 void cleanDataFiles(const QStringList &tabNames)
 {
-    QDir dir( QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) );
-    if ( !dir.cd(QStringLiteral("items")) )
+    QDir dir(itemDataPath());
+    if ( !dir.exists() )
         return;
 
     QStringList files;

--- a/src/item/itemstore.cpp
+++ b/src/item/itemstore.cpp
@@ -6,11 +6,14 @@
 #include "common/log.h"
 #include "common/textdata.h"
 #include "item/itemfactory.h"
+#include "item/serialize.h"
 
 #include <QAbstractItemModel>
 #include <QDir>
 #include <QFile>
 #include <QSaveFile>
+#include <QSet>
+#include <QStandardPaths>
 
 namespace {
 
@@ -63,6 +66,27 @@ ItemSaverPtr createTab(
         return nullptr;
 
     return saver;
+}
+
+bool itemDataFiles(const QString &tabName, QStringList *files)
+{
+    const QString tabFileName = itemFileName(tabName);
+    if ( !QFile::exists(tabFileName) )
+        return true;
+
+    QFile tabFile(tabFileName);
+    if ( !tabFile.open(QIODevice::ReadOnly) ) {
+        printItemFileError("read tab", tabName, tabFile);
+        return false;
+    }
+
+    return itemDataFiles(&tabFile, files);
+}
+
+void cleanDataDir(QDir *dir)
+{
+    if ( dir->isEmpty() )
+        QDir().rmdir( dir->absolutePath() );
 }
 
 } // namespace
@@ -150,4 +174,45 @@ bool moveItems(const QString &oldId, const QString &newId)
        ), LogError );
 
     return false;
+}
+
+void cleanDataFiles(const QStringList &tabNames)
+{
+    QDir dir( QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) );
+    if ( !dir.cd(QStringLiteral("items")) )
+        return;
+
+    QStringList files;
+    for (const QString &tabName : tabNames) {
+        if ( !itemDataFiles(tabName, &files) ) {
+            COPYQ_LOG( QStringLiteral("Stopping cleanup due to corrupted file: %1")
+                    .arg(tabName) );
+            return;
+        }
+    }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+    const QSet fileSet(files.constBegin(), files.constEnd());
+#else
+    const QSet fileSet = files.toSet();
+#endif
+    for ( const auto &i1 : dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot) ) {
+        QDir d1(i1.absoluteFilePath());
+        for ( const auto &i2 : d1.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot) ) {
+            QDir d2(i2.absoluteFilePath());
+            for ( const auto &i3 : d2.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot) ) {
+                QDir d3(i3.absoluteFilePath());
+                for ( const auto &f : d3.entryInfoList(QDir::Files) ) {
+                    const QString path = f.absoluteFilePath();
+                    if ( !fileSet.contains(path) ) {
+                        COPYQ_LOG( QStringLiteral("Cleaning: %1").arg(path) );
+                        QFile::remove(path);
+                    }
+                }
+                cleanDataDir(&d3);
+            }
+            cleanDataDir(&d2);
+        }
+        cleanDataDir(&d1);
+    }
 }

--- a/src/item/itemstore.h
+++ b/src/item/itemstore.h
@@ -26,4 +26,6 @@ bool moveItems(
         const QString &newId //!< See ClipboardBrowser::getID().
         );
 
+void cleanDataFiles(const QStringList &tabNames);
+
 #endif // ITEMSTORE_H

--- a/src/item/itemwidget.h
+++ b/src/item/itemwidget.h
@@ -292,7 +292,8 @@ public:
      */
     virtual void applySettings(QSettings &) {}
 
-    virtual void setEnabled(bool) {}
+    virtual void setEnabled(bool enabled) { m_enabled = enabled; }
+    bool isEnabled() const { return m_enabled; }
 
     /**
      * Load stored configuration values.
@@ -390,6 +391,9 @@ public:
 
     ItemLoaderInterface(const ItemLoaderInterface &) = delete;
     ItemLoaderInterface &operator=(const ItemLoaderInterface &) = delete;
+
+private:
+    bool m_enabled = true;
 };
 
 Q_DECLARE_INTERFACE(ItemLoaderInterface, COPYQ_PLUGIN_ITEM_LOADER_ID)

--- a/src/item/serialize.cpp
+++ b/src/item/serialize.cpp
@@ -7,6 +7,7 @@
 #include "common/mimetypes.h"
 
 #include <QAbstractItemModel>
+#include <QCoreApplication>
 #include <QByteArray>
 #include <QCryptographicHash>
 #include <QDataStream>
@@ -15,7 +16,6 @@
 #include <QList>
 #include <QPair>
 #include <QSaveFile>
-#include <QStandardPaths>
 #include <QStringList>
 
 #include <unordered_map>
@@ -185,12 +185,12 @@ bool deserializeDataV2(QDataStream *out, QVariantMap *data)
 
 QString dataFilePath(const QByteArray &bytes, bool create = false)
 {
-    QDir dir( QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) );
+    QDir dir(itemDataPath());
     QCryptographicHash hash(QCryptographicHash::Sha256);
     hash.addData(QByteArrayLiteral("copyq_salt"));
     hash.addData(bytes);
     const QString sha = QString::fromUtf8( hash.result().toHex() );
-    const QString subpath = QStringLiteral("items/%1/%2/%3").arg(
+    const QString subpath = QStringLiteral("%1/%2/%3").arg(
             sha.mid(0, 16),
             sha.mid(16, 16),
             sha.mid(32, 16)
@@ -431,4 +431,9 @@ bool itemDataFiles(QIODevice *file, QStringList *files)
     }
 
     return out.status() == QDataStream::Ok;
+}
+
+QString itemDataPath()
+{
+    return qApp->property("CopyQ_item_data_path").toString();
 }

--- a/src/item/serialize.h
+++ b/src/item/serialize.h
@@ -25,6 +25,7 @@ bool deserializeData(QAbstractItemModel *model, QDataStream *stream, int maxItem
 bool serializeData(const QAbstractItemModel &model, QIODevice *file, int itemDataThreshold = -1);
 bool deserializeData(QAbstractItemModel *model, QIODevice *file, int maxItems);
 
+QString itemDataPath();
 bool itemDataFiles(QIODevice *file, QStringList *files);
 
 #endif // SERIALIZE_H

--- a/src/item/serialize.h
+++ b/src/item/serialize.h
@@ -10,14 +10,21 @@ class QByteArray;
 class QDataStream;
 class QIODevice;
 
-void serializeData(QDataStream *stream, const QVariantMap &data);
+class DataFile;
+QDataStream &operator<<(QDataStream &out, DataFile value);
+QDataStream &operator>>(QDataStream &in, DataFile &value);
+void registerDataFileConverter();
+
+void serializeData(QDataStream *stream, const QVariantMap &data, int itemDataThreshold = -1);
 bool deserializeData(QDataStream *stream, QVariantMap *data);
 QByteArray serializeData(const QVariantMap &data);
 bool deserializeData(QVariantMap *data, const QByteArray &bytes);
 
-bool serializeData(const QAbstractItemModel &model, QDataStream *stream);
+bool serializeData(const QAbstractItemModel &model, QDataStream *stream, int itemDataThreshold = -1);
 bool deserializeData(QAbstractItemModel *model, QDataStream *stream, int maxItems);
-bool serializeData(const QAbstractItemModel &model, QIODevice *file);
+bool serializeData(const QAbstractItemModel &model, QIODevice *file, int itemDataThreshold = -1);
 bool deserializeData(QAbstractItemModel *model, QIODevice *file, int maxItems);
+
+bool itemDataFiles(QIODevice *file, QStringList *files);
 
 #endif // SERIALIZE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int evaluate(
     setLogLabel("Prompt");
 
     QJSEngine engine;
-    Scriptable scriptable(&engine, nullptr);
+    Scriptable scriptable(&engine, nullptr, nullptr);
 
     QJSValue function = engine.globalObject().property(functionName);
     QJSValueList functionArguments;

--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -125,6 +125,7 @@ Application *createApplication(int &argc, char **argv)
     if ( !portableFolder.isEmpty() ) {
         QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, portableFolder);
         qputenv("COPYQ_LOG_FILE", portableFolder.toUtf8() + "/copyq.log");
+        app->setProperty("CopyQ_item_data_path", portableFolder + QLatin1String("/items"));
     }
 
     return app;

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -421,7 +421,7 @@ struct ScriptValueFactory<QVariant> {
             return ::toScriptValue(variant.value<QVariantMap>(), scriptable);
 
         if (variant.canConvert<QByteArray>())
-            return ::toScriptValue(variant.toByteArray(), scriptable);
+            return scriptable->engine()->newQObject(new ScriptableByteArray(variant));
 
         return scriptable->engine()->toScriptValue(variant);
     }

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -47,7 +47,6 @@
 #include <QSysInfo>
 #include <QUrl>
 #include <QVector>
-#include <QStandardPaths>
 #include <QThread>
 #include <QTimer>
 
@@ -1741,7 +1740,7 @@ QJSValue Scriptable::info()
     info.insert("config", QSettings().fileName());
     info.insert("exe", QCoreApplication::applicationFilePath());
     info.insert("log", logFileName());
-    info.insert("data", QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+    info.insert("data", itemDataPath());
 
     info.insert("plugins",
 #ifdef COPYQ_PLUGIN_PREFIX

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -16,6 +16,7 @@
 #include "platform/platformnativeinterface.h"
 
 class Action;
+class ScriptableByteArray;
 class ClipboardBrowser;
 class ItemFactory;
 class NetworkReply;
@@ -56,7 +57,6 @@ class Scriptable final : public QObject
 
     Q_PROPERTY(QJSValue _copyqUncaughtException READ uncaughtException WRITE setUncaughtException)
     Q_PROPERTY(QJSValue _copyqHasUncaughtException READ hasUncaughtException)
-    Q_PROPERTY(QJSValue _initItemSelection READ getUndefined WRITE initItemSelection)
 
 public:
     Scriptable(
@@ -76,6 +76,7 @@ public:
     QJSValue argument(int index) const;
 
     QJSValue newByteArray(const QByteArray &bytes) const;
+    QJSValue newByteArray(ScriptableByteArray *ba) const;
 
     QByteArray fromString(const QString &value) const;
     QVariant toVariant(const QJSValue &value);
@@ -153,6 +154,13 @@ public:
     void abortEvaluation(Abort abort = Abort::AllEvaluations);
 
 public slots:
+    QJSValue ByteArray() const;
+    QJSValue File() const;
+    QJSValue TemporaryFile() const;
+    QJSValue Dir() const;
+    QJSValue ItemSelection() const;
+    QJSValue Settings() const;
+
     QJSValue version();
     QJSValue help();
 
@@ -451,8 +459,7 @@ private:
     NetworkReply *networkGetHelper();
     NetworkReply *networkPostHelper();
 
-    QJSValue getUndefined () { return {}; }
-    QJSValue initItemSelection(const QJSValue &obj);
+    QJSValue newQObject(QObject *obj, const QJSValue &prototype) const;
 
     ScriptableProxy *m_proxy;
     QJSEngine *m_engine;
@@ -494,6 +501,13 @@ private:
     QJSValue m_createFn;
     QJSValue m_createFnB;
     QJSValue m_createProperty;
+
+    QJSValue m_byteArrayPrototype;
+    QJSValue m_filePrototype;
+    QJSValue m_temporaryFilePrototype;
+    QJSValue m_dirPrototype;
+    QJSValue m_itemSelectionPrototype;
+    QJSValue m_settingsPrototype;
 };
 
 class NetworkReply final : public QObject {

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -59,9 +59,10 @@ class Scriptable final : public QObject
     Q_PROPERTY(QJSValue _initItemSelection READ getUndefined WRITE initItemSelection)
 
 public:
-    explicit Scriptable(
+    Scriptable(
             QJSEngine *engine,
             ScriptableProxy *proxy,
+            ItemFactory *factory = nullptr,
             QObject *parent = nullptr);
 
     enum class Abort {
@@ -455,6 +456,7 @@ private:
 
     ScriptableProxy *m_proxy;
     QJSEngine *m_engine;
+    ItemFactory *m_factory;
     QJSValue m_temporaryFileClass;
     QString m_inputSeparator;
     QJSValue m_input;
@@ -536,14 +538,14 @@ class ScriptablePlugins final : public QObject {
     Q_OBJECT
 
 public:
-    explicit ScriptablePlugins(Scriptable *scriptable);
+    ScriptablePlugins(Scriptable *scriptable, ItemFactory *factory);
 
 public slots:
     QJSValue load(const QString &name);
 
 private:
-    ItemFactory *m_factory = nullptr;
     Scriptable *m_scriptable;
+    ItemFactory *m_factory;
     QMap<QString, QJSValue> m_plugins;
 };
 

--- a/src/scriptable/scriptablebytearray.h
+++ b/src/scriptable/scriptablebytearray.h
@@ -6,6 +6,7 @@
 #include <QByteArray>
 #include <QJSValue>
 #include <QObject>
+#include <QVariant>
 
 class ScriptableByteArray final : public QObject
 {
@@ -17,33 +18,34 @@ public:
     Q_INVOKABLE ScriptableByteArray() {}
     Q_INVOKABLE explicit ScriptableByteArray(const QByteArray &bytes);
     Q_INVOKABLE explicit ScriptableByteArray(const QString &text);
+    Q_INVOKABLE explicit ScriptableByteArray(const QVariant &value);
     Q_INVOKABLE explicit ScriptableByteArray(int size);
 
     Q_INVOKABLE ScriptableByteArray(const ScriptableByteArray &other);
 
-    const QByteArray *data() const { return &m_self; }
+    const QByteArray *data() { return &self(); }
 
 public slots:
     void chop(int n);
     bool equals(const QJSValue &other);
-    QJSValue left(int len) const;
-    QJSValue mid(int pos, int len = -1) const;
+    QJSValue left(int len);
+    QJSValue mid(int pos, int len = -1);
     QJSValue remove(int pos, int len);
-    QJSValue right(int len) const;
-    QJSValue simplified() const;
-    QJSValue toBase64() const;
-    QJSValue toLower() const;
-    QJSValue toUpper() const;
-    QJSValue trimmed() const;
+    QJSValue right(int len);
+    QJSValue simplified();
+    QJSValue toBase64();
+    QJSValue toLower();
+    QJSValue toUpper();
+    QJSValue trimmed();
     void truncate(int pos);
-    QJSValue valueOf() const;
+    QJSValue valueOf();
 
-    int size() const;
+    int size();
 
-    QString toString() const;
-    QString toLatin1String() const;
+    QString toString();
+    QString toLatin1String();
 
-    QJSValue length() const;
+    QJSValue length();
     void setLength(QJSValue size);
 
 private:
@@ -51,7 +53,10 @@ private:
 
     QJSValue newByteArray(const QByteArray &bytes) const;
 
+    QByteArray &self();
+
     QByteArray m_self;
+    QVariant m_variant;
 };
 
 const QByteArray *getByteArray(const QJSValue &value);

--- a/src/tests/test_utils.h
+++ b/src/tests/test_utils.h
@@ -6,6 +6,7 @@
 #include "common/commandstatus.h"
 
 #include <QByteArray>
+#include <QKeySequence>
 #include <QString>
 #include <QStringList>
 #include <QTest>
@@ -90,6 +91,11 @@ inline QByteArray toByteArray(const char *text)
 inline QString testTab(int i)
 {
     return "Tab_&" + QString::number(i);
+}
+
+inline QString keyNameFor(QKeySequence::StandardKey standardKey)
+{
+    return QKeySequence(standardKey).toString();
 }
 
 #endif // TEST_UTILS_H

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1971,6 +1971,7 @@ void Tests::classByteArray()
 {
     RUN("ByteArray", "");
     RUN("ByteArray('test')", "test");
+    RUN("ByteArray(ByteArray('test'))", "test");
     RUN("typeof(ByteArray('test'))", "object\n");
     RUN("ByteArray('test') instanceof ByteArray", "true\n");
     RUN("b = ByteArray('0123'); b.chop(2); b", "01");
@@ -1979,6 +1980,7 @@ void Tests::classByteArray()
     RUN("ByteArray('0123').mid(1, 2)", "12");
     RUN("ByteArray('0123').mid(1)", "123");
     RUN("ByteArray('0123').right(3)", "123");
+    RUN("ByteArray('0123').remove(1, 2)", "03");
     RUN("ByteArray(' 01  23 ').simplified()", "01 23");
     RUN("ByteArray('0123').toBase64()", "MDEyMw==");
     RUN("ByteArray('ABCd').toLower()", "abcd");

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -3419,6 +3419,20 @@ void Tests::configPathEnvVariable()
     QCOMPARE( out.left(expectedOut.size()), expectedOut );
 }
 
+void Tests::itemDataPathEnvVariable()
+{
+    const auto path = QDir::home().absoluteFilePath("copyq-data");
+    const auto environment = QStringList("COPYQ_ITEM_DATA_PATH=" + path);
+
+    QByteArray out;
+    QByteArray err;
+    run(Args() << "info" << "data", &out, &err, QByteArray(), environment);
+    QVERIFY2( testStderr(err), err );
+
+    const auto expectedOut = path.toUtf8();
+    QCOMPARE( out.left(expectedOut.size()), expectedOut );
+}
+
 void Tests::configTabs()
 {
     const QString sep = QStringLiteral("\n");

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -216,6 +216,7 @@ private slots:
     void configAutostart();
 
     void configPathEnvVariable();
+    void itemDataPathEnvVariable();
 
     void configTabs();
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -295,6 +295,8 @@ private slots:
 
     void currentClipboardOwner();
 
+    void saveLargeItem();
+
 private:
     void clearServerErrors();
     int run(const QStringList &arguments, QByteArray *stdoutData = nullptr,

--- a/src/ui/configtabhistory.ui
+++ b/src/ui/configtabhistory.ui
@@ -77,7 +77,7 @@
              <string>Maximum number of items in each tab</string>
             </property>
             <property name="maximum">
-             <number>10000</number>
+             <number>100000</number>
             </property>
             <property name="value">
              <number>200</number>

--- a/src/ui/tabpropertieswidget.ui
+++ b/src/ui/tabpropertieswidget.ui
@@ -56,7 +56,7 @@
         <string>default</string>
        </property>
        <property name="maximum">
-        <number>10000</number>
+        <number>100000</number>
        </property>
        <property name="value">
         <number>200</number>


### PR DESCRIPTION
Saves larger data in separate files.

Data from these files are loaded into memory only when needed.

This makes saving data much more efficient because the tab data files
are much smaller and the separate data files can be shared between
multiple tabs. These data files are only removed when all related items
are removed (when app is idle and on exit).

The path to the data directory can be overridden with
`COPYQ_ITEM_DATA_PATH` environment variable. But the directory
should be used by single app instance.

The threshold value in bytes is stored as "item_data_threshold" hidden
option. Item data that are larger than this value will be stored in
separate files. The default value is 1024. Setting value to 0 would
store all non-empty item data to separate files. A negative value
disables the functionality and saves all into tab data file as before.

Files in synchronized directories now also work the same.

This change is not backwards-compatible. Going back to previous release
could mean losing some data. But going to a new release again would
parse the data correctly. Workaround is to set "item_data_threshold" to
a negative value and trigger storing data tab (e.g. moving an item back
and forth).

Fixes #1144