### PR TITLE
Apply display commands to menu items too

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -2161,6 +2161,13 @@ These MIME types values are assigned to global variables prefixed with
 
    Valid only in automatic commands.
 
+.. js:data:: mimeDisplayItemInMenu
+
+   Indicates if display commands run for a menu. Value: 'application/x-copyq-display-item-in-menu'.
+
+   Set to "1" for display commands if the item data is related to a menu item
+   instead of an item list.
+
 Selected Items
 --------------
 

--- a/src/common/mimetypes.cpp
+++ b/src/common/mimetypes.cpp
@@ -21,3 +21,4 @@ const QLatin1String mimeHidden(COPYQ_MIME_PREFIX "hidden");
 const QLatin1String mimeShortcut(COPYQ_MIME_PREFIX "shortcut");
 const QLatin1String mimeColor(COPYQ_MIME_PREFIX "color");
 const QLatin1String mimeOutputTab(COPYQ_MIME_PREFIX "output-tab");
+const QLatin1String mimeDisplayItemInMenu(COPYQ_MIME_PREFIX "display-item-in-menu");

--- a/src/common/mimetypes.h
+++ b/src/common/mimetypes.h
@@ -22,3 +22,4 @@ extern const QLatin1String mimeHidden;
 extern const QLatin1String mimeShortcut;
 extern const QLatin1String mimeColor;
 extern const QLatin1String mimeOutputTab;
+extern const QLatin1String mimeDisplayItemInMenu;

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -200,6 +200,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("mimeShortcut", "mimeShortcut", "Application or global shortcut which activated the command. Value: 'application/x-copyq-shortcut'.");
     addDocumentation("mimeColor", "mimeColor", "Item color (same as the one used by themes). Value: 'application/x-copyq-color'.");
     addDocumentation("mimeOutputTab", "mimeOutputTab", "Name of the tab where to store new item. Value: 'application/x-copyq-output-tab'.");
+    addDocumentation("mimeDisplayItemInMenu", "mimeDisplayItemInMenu", "Indicates if display commands run for a menu. Value: 'application/x-copyq-display-item-in-menu'.");
     addDocumentation("plugins.itemsync.selectedTabPath", "plugins.itemsync.selectedTabPath()", "Returns synchronization path for current tab (mimeCurrentTab).");
     addDocumentation("plugins.itemsync.tabPaths", "plugins.itemsync.tabPaths", "Object that maps tab name to synchronization path.");
     addDocumentation("plugins.itemsync.mimeBaseName", "plugins.itemsync.mimeBaseName", "MIME type for accessing base name (without full path).");

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1836,8 +1836,14 @@ void MainWindow::addMenuItems(TrayMenu *menu, ClipboardBrowserPlaceholder *place
         const QModelIndex index = c->model()->index(i, 0);
         if ( !searchText.isEmpty() && !menuItemMatches(index, searchText) )
             continue;
-        const QVariantMap data = index.data(contentType::data).toMap();
-        menu->addClipboardItemAction(data, m_options.trayImages);
+        QVariantMap data = index.data(contentType::data).toMap();
+        QAction *act = menu->addClipboardItemAction(data, m_options.trayImages);
+        if ( !m_displayCommands.isEmpty() ) {
+            data.insert(mimeCurrentTab, c->tabName());
+            data.insert(mimeDisplayItemInMenu, QByteArrayLiteral("1"));
+            PersistentDisplayItem item(act, data);
+            onItemWidgetCreated(item);
+        }
         ++itemCount;
     }
 }

--- a/src/gui/traymenu.h
+++ b/src/gui/traymenu.h
@@ -16,12 +16,15 @@ class TrayMenu final : public QMenu
 public:
     explicit TrayMenu(QWidget *parent = nullptr);
 
+    static void updateTextFromData(QAction *act, const QVariantMap &data);
+    static bool updateIconFromData(QAction *act, const QVariantMap &data);
+
     /**
      * Add clipboard item action with number key hint.
      *
      * Triggering this action emits clipboardItemActionTriggered() signal.
      */
-    void addClipboardItemAction(const QVariantMap &data, bool showImages);
+    QAction *addClipboardItemAction(const QVariantMap &data, bool showImages);
 
     void clearClipboardItems();
 

--- a/src/item/persistentdisplayitem.cpp
+++ b/src/item/persistentdisplayitem.cpp
@@ -2,7 +2,10 @@
 
 #include "persistentdisplayitem.h"
 
+#include "gui/traymenu.h"
 #include "item/itemdelegate.h"
