### PR TITLE
Get clipboard owner from script

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1060,6 +1060,24 @@ unlike in GUI, where row numbers start from 1 by default.
    :returns: Current window title.
    :rtype: string
 
+.. js:function:: String currentClipboardOwner()
+
+   Returns name of the current clipboard owner.
+
+   The default implementation returns `currentWindowTitle()`.
+
+   This is used to set `mimeWindowTitle` format for the clipboard data in
+   automatic commands and filtering by window title.
+
+   Depending on the current system, option `update_clipboard_owner_delay_ms`
+   can introduce a delay before any new owner value return by this function is
+   used. The reason is to avoid using an incorrect clipboard owner from the
+   current window title if the real clipboard owner set the clipboard after or
+   just before hiding its window (like with some password managers).
+
+   :returns: Current clipboard owner name.
+   :rtype: string
+
 .. js:function:: dialog(...)
 
    Shows messages or asks user for input.

--- a/plugins/itemsync/tests/itemsynctests.cpp
+++ b/plugins/itemsync/tests/itemsynctests.cpp
@@ -758,6 +758,7 @@ void ItemSyncTests::avoidDuplicateItemsAddedFromClipboard()
     const Args args = Args() << "separator" << "," << "tab" << tab1;
 
     RUN("config" << "clipboard_tab" << tab1, tab1 + "\n");
+    WAIT_ON_OUTPUT("isClipboardMonitorRunning", "true\n");
 
     TEST( m_test->setClipboard("one") );
     WAIT_ON_OUTPUT(args << "read(0,1,2,3)", "one,,,");

--- a/src/app/clipboardmonitor.h
+++ b/src/app/clipboardmonitor.h
@@ -3,6 +3,7 @@
 #ifndef CLIPBOARDMONITOR_H
 #define CLIPBOARDMONITOR_H
 
+#include "app/clipboardownermonitor.h"
 #include "common/common.h"
 #include "platform/platformnativeinterface.h"
 #include "platform/platformclipboard.h"
@@ -22,11 +23,14 @@ class ClipboardMonitor final : public QObject
 public:
     explicit ClipboardMonitor(const QStringList &formats);
     void startMonitoring();
+    QString currentClipboardOwner();
+    void setClipboardOwner(const QString &owner);
 
 signals:
     void clipboardChanged(const QVariantMap &data, ClipboardOwnership ownership);
     void clipboardUnchanged(const QVariantMap &data);
     void synchronizeSelection(ClipboardMode sourceMode, uint sourceTextHash, uint targetTextHash);
+    void fetchCurrentClipboardOwner(QString *title);
 
 private:
     void onClipboardChanged(ClipboardMode mode);
@@ -40,12 +44,16 @@ private:
     QString m_clipboardTab;
     bool m_storeClipboard;
 
+    ClipboardOwnerMonitor m_ownerMonitor;
+
 #ifdef HAS_MOUSE_SELECTIONS
     bool m_storeSelection;
     bool m_runSelection;
     bool m_clipboardToSelection;
     bool m_selectionToClipboard;
 #endif
+
+    QString m_clipboardOwner;
 };
 
 #endif // CLIPBOARDMONITOR_H

--- a/src/app/clipboardownermonitor.cpp
+++ b/src/app/clipboardownermonitor.cpp
@@ -2,28 +2,46 @@
 
 #include "clipboardownermonitor.h"
 
-#include "common/appconfig.h"
-#include "platform/platformwindow.h"
+#include "app/clipboardmonitor.h"
+#include "common/log.h"
 
 #include <QCoreApplication>
 
