### PR TITLE
Show read-only advanced command properties for internal commands

### DIFF
--- a/src/gui/commandedit.cpp
+++ b/src/gui/commandedit.cpp
@@ -58,6 +58,11 @@ bool CommandEdit::isEmpty() const
     return ui->plainTextEditCommand->document()->characterCount() == 0;
 }
 
+void CommandEdit::setReadOnly(bool readOnly)
+{
+    ui->plainTextEditCommand->setReadOnly(readOnly);
+}
+
 void CommandEdit::onPlainTextEditCommandTextChanged()
 {
     // TODO: Highlight syntax errors!

--- a/src/gui/commandedit.h
+++ b/src/gui/commandedit.h
@@ -22,6 +22,8 @@ public:
 
     bool isEmpty() const;
 
+    void setReadOnly(bool readOnly);
+
 signals:
     void changed();
     void commandTextChanged(const QString &command);

--- a/src/gui/commandwidget.cpp
+++ b/src/gui/commandwidget.cpp
@@ -152,9 +152,11 @@ Command CommandWidget::command() const
 void CommandWidget::setCommand(const Command &c)
 {
     m_internalId = c.internalId;
-    m_isEditable = m_internalId.startsWith(QLatin1String("copyq_"));
+    const bool isEditable = !m_internalId.startsWith(QLatin1String("copyq_"));
 
-    ui->lineEditName->setReadOnly(m_isEditable);
+    ui->scrollAreaWidgetContents->setEnabled(isEditable);
+    ui->commandEdit->setReadOnly(!isEditable);
+    ui->lineEditName->setReadOnly(!isEditable);
     ui->lineEditName->setText(c.name);
     ui->lineEditMatch->setText( c.re.pattern() );
     ui->lineEditWindow->setText( c.wndre.pattern() );
@@ -251,10 +253,8 @@ void CommandWidget::updateWidgets()
 
 void CommandWidget::updateShowAdvanced()
 {
-    const bool canEditAdvanced = m_showAdvanced && !m_isEditable;
-    ui->widgetCommandType->setVisible(canEditAdvanced);
-    ui->tabWidget->setVisible(canEditAdvanced);
-
+    ui->widgetCommandType->setVisible(m_showAdvanced);
+    ui->tabWidget->setVisible(m_showAdvanced);
     ui->labelDescription->setVisible(m_showAdvanced);
 
     // Hide the Advanced tab if there are no visible widgets.

--- a/src/gui/commandwidget.h
+++ b/src/gui/commandwidget.h
@@ -64,7 +64,6 @@ private:
     Ui::CommandWidget *ui;
     bool m_showAdvanced = true;
     QString m_internalId;
-    bool m_isEditable = true;
 };
 
 #endif // COMMANDWIDGET_H


### PR DESCRIPTION
This is helpful so that the command itself can be copied.