### PR TITLE
Add event handlers

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,18 +17,21 @@ jobs:
             compiler: g++
             compiler_package: g++
             with_qt6: false
+            with_native_notifications: true
 
           - os: ubuntu-20.04
             buildname: Linux-Clang
             compiler: clang++
             compiler_package: clang
             with_qt6: false
+            with_native_notifications: true
 
           - os: ubuntu-latest
             buildname: Qt 6
             compiler: g++
             compiler_package: g++
             with_qt6: true
+            with_native_notifications: false
             coverage: true
             compiler_flags: >-
               --coverage
@@ -74,7 +77,8 @@ jobs:
             '-DCMAKE_CXX_COMPILER=${{matrix.compiler}}',
             '-DCMAKE_CXX_FLAGS=${{matrix.compiler_flags}}',
             '-DCMAKE_C_FLAGS=${{matrix.compiler_flags}}',
-            '-DWITH_QT6=${{matrix.with_qt6}}'
+            '-DWITH_QT6=${{matrix.with_qt6}}',
+            '-DWITH_NATIVE_NOTIFICATIONS=${{matrix.with_native_notifications}}'
             ]
 
       - name: Create gnupg directory for tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,7 @@ else()
 endif()
 
 # C++17
-if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
-    set(CMAKE_CXX_STANDARD 17)
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-endif()
+set(CMAKE_CXX_STANDARD 17)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(COPYQ_DEBUG ON)

--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1622,6 +1622,48 @@ unlike in GUI, where row numbers start from 1 by default.
 
        config("style", styleName)
 
+.. js:function:: onItemsAdded()
+
+   Called when items are added to a tab.
+
+   The target tab is returned by `selectedTab()`.
+
+   The new items can be accessed with `selectedItemsData()`,
+   `selectedItemData()`, `selectedItems()` and `ItemSelection().current()`.
+
+.. js:function:: onItemsRemoved()
+
+   Called when items are being removed from a tab.
+
+   The target tab is returned by `selectedTab()`.
+
+   The removed items can be accessed with `selectedItemsData()`,
+   `selectedItemData()`, `selectedItems()` and `ItemSelection().current()`.
+
+.. js:function:: onItemsChanged()
+
+   Called when data in items change.
+
+   The target tab is returned by `selectedTab()`.
+
+   The modified items can be accessed with `selectedItemsData()`,
+   `selectedItemData()`, `selectedItems()` and `ItemSelection().current()`.
+
+.. js:function:: onTabSelected()
+
+   Called when another tab is opened.
+
+   The newly selected tab is returned by `selectedTab()`.
+
+   The changed items can be accessed with `selectedItemsData()`,
+   `selectedItemData()`, `selectedItems()` and `ItemSelection().current()`.
+
+.. js:function:: onItemsLoaded()
+
+   Called when all items are loaded into a tab.
+
+   The target tab is returned by `selectedTab()`.
+
 Types
 -----
 

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -28,6 +28,7 @@
 #include <QTextEdit>
 #include <QtPlugin>
 #include <QVBoxLayout>