-ClipboardOwnerMonitor::ClipboardOwnerMonitor()
+constexpr int updateAfterEventIntervalMs = 20;
+
+ClipboardOwnerMonitor::ClipboardOwnerMonitor(ClipboardMonitor *monitor)
+    : m_monitor(monitor)
 {
     qApp->installNativeEventFilter(this);
 
-    m_timer.setSingleShot(true);
-    const int delay = AppConfig().option<Config::change_clipboard_owner_delay_ms>();
-    m_timer.setInterval(delay);
-    QObject::connect( &m_timer, &QTimer::timeout, [this]() {
-        m_clipboardOwner = m_newClipboardOwner;
+    m_timerSetOwner.setSingleShot(true);
 
-        PlatformWindowPtr currentWindow = platformNativeInterface()->getCurrentWindow();
-        if (currentWindow) {
-            const auto currentWindowTitle = currentWindow->getTitle().toUtf8();
-            if (m_newClipboardOwner != currentWindowTitle) {
-                m_newClipboardOwner = currentWindowTitle;
-                m_timer.start();
+    m_timerUpdateAfterEvent.setSingleShot(true);
+    m_timerUpdateAfterEvent.setInterval(updateAfterEventIntervalMs);
+
+    QObject::connect(
+        &m_timerSetOwner, &QTimer::timeout,
+        [this]() {
+            if (!m_nextClipboardOwners.isEmpty()) {
+                m_monitor->setClipboardOwner(m_nextClipboardOwners.takeFirst());
+                if (!m_nextClipboardOwners.isEmpty())
+                    m_timerSetOwner.start();
             }
+        });
+
+    QObject::connect( &m_timerUpdateAfterEvent, &QTimer::timeout, [this]() {
+        const QString title = m_monitor->currentClipboardOwner();
+        if (m_lastClipboardOwner != title) {
+            m_lastClipboardOwner = title;
+            if ( m_timerSetOwner.interval() == 0 )
+                m_nextClipboardOwners = QStringList{m_lastClipboardOwner};
+            else
+                m_nextClipboardOwners.append(m_lastClipboardOwner);
+
+            if (!m_timerSetOwner.isActive())
+                m_timerSetOwner.start();
+
+            COPYQ_LOG(QStringLiteral("Next clipboard owner: %1").arg(title));
         }
     });
 }
@@ -33,10 +51,21 @@ ClipboardOwnerMonitor::~ClipboardOwnerMonitor()
     qApp->removeNativeEventFilter(this);
 }
 
+void ClipboardOwnerMonitor::update()
+{
+    if ( m_timerSetOwner.interval() == 0 ) {
+        m_lastClipboardOwner = m_monitor->currentClipboardOwner();
+        m_nextClipboardOwners.clear();
+        m_monitor->setClipboardOwner(m_lastClipboardOwner);
+    } else if ( !m_timerUpdateAfterEvent.isActive() ) {
+        m_timerUpdateAfterEvent.start();
+    }
+}
+
 bool ClipboardOwnerMonitor::nativeEventFilter(const QByteArray &, void *, NativeEventResult *)
 {
-    if ( !m_timer.isActive() )
-        m_timer.start();
+    if ( !m_timerUpdateAfterEvent.isActive() )
+        m_timerUpdateAfterEvent.start();
 
     return false;
 }

--- a/src/app/clipboardownermonitor.h
+++ b/src/app/clipboardownermonitor.h
@@ -7,7 +7,7 @@
 #include <QByteArray>
 #include <QTimer>
 
-#include "platform/platformnativeinterface.h"
+class ClipboardMonitor;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
 using NativeEventResult = qintptr;
@@ -18,18 +18,22 @@ using NativeEventResult = long;
 class ClipboardOwnerMonitor final : public QAbstractNativeEventFilter
 {
 public:
-    ClipboardOwnerMonitor();
+    explicit ClipboardOwnerMonitor(ClipboardMonitor *monitor);
     ~ClipboardOwnerMonitor();
-
-    const QByteArray &clipboardOwner() const { return m_clipboardOwner; }
 
     bool nativeEventFilter(
         const QByteArray &, void *message, NativeEventResult *result) override;
 
+    void setUpdateInterval(int ms) { m_timerSetOwner.setInterval(ms); }
+
+    void update();
+
 private:
-    QByteArray m_clipboardOwner;
-    QByteArray m_newClipboardOwner;
-    QTimer m_timer;
+    ClipboardMonitor *m_monitor;
+    QString m_lastClipboardOwner;
+    QStringList m_nextClipboardOwners;
+    QTimer m_timerSetOwner;
+    QTimer m_timerUpdateAfterEvent;
 };
 
 #endif // CLIPBOARDOWNERMONITOR_H

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -216,6 +216,7 @@ void ClipboardServer::stopMonitoring()
         return;
 
     COPYQ_LOG("Terminating monitor");
+    setClipboardMonitorRunning(false);
 
     const auto client = findClient(m_monitor->id());
     if (client)

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -486,11 +486,12 @@ struct window_wait_for_modifier_released_ms : Config<int> {
     }
 };
 
-struct change_clipboard_owner_delay_ms : Config<int> {
-    static QString name() { return "change_clipboard_owner_delay_ms"; }
-    static Value defaultValue() { return 150; }
+struct update_clipboard_owner_delay_ms : Config<int> {
+    static QString name() { return "update_clipboard_owner_delay_ms"; }
+    static Value defaultValue() { return -1; }
     static const char *description() {
-        return "Delay to save new clipboard owner window title";
+        return "Delay to update new clipboard owner window title"
+               " (use negative value for the default interval)";
     }
 };
 

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -327,7 +327,7 @@ void ConfigurationManager::initOptions()
     bind<Config::window_key_press_time_ms>();
     bind<Config::window_wait_for_modifier_released_ms>();
 
-    bind<Config::change_clipboard_owner_delay_ms>();
+    bind<Config::update_clipboard_owner_delay_ms>();
 
     bind<Config::style>();
 

--- a/src/platform/dummy/dummyclipboard.h
+++ b/src/platform/dummy/dummyclipboard.h
@@ -3,7 +3,6 @@
 #ifndef DUMMYCLIPBOARD_H
 #define DUMMYCLIPBOARD_H
 
-#include "app/clipboardownermonitor.h"
 #include "common/clipboardmode.h"
 #include "platform/platformclipboard.h"
 
@@ -22,20 +21,18 @@ public:
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
 
-    QByteArray clipboardOwner() override { return m_ownerMonitor.clipboardOwner(); }
-
     const QMimeData *mimeData(ClipboardMode mode) const override;
 
     bool isSelectionSupported() const override { return false; }
 
     bool isHidden(const QMimeData &data) const override;
 
+    void setClipboardOwner(const QString &) override {}
+
 protected:
     virtual const QMimeData *rawMimeData(ClipboardMode mode) const;
     virtual void onChanged(int mode);
     void onClipboardChanged(QClipboard::Mode mode);
-
-    ClipboardOwnerMonitor m_ownerMonitor;
 };
 
 #endif // DUMMYCLIPBOARD_H

--- a/src/platform/mac/macclipboard.h
+++ b/src/platform/mac/macclipboard.h
@@ -11,8 +11,6 @@ public:
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
 
-    QByteArray clipboardOwner() override;
-
     bool isHidden(const QMimeData &data) const override;
 
 protected:

--- a/src/platform/mac/macclipboard.mm
+++ b/src/platform/mac/macclipboard.mm
@@ -52,14 +52,6 @@ void MacClipboard::setData(ClipboardMode mode, const QVariantMap &dataMap)
     return DummyClipboard::setData(mode, dataMapForMac);
 }
 
-QByteArray MacClipboard::clipboardOwner()
-{
-    PlatformWindowPtr currentWindow = platformNativeInterface()->getCurrentWindow();
-    if (currentWindow)
-        return currentWindow->getTitle().toUtf8();
-    return QByteArray();
-}
-
 bool MacClipboard::isHidden(const QMimeData &data) const
 {
     return data.hasFormat( QStringLiteral("application/x-nspasteboard-concealed-type") );

--- a/src/platform/platformclipboard.h
+++ b/src/platform/platformclipboard.h
@@ -34,13 +34,13 @@ public:
      */
     virtual void setData(ClipboardMode mode, const QVariantMap &dataMap) = 0;
 
-    virtual QByteArray clipboardOwner() = 0;
-
     virtual const QMimeData *mimeData(ClipboardMode mode) const = 0;
 
     virtual bool isSelectionSupported() const = 0;
 
     virtual bool isHidden(const QMimeData &data) const = 0;
+
+    virtual void setClipboardOwner(const QString &owner) = 0;
 
 signals:
     /// Notifies about clipboard changes.

--- a/src/platform/x11/x11platformclipboard.cpp
+++ b/src/platform/x11/x11platformclipboard.cpp
@@ -13,6 +13,8 @@
 
 #include "systemclipboard/waylandclipboard.h"
 
+#include <QDataStream>
+
 #ifdef COPYQ_WITH_X11
 #   include <X11/Xlib.h>
 #   include <X11/Xatom.h>
@@ -136,7 +138,7 @@ QVariantMap X11PlatformClipboard::data(ClipboardMode mode, const QStringList &fo
 
     auto data = clipboardData.data;
     if ( !data.contains(mimeOwner) )
-        data[mimeWindowTitle] = clipboardData.owner;
+        data[mimeWindowTitle] = clipboardData.owner.toUtf8();
     return data;
 }
 
@@ -174,15 +176,7 @@ void X11PlatformClipboard::onChanged(int mode)
     // Store the current window title right after the clipboard/selection changes.
     // This makes sure that the title points to the correct clipboard/selection
     // owner most of the times.
-    const auto currentWindowTitle = clipboardOwner();
-    if (currentWindowTitle != clipboardData.newOwner) {
-        COPYQ_LOG( QString("New %1 owner: \"%2\"")
-                   .arg(
-                       QString::fromLatin1(mode == QClipboard::Clipboard ? "clipboard" : "selection"),
-                       QString::fromUtf8(currentWindowTitle)
-                   ) );
-        clipboardData.newOwner = currentWindowTitle;
-    }
+    clipboardData.newOwner = m_clipboardOwner;
 
     if (mode == QClipboard::Selection) {
         // Omit checking selection too fast.

--- a/src/platform/x11/x11platformclipboard.h
+++ b/src/platform/x11/x11platformclipboard.h
@@ -26,6 +26,8 @@ public:
 
     bool isSelectionSupported() const override { return m_selectionSupported; }
 
+    void setClipboardOwner(const QString &owner) override { m_clipboardOwner = owner; }
+
 protected:
     const QMimeData *rawMimeData(ClipboardMode mode) const override;
     void onChanged(int mode) override;
@@ -34,8 +36,8 @@ private:
     struct ClipboardData {
         QVariantMap newData;
         QVariantMap data;
-        QByteArray owner;
-        QByteArray newOwner;
+        QString owner;
+        QString newOwner;
         QTimer timerEmitChange;
         QStringList formats;
         quint32 newDataTimestamp;
@@ -59,6 +61,8 @@ private:
 
     bool m_monitoring = false;
     bool m_selectionSupported = true;
+
+    QString m_clipboardOwner;
 };
 
 #endif // X11PLATFORMCLIPBOARD_H

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -297,6 +297,7 @@ public slots:
     QJSValue execute();
 
     QJSValue currentWindowTitle();
+    QJSValue currentClipboardOwner();
 
     QJSValue dialog();
 
@@ -389,6 +390,7 @@ private:
     void onMonitorClipboardChanged(const QVariantMap &data, ClipboardOwnership ownership);
     void onMonitorClipboardUnchanged(const QVariantMap &data);
     void onSynchronizeSelection(ClipboardMode sourceMode, uint sourceTextHash, uint targetTextHash);
+    void onFetchCurrentClipboardOwner(QString *title);
 
     bool sourceScriptCommands();
     void callDisplayFunctions(QJSValueList displayFunctions);
@@ -416,7 +418,6 @@ private:
     bool runCommands(CommandType::CommandType type);
     bool canExecuteCommand(const Command &command);
     bool canExecuteCommandFilter(const QString &matchCommand);
-    bool canAccessClipboard() const;
     bool verifyClipboardAccess();
     void provideClipboard(ClipboardMode mode);
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -293,6 +293,8 @@ private slots:
 
     void avoidStoringPasswords();
 
+    void currentClipboardOwner();
+
 private:
     void clearServerErrors();
     int run(const QStringList &arguments, QByteArray *stdoutData = nullptr,


### PR DESCRIPTION
Adds `currentClipboardOwner()` function to scripting which returns name of the current clipboard owner. This by default returns `currentWindowTitle()`.

The value is used to set `mimeWindowTitle` format for the clipboard data in automatic commands and filtering by window title.