+
+#include <QAction>
 
 PersistentDisplayItem::PersistentDisplayItem(ItemDelegate *delegate,
         const QVariantMap &data,
@@ -13,16 +16,28 @@ PersistentDisplayItem::PersistentDisplayItem(ItemDelegate *delegate,
 {
 }
 
+PersistentDisplayItem::PersistentDisplayItem(QAction *action, const QVariantMap &data)
+    : m_data(data)
+    , m_action(action)
+{
+}
+
 bool PersistentDisplayItem::isValid()
 {
-    if ( m_widget.isNull() || m_delegate.isNull() )
-        return false;
-
-    return !m_delegate->invalidateHidden( m_widget.data() );
+    return !m_action.isNull() || (
+        !m_widget.isNull() && !m_delegate.isNull()
+        && !m_delegate->invalidateHidden(m_widget.data()) );
 }
 
 void PersistentDisplayItem::setData(const QVariantMap &data)
 {
-    if ( !data.isEmpty() && isValid() && m_delegate && data != m_data )
+    if ( data.isEmpty() || data == m_data )
+        return;
+
+    if ( !m_action.isNull() ) {
+        TrayMenu::updateTextFromData(m_action, data);
+        TrayMenu::updateIconFromData(m_action, data);
+    } else if ( !m_widget.isNull() && !m_delegate.isNull() ) {
         m_delegate->updateWidget(m_widget, data);
+    }
 }

--- a/src/item/persistentdisplayitem.h
+++ b/src/item/persistentdisplayitem.h
@@ -9,6 +9,7 @@
 #include <QVariantMap>
 
 class ItemDelegate;
+class QAction;
 class QModelIndex;
 class QWidget;
 class QString;
@@ -25,6 +26,8 @@ public:
 
     PersistentDisplayItem(
             ItemDelegate *delegate, const QVariantMap &data, QWidget *widget);
+
+    PersistentDisplayItem(QAction *action, const QVariantMap &data);
 
     /**
      * Returns display data of the item.
@@ -48,6 +51,7 @@ public:
 private:
     QVariantMap m_data;
     QPointer<QWidget> m_widget;
+    QPointer<QAction> m_action;
     QPointer<ItemDelegate> m_delegate;
 };
 

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -50,6 +50,7 @@ class Scriptable final : public QObject
     Q_PROPERTY(QJSValue mimeShortcut READ getMimeShortcut CONSTANT)
     Q_PROPERTY(QJSValue mimeColor READ getMimeColor CONSTANT)
     Q_PROPERTY(QJSValue mimeOutputTab READ getMimeOutputTab CONSTANT)
+    Q_PROPERTY(QJSValue mimeDisplayItemInMenu READ getMimeDisplayItemInMenu CONSTANT)
 
     Q_PROPERTY(QJSValue plugins READ getPlugins CONSTANT)
 
@@ -134,6 +135,7 @@ public:
     QJSValue getMimeShortcut() const { return mimeShortcut; }
     QJSValue getMimeColor() const { return mimeColor; }
     QJSValue getMimeOutputTab() const { return mimeOutputTab; }
+    QJSValue getMimeDisplayItemInMenu() const { return mimeDisplayItemInMenu; }
 
     QJSValue getPlugins();
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -3986,6 +3986,36 @@ void Tests::displayCommand()
                 .toUtf8() );
 }
 
+void Tests::displayCommandForMenu()
+{
+    const auto tab = testTab(1);
+    const auto args = Args("tab") << tab << "separator" << ",";
+    const auto script = QString(R"(
+        setCommands([{
+            display: true,
+            cmd: 'copyq:'
+               + 'currentTab = str(data(mimeCurrentTab));'
+               + 'inMenu = str(data(mimeDisplayItemInMenu));'
+               + 'if (inMenu != "1" || currentTab != "%1") abort();'
+               + 'text = str(data(mimeText));'
+               + 'setData(mimeText, "display:" + text);'
+               + 'setData(mimeIcon, String.fromCharCode(0xF328));'
+               + 'setData("application/x-copyq-item-tag", "TAG");'
+               + 'tab(tab()[0]);'
+               + 'old = str(read(0));'
+               + 'add(old + "|" + text);'
+        }])
+        )").arg(tab);
+
+    RUN("config" << "tray_tab" << tab, tab + "\n");
+    RUN("config" << "tray_tab_is_current" << "false", "false\n");
+    RUN(script, "");
+
+    RUN(args << "add(1,2,3,4,5)", "");
+    RUN("menu", "");
+    WAIT_ON_OUTPUT("read(0)", "|5|4|3|2|1");
+}
+
 void Tests::synchronizeInternalCommands()
 {
     // Keep internal commands synced with the latest version

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -250,6 +250,7 @@ private slots:
     void scriptCommandEndingWithComment();
     void scriptCommandWithError();
     void displayCommand();
+    void displayCommandForMenu();
 
     void synchronizeInternalCommands();
 


### PR DESCRIPTION
In the display command, the format stored in `mimeDisplayItemInMenu`
indicates whether the display item data are related to a menu item
instead of an item list.

Fixes hluk/copyq-commands#79