+#include <QVariantMap>
 
 namespace {
 

--- a/plugins/itemencrypted/itemencrypted.h
+++ b/plugins/itemencrypted/itemencrypted.h
@@ -7,6 +7,7 @@
 #include "gui/icons.h"
 
 #include <QProcess>
+#include <QVariant>
 #include <QWidget>
 
 #include <memory>

--- a/plugins/itemfakevim/itemfakevim.cpp
+++ b/plugins/itemfakevim/itemfakevim.cpp
@@ -30,6 +30,7 @@ using namespace FakeVim::Internal;
 #include <QSettings>
 #include <QStyle>
 #include <QStyleHints>
+#include <QVariantMap>
 #include <QtPlugin>
 
 #define EDITOR(s) (m_textEdit ? m_textEdit->s : m_plainTextEdit->s)

--- a/plugins/itemimage/itemimage.cpp
+++ b/plugins/itemimage/itemimage.cpp
@@ -21,6 +21,7 @@
 #include <QSettings>
 #include <QtPlugin>
 #include <QVariant>
+#include <QVariantMap>
 
 namespace {
 

--- a/plugins/itemimage/itemimage.h
+++ b/plugins/itemimage/itemimage.h
@@ -8,6 +8,7 @@
 
 #include <QLabel>
 #include <QPixmap>
+#include <QVariant>
 
 #include <memory>
 

--- a/plugins/itemnotes/itemnotes.cpp
+++ b/plugins/itemnotes/itemnotes.cpp
@@ -22,6 +22,7 @@
 #include <QTextEdit>
 #include <QTimer>
 #include <QToolTip>
+#include <QVariantMap>
 #include <QtPlugin>
 
 #include <cmath>

--- a/plugins/itemnotes/itemnotes.h
+++ b/plugins/itemnotes/itemnotes.h
@@ -6,6 +6,7 @@
 #include "gui/icons.h"
 #include "item/itemwidgetwrapper.h"
 
+#include <QVariant>
 #include <QWidget>
 
 namespace Ui {

--- a/plugins/itempinned/itempinned.h
+++ b/plugins/itempinned/itempinned.h
@@ -7,6 +7,8 @@
 #include "item/itemwidgetwrapper.h"
 #include "item/itemsaverwrapper.h"
 
+#include <QPointer>
+#include <QVariant>
 #include <QWidget>
 
 class ItemPinned final : public QWidget, public ItemWidgetWrapper

--- a/plugins/itemsync/itemsync.h
+++ b/plugins/itemsync/itemsync.h
@@ -6,6 +6,7 @@
 #include "gui/icons.h"
 #include "item/itemwidgetwrapper.h"
 
+#include <QVariantMap>
 #include <QWidget>
 
 #include <memory>

--- a/src/app/clipboardclient.cpp
+++ b/src/app/clipboardclient.cpp
@@ -61,11 +61,7 @@ ClipboardClient::ClipboardClient(int &argc, char **argv, const QStringList &argu
     App::installTranslator();
 
     // Start script after QCoreApplication::exec().
-    auto timer = new QTimer(this);
-    timer->setSingleShot(true);
-    connect(timer, &QTimer::timeout, this, [&]() { start(arguments); });
-    connect(timer, &QTimer::timeout, timer, &QObject::deleteLater);
-    timer->start(0);
+    QTimer::singleShot(0, this, [&]() { start(arguments); });
 }
 
 void ClipboardClient::onMessageReceived(const QByteArray &data, int messageCode)

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -163,6 +163,8 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     connect( m_wnd, &MainWindow::commandsSaved,
              this, &ClipboardServer::onCommandsSaved );
 
+    m_server->start();
+
     {
         AppConfig appConfig;
         loadSettings(&appConfig);
@@ -172,8 +174,6 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     m_wnd->enterBrowseMode();
 
     qApp->installEventFilter(this);
-
-    m_server->start();
 
     // Ignore global shortcut key presses in any widget.
     m_ignoreKeysTimer.setInterval(100);

--- a/src/common/action.cpp
+++ b/src/common/action.cpp
@@ -262,7 +262,7 @@ void Action::start()
                  this, &Action::onSubProcessErrorOutput );
     }
 
-    pipeThroughProcesses(m_processes.begin(), m_processes.end());
+    pipeThroughProcesses(m_processes.constBegin(), m_processes.constEnd());
 
     QProcess *lastProcess = m_processes.back();
     connect( lastProcess, &QProcess::started,
@@ -345,7 +345,7 @@ void Action::appendErrorOutput(const QByteArray &errorOutput)
     m_errorOutput.append(errorOutput);
 }
 
-void Action::onSubProcessError(QProcess::ProcessError error)
+void Action::onSubProcessError(int error)
 {
     QProcess *p = qobject_cast<QProcess*>(sender());
     Q_ASSERT(p);
@@ -379,7 +379,7 @@ void Action::onSubProcessOutput()
     if ( m_processes.empty() )
         return;
 
-    auto p = m_processes.back();
+    QProcess *p = m_processes.back();
     if ( p->isReadable() )
         appendOutput( p->readAll() );
 }
@@ -432,8 +432,9 @@ void Action::closeSubCommands()
     if (m_processes.empty())
         return;
 
-    m_exitCode = m_processes.back()->exitCode();
-    m_failed = m_failed || m_processes.back()->exitStatus() != QProcess::NormalExit;
+    QProcess *last = m_processes.back();
+    m_exitCode = last->exitCode();
+    m_failed = m_failed || last->exitStatus() != QProcess::NormalExit;
 
     for (auto p : m_processes)
         p->deleteLater();

--- a/src/common/action.cpp
+++ b/src/common/action.cpp
@@ -310,7 +310,7 @@ bool Action::waitForFinished(int msecs)
         t.setSingleShot(true);
         t.start(msecs);
     }
-    loop.exec(QEventLoop::ExcludeUserInputEvents);
+    loop.exec(QEventLoop::AllEvents);
 
     // Loop stopped because application is exiting?
     while ( self && isRunning() && (msecs < 0 || t.isActive()) )

--- a/src/common/action.h
+++ b/src/common/action.h
@@ -3,14 +3,11 @@
 #ifndef ACTION_H
 #define ACTION_H
 
-#include <QModelIndex>
-#include <QProcess>
 #include <QStringList>
 #include <QVariantMap>
 
-#include <vector>
-
 class QAction;
+class QProcess;
 
 /**
  * Terminate process or kill if it takes too long.
@@ -101,7 +98,7 @@ signals:
     void actionOutput(const QByteArray &output);
 
 private:
-    void onSubProcessError(QProcess::ProcessError error);
+    void onSubProcessError(int error);
     void onSubProcessStarted();
     void onSubProcessFinished();
     void onSubProcessOutput();
@@ -122,7 +119,7 @@ private:
     int m_currentLine;
     QString m_name;
     QVariantMap m_data;
-    std::vector<QProcess*> m_processes;
+    QList<QProcess*> m_processes;
 
     int m_exitCode;
     QString m_errorString;

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -5,9 +5,8 @@
 
 #include "common/settings.h"
 
-#include <QVariant>
-
 class QString;
+class QVariant;
 
 QString defaultClipboardTabName();
 

--- a/src/common/server.h
+++ b/src/common/server.h
@@ -3,7 +3,6 @@
 #ifndef SERVER_H
 #define SERVER_H
 
-#include <QLockFile>
 #include <QMetaType>
 #include <QObject>
 
@@ -37,10 +36,8 @@ private:
     void onNewConnection();
     void onSocketDestroyed();
 
-    QLocalServer *m_server;
-    QLockFile m_lockFile;
-    int m_socketCount;
-    QEventLoop *m_loop = nullptr;
+    struct PrivateData;
+    std::unique_ptr<PrivateData> m_data;
 };
 
 #endif // SERVER_H

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -3,7 +3,8 @@
 #pragma once
 
 #include <QSettings>
-#include <QString>
+
+class QString;
 
 /**
  * Simple wrapper class for QSettings.

--- a/src/common/textdata.cpp
+++ b/src/common/textdata.cpp
@@ -6,7 +6,6 @@
 
 #include <QLocale>
 #include <QString>
-#include <Qt>
 
 #include <algorithm>
 #include <iterator>

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1671,6 +1671,7 @@ bool ClipboardBrowser::loadItems()
         return false;
 
     d.rowsInserted(QModelIndex(), 0, m.rowCount());
+    emit itemsLoaded(this);
     if ( hasFocus() )
         setCurrent(0);
     onItemCountChanged();

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -242,6 +242,8 @@ class ClipboardBrowser final : public QListView
 
         void itemsChanged(const ClipboardBrowser *self);
 
+        void itemsLoaded(const ClipboardBrowser *self);
+
         void itemSelectionChanged(const ClipboardBrowser *self);
 
         void internalEditorStateChanged(const ClipboardBrowser *self);

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -5,7 +5,6 @@
 
 #include "common/clipboardmode.h"
 #include "gui/clipboardbrowsershared.h"
-#include "gui/theme.h"
 #include "item/clipboardmodel.h"
 #include "item/itemdelegate.h"
 #include "item/itemfilter.h"
@@ -15,9 +14,6 @@
 #include <QPointer>
 #include <QTimer>
 #include <QVariantMap>
-#include <QVector>
-
-#include <memory>
 
 class ItemEditorWidget;
 class ItemFactory;

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -118,6 +118,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("open", "open(url, ...) -> bool", "Tries to open URLs in appropriate applications.");
     addDocumentation("execute", "execute(argument, ..., null, stdinData, ...) -> `FinishedCommand` or `undefined`", "Executes a command.");
     addDocumentation("currentWindowTitle", "String currentWindowTitle() -> string", "Returns window title of currently focused window.");
+    addDocumentation("currentClipboardOwner", "String currentClipboardOwner() -> string", "Returns name of the current clipboard owner.");
     addDocumentation("dialog", "dialog(...)", "Shows messages or asks user for input.");
     addDocumentation("menuItems", "menuItems(text...) -> string", "Opens menu with given items and returns selected item or an empty string.");
     addDocumentation("menuItems", "menuItems(items[]) -> int", "Opens menu with given items and returns index of selected item or -1.");
@@ -171,6 +172,11 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("hideDataNotification", "hideDataNotification()", "Hide notification for current data.");
     addDocumentation("setClipboardData", "setClipboardData()", "Sets clipboard data for menu commands.");
     addDocumentation("styles", "styles() -> array of strings", "List available styles for `style` option.");
+    addDocumentation("onItemsAdded", "onItemsAdded()", "Called when items are added to a tab.");
+    addDocumentation("onItemsRemoved", "onItemsRemoved()", "Called when items are being removed from a tab.");
+    addDocumentation("onItemsChanged", "onItemsChanged()", "Called when data in items change.");
+    addDocumentation("onTabSelected", "onTabSelected()", "Called when another tab is open.");
+    addDocumentation("onItemsLoaded", "onItemsLoaded()", "Called when items a loaded to a tab.");
     addDocumentation("ByteArray", "ByteArray", "Wrapper for QByteArray Qt class.");
     addDocumentation("File", "File", "Wrapper for QFile Qt class.");
     addDocumentation("Dir", "Dir", "Wrapper for QDir Qt class.");

--- a/src/gui/iconfactory.cpp
+++ b/src/gui/iconfactory.cpp
@@ -631,6 +631,16 @@ QIcon iconFromFile(const QString &fileName, const QString &tag, const QColor &co
     return IconEngine::createIcon(0, fileName, tag, color);
 }
 
+QIcon iconFromFile(const QString &fileName, const QString &tag)
+{
+    return iconFromFile(fileName, tag, {});
+}
+
+QIcon iconFromFile(const QString &fileName)
+{
+    return iconFromFile(fileName, {}, {});
+}
+
 QPixmap createPixmap(unsigned short id, const QColor &color, int size)
 {
     if (loadIconFont())

--- a/src/gui/iconfactory.h
+++ b/src/gui/iconfactory.h
@@ -3,9 +3,7 @@
 #ifndef ICONFACTORY_H
 #define ICONFACTORY_H
 
-#include <QColor>
-#include <QString>
-
+class QColor;
 class QIcon;
 class QPixmap;
 class QPainter;
@@ -20,7 +18,9 @@ QIcon getIcon(const QVariant &iconOrIconId);
 
 QIcon getIconFromResources(const QString &iconName);
 
-QIcon iconFromFile(const QString &fileName, const QString &tag = QString(), const QColor &color = QColor());
+QIcon iconFromFile(const QString &fileName, const QString &tag, const QColor &color);
+QIcon iconFromFile(const QString &fileName, const QString &tag);
+QIcon iconFromFile(const QString &fileName);
 
 unsigned short toIconId(const QString &fileNameOrId);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -72,10 +72,12 @@
 #include <QModelIndex>
 #include <QPushButton>
 #include <QShortcut>
+#include <QSystemTrayIcon>
 #include <QTemporaryFile>
 #include <QTimer>
 #include <QToolBar>
 #include <QUrl>
+#include <QVector>
 
 #include <algorithm>
 #include <memory>
@@ -2975,7 +2977,7 @@ void MainWindow::onTrayActionTriggered(const QVariantMap &data, bool omitPaste)
     activateMenuItem( getPlaceholderForTrayMenu(), data, omitPaste );
 }
 
-void MainWindow::trayActivated(QSystemTrayIcon::ActivationReason reason)
+void MainWindow::trayActivated(int reason)
 {
 #ifdef Q_OS_MAC
     if (!m_options.nativeTrayMenu && reason == QSystemTrayIcon::Context) {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -15,6 +15,7 @@
 #include <QModelIndex>
 #include <QPointer>
 #include <QSystemTrayIcon>
+#include <QSet>
 #include <QTimer>
 #include <QVector>
 
@@ -411,6 +412,9 @@ public:
     void setItemPreviewVisible(bool visible);
     bool isItemPreviewVisible() const;
 
+    void setScriptOverrides(const QVector<int> &overrides);
+    bool isScriptOverridden(int id) const;
+
 signals:
     /** Request clipboard change. */
     void changeClipboard(const QVariantMap &data, ClipboardMode mode);
@@ -693,6 +697,8 @@ private:
     bool m_isActiveWindow = false;
     bool m_singleClickActivate = 0;
     bool m_enteringSearchMode = false;
+
+    QVector<int> m_overrides;
 };
 
 #endif // MAINWINDOW_H

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -12,12 +12,9 @@
 #include "platform/platformnativeinterface.h"
 
 #include <QMainWindow>
