### PR TITLE
macOS: Use macos-13-xlarge image for M1 build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -17,7 +17,7 @@ jobs:
             bundle_suffix: '-macos-10'
             cmake_preset: macOS-10
 
-          - os: macos-14
+          - os: macos-13-xlarge
             buildname: macOS 12 M1
             bundle_suffix: '-macos-12-m1'
             cmake_preset: macOS-12-m1


### PR DESCRIPTION
Fixes #2637