-#include <QModelIndex>
 #include <QPointer>
-#include <QSystemTrayIcon>
-#include <QSet>
 #include <QTimer>
-#include <QVector>
+#include <QtContainerFwd>
 
 class Action;
 class ActionDialog;
@@ -35,6 +32,7 @@ class Tabs;
 class Theme;
 class TrayMenu;
 class ToolBar;
+class QModelIndex;
 struct MainWindowOptions;
 struct NotificationButton;
 
@@ -449,7 +447,7 @@ private:
     ClipboardBrowserPlaceholder *getPlaceholderForTrayMenu();
     void filterMenuItems(const QString &searchText);
     void filterTrayMenuItems(const QString &searchText);
-    void trayActivated(QSystemTrayIcon::ActivationReason reason);
+    void trayActivated(int reason);
     void onMenuActionTriggered(const QVariantMap &data, bool omitPaste);
     void onTrayActionTriggered(const QVariantMap &data, bool omitPaste);
     void findNextOrPrevious();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -412,7 +412,7 @@ public:
     void setItemPreviewVisible(bool visible);
     bool isItemPreviewVisible() const;
 
-    void setScriptOverrides(const QVector<int> &overrides);
+    void setScriptOverrides(const QVector<int> &overrides, int actionId);
     bool isScriptOverridden(int id) const;
 
 signals:
@@ -500,6 +500,7 @@ private:
 
     void onBrowserCreated(ClipboardBrowser *browser);
     void onBrowserDestroyed(ClipboardBrowserPlaceholder *placeholder);
+    void onBrowserItemsLoaded(const ClipboardBrowser *browser);
 
     void onItemSelectionChanged(const ClipboardBrowser *browser);
     void onItemsChanged(const ClipboardBrowser *browser);
@@ -630,6 +631,9 @@ private:
     const Theme &theme() const;
 
     Action *runScript(const QString &script, const QVariantMap &data = QVariantMap());
+    void runEventHandlerScript(const QString &script, const QVariantMap &data = QVariantMap());
+    void runItemHandlerScript(
+        const QString &script, const ClipboardBrowser *browser, int firstRow, int lastRow);
 
     void activateCurrentItemHelper();
     void onItemClicked();
@@ -699,6 +703,8 @@ private:
     bool m_enteringSearchMode = false;
 
     QVector<int> m_overrides;
+    int m_maxEventHandlerScripts = 10;
+    QPointer<Action> m_actionCollectOverrides;
 };
 
 #endif // MAINWINDOW_H

--- a/src/item/itemfactory.cpp
+++ b/src/item/itemfactory.cpp
@@ -208,10 +208,11 @@ class DummyLoader final : public ItemLoaderInterface
 public:
     int priority() const override { return std::numeric_limits<int>::min(); }
 
-    QString id() const override { return QString(); }
-    QString name() const override { return QString(); }
-    QString author() const override { return QString(); }
-    QString description() const override { return QString(); }
+    QString id() const override { return {}; }
+    QString name() const override { return {}; }
+    QString author() const override { return {}; }
+    QString description() const override { return {}; }
+    QVariant icon() const override { return {}; }
 
     void setEnabled(bool) override {}
     void loadSettings(const QSettings &) override

--- a/src/item/itemfactory.h
+++ b/src/item/itemfactory.h
@@ -10,8 +10,6 @@
 #include <QObject>
 #include <QtContainerFwd>
 
-#include <memory>
-
 class ItemLoaderInterface;
 class ItemWidget;
 class ScriptableProxy;
@@ -23,7 +21,7 @@ class QWidget;
 struct Command;
 struct CommandMenu;
 
-using ItemLoaderList = QVector<ItemLoaderPtr>;
+using ItemLoaderList = QList<ItemLoaderPtr>;
 
 /**
  * Loads item plugins (loaders) and instantiates ItemWidget objects using appropriate

--- a/src/item/itemsaverwrapper.cpp
+++ b/src/item/itemsaverwrapper.cpp
@@ -1,5 +1,7 @@
 #include "itemsaverwrapper.h"
 
+#include <QVariantMap>
+
 ItemSaverWrapper::ItemSaverWrapper(const ItemSaverPtr &saver)
     : m_saver(saver)
 {

--- a/src/item/itemstore.cpp
+++ b/src/item/itemstore.cpp
@@ -191,9 +191,9 @@ void cleanDataFiles(const QStringList &tabNames)
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
-    const QSet fileSet(files.constBegin(), files.constEnd());
+    const QSet<QString> fileSet(files.constBegin(), files.constEnd());
 #else
-    const QSet fileSet = files.toSet();
+    const QSet<QString> fileSet = files.toSet();
 #endif
     for ( const auto &i1 : dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot) ) {
         QDir d1(i1.absoluteFilePath());

--- a/src/item/itemwidget.cpp
+++ b/src/item/itemwidget.cpp
@@ -215,6 +215,11 @@ ItemWidget *ItemLoaderInterface::create(const QVariantMap &, QWidget *, bool) co
     return nullptr;
 }
 
+QStringList ItemLoaderInterface::formatsToSave() const
+{
+    return {};
+}
+
 bool ItemLoaderInterface::canLoadItems(QIODevice *) const
 {
     return false;

--- a/src/item/itemwidget.h
+++ b/src/item/itemwidget.h
@@ -3,23 +3,23 @@
 #ifndef ITEMWIDGET_H
 #define ITEMWIDGET_H
 
-#include "common/command.h"
 #include "tests/testinterface.h"
 
-#include <QStringList>
+#include <QObject>
 #include <QtContainerFwd>
-#include <QtPlugin>
-#include <QVariantMap>
-#include <QWidget>
 
 #include <memory>
 
+struct Command;
+
 class ItemFilter;
+class TestInterface;
 class QAbstractItemModel;
 class QIODevice;
 class QModelIndex;
 class QSettings;
 class QTextEdit;
+class QWidget;
 
 class ItemLoaderInterface;
 using ItemLoaderPtr = std::shared_ptr<ItemLoaderInterface>;
@@ -29,6 +29,8 @@ using ItemSaverPtr = std::shared_ptr<ItemSaverInterface>;
 
 class ItemScriptableFactoryInterface;
 using ItemScriptableFactoryPtr = std::shared_ptr<ItemScriptableFactoryInterface>;
+
+using TestInterfacePtr = std::shared_ptr<TestInterface>;
 
 #define COPYQ_PLUGIN_ITEM_LOADER_ID "com.github.hluk.copyq.itemloader/7.1.0"
 
@@ -278,14 +280,14 @@ public:
      *
      * Default is no icon.
      */
-    virtual QVariant icon() const { return QVariant(); }
+    virtual QVariant icon() const = 0;
 
     /**
      * Provide formats to save (possibly configurable).
      *
      * The values are stored into user QSettings, under group with name same as value of id().
      */
-    virtual QStringList formatsToSave() const { return QStringList(); }
+    virtual QStringList formatsToSave() const;
 
     /**
      * Save and return configuration values to save from current settings widget.

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -653,6 +653,11 @@ bool isGuiApplication()
     return qobject_cast<QGuiApplication*>(qApp);
 }
 
+bool isOverridden(const QJSValue &globalObject, const QString &property)
+{
+    return globalObject.property(property).property(QStringLiteral("_copyq")).toInt() != 1;
+}
+
 } // namespace
 
 Scriptable::Scriptable(
@@ -2947,15 +2952,24 @@ QJSValue Scriptable::styles()
     return toScriptValue( m_proxy->styles(), this );
 }
 
-void Scriptable::collectOverrides()
+void Scriptable::collectScriptOverrides()
 {
     m_skipArguments = 1;
     auto globalObject = engine()->globalObject();
 
     QVector<int> overrides;
-    const auto pasteFn = globalObject.property("paste");
-    if (pasteFn.property("_copyq").toInt() != 1)
+    if (isOverridden(globalObject, QStringLiteral("paste")))
         overrides.append(ScriptOverrides::Paste);
+    if (isOverridden(globalObject, QStringLiteral("onItemsAdded")))
+        overrides.append(ScriptOverrides::OnItemsAdded);
+    if (isOverridden(globalObject, QStringLiteral("onItemsRemoved")))
+        overrides.append(ScriptOverrides::OnItemsRemoved);
+    if (isOverridden(globalObject, QStringLiteral("onItemsChanged")))
+        overrides.append(ScriptOverrides::OnItemsChanged);
+    if (isOverridden(globalObject, QStringLiteral("onTabSelected")))
+        overrides.append(ScriptOverrides::OnTabSelected);
+    if (isOverridden(globalObject, QStringLiteral("onItemsLoaded")))
+        overrides.append(ScriptOverrides::OnItemsLoaded);
 
     m_proxy->setScriptOverrides(overrides);
 }

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -389,6 +389,8 @@ public slots:
 
     QJSValue styles();
 
+    void collectOverrides();
+
 signals:
     void finished();
     void dataReceived(const QByteArray &data);

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -389,7 +389,12 @@ public slots:
 
     QJSValue styles();
 
-    void collectOverrides();
+    void onItemsAdded() {}
+    void onItemsRemoved() {}
+    void onItemsChanged() {}
+    void onTabSelected() {}
+    void onItemsLoaded() {}
+    void collectScriptOverrides();
 
 signals:
     void finished();

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2601,6 +2601,12 @@ QStringList ScriptableProxy::styles()
     return QStyleFactory::keys();
 }
 
+void ScriptableProxy::setScriptOverrides(const QVector<int> &overrides)
+{
+    INVOKE2(setScriptOverrides, (overrides));
+    m_wnd->setScriptOverrides(overrides);
+}
+
 ClipboardBrowser *ScriptableProxy::fetchBrowser(const QString &tabName)
 {
     if (tabName.isEmpty()) {

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2604,7 +2604,7 @@ QStringList ScriptableProxy::styles()
 void ScriptableProxy::setScriptOverrides(const QVector<int> &overrides)
 {
     INVOKE2(setScriptOverrides, (overrides));
-    m_wnd->setScriptOverrides(overrides);
+    m_wnd->setScriptOverrides(overrides, m_actionId);
 }
 
 ClipboardBrowser *ScriptableProxy::fetchBrowser(const QString &tabName)

--- a/src/scriptable/scriptableproxy.h
+++ b/src/scriptable/scriptableproxy.h
@@ -285,6 +285,8 @@ public slots:
 
     QStringList styles();
 
+    void setScriptOverrides(const QVector<int> &overrides);
+
 signals:
     void functionCallFinished(int functionCallId, const QVariant &returnValue);
     void inputDialogFinished(int dialogId, const NamedValueList &result);

--- a/src/scriptable/scriptoverrides.h
+++ b/src/scriptable/scriptoverrides.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+namespace ScriptOverrides {
+enum ScriptOverrides {
+    Paste = 0,
+};
+}

--- a/src/scriptable/scriptoverrides.h
+++ b/src/scriptable/scriptoverrides.h
@@ -4,5 +4,10 @@
 namespace ScriptOverrides {
 enum ScriptOverrides {
     Paste = 0,
+    OnItemsAdded = 1,
+    OnItemsRemoved = 2,
+    OnItemsChanged = 3,
+    OnTabSelected = 4,
+    OnItemsLoaded = 5,
 };
 }

--- a/src/tests/testinterface.h
+++ b/src/tests/testinterface.h
@@ -5,8 +5,10 @@
 
 #include "common/clipboardmode.h"
 
+#include <QByteArray>
 #include <QStringList>
-#include <QVariantMap>
+#include <QVariant>
+#include <QtContainerFwd>
 
 #include <memory>
 
@@ -60,7 +62,7 @@ public:
     virtual QByteArray waitOnOutput(const QStringList &arguments, const QByteArray &stdoutExpected) = 0;
 
     /// Set clipboard through monitor process.
-    virtual QByteArray setClipboard(const QVariantMap &data, ClipboardMode mode = ClipboardMode::Clipboard) = 0;
+    virtual QByteArray setClipboard(const QMap<QString, QVariant> &data, ClipboardMode mode = ClipboardMode::Clipboard) = 0;
 
     /// Set clipboard through monitor process.
     virtual QByteArray setClipboard(

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -250,6 +250,16 @@ private slots:
     void scriptCommandEnhanceFunction();
     void scriptCommandEndingWithComment();
     void scriptCommandWithError();
+
+    void scriptPaste();
+    void scriptOnTabSelected();
+    void scriptOnItemsRemoved();
+    void scriptOnItemsAdded();
+    void scriptOnItemsChanged();
+    void scriptOnItemsLoaded();
+    void scriptEventMaxRecursion();
+    void scriptSlowCollectOverrides();
+
     void displayCommand();
     void displayCommandForMenu();
 


### PR DESCRIPTION
Allows to use scripting to handle some events:

- items added/removed/changed
- tab items loaded
- tab selected

Fixes #59

Uses overridden paste() when activating items.

Fixes hluk/copyq-commands#83