### PR TITLE
Linux: Fix storing selection with disabled automatic commands

### DIFF
--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -179,14 +179,20 @@ void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)
     }
 
     // omit running run automatic commands when disabled
-    if ( !m_runSelection && mode == ClipboardMode::Selection )
+    if ( !m_runSelection && mode == ClipboardMode::Selection ) {
+        if ( m_storeSelection && !m_clipboardTab.isEmpty() ) {
+            data.insert(mimeClipboardMode, QByteArrayLiteral("selection"));
+            setTextData(&data, m_clipboardTab, mimeOutputTab);
+            emit saveData(data);
+        }
         return;
+    }
 #endif
 
     if (mode != ClipboardMode::Clipboard) {
         const QString modeName = mode == ClipboardMode::Selection
-                ? "selection"
-                : "find buffer";
+                ? QStringLiteral("selection")
+                : QStringLiteral("find buffer");
         data.insert(mimeClipboardMode, modeName);
     }
 

--- a/src/app/clipboardmonitor.h
+++ b/src/app/clipboardmonitor.h
@@ -29,6 +29,7 @@ public:
 signals:
     void clipboardChanged(const QVariantMap &data, ClipboardOwnership ownership);
     void clipboardUnchanged(const QVariantMap &data);
+    void saveData(const QVariantMap &data);
     void synchronizeSelection(ClipboardMode sourceMode, uint sourceTextHash, uint targetTextHash);
     void fetchCurrentClipboardOwner(QString *title);
 

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -2608,6 +2608,11 @@ void Scriptable::monitorClipboard()
              this, &Scriptable::onSynchronizeSelection );
     connect( &monitor, &ClipboardMonitor::fetchCurrentClipboardOwner,
              this, &Scriptable::onFetchCurrentClipboardOwner );
+    connect( &monitor, &ClipboardMonitor::saveData,
+             m_proxy, [this](const QVariantMap &data) {
+                 m_data = data;
+                 eval("saveData()");
+             } );
 
     monitor.startMonitoring();
     setClipboardMonitorRunning(true);


### PR DESCRIPTION
Fixes storing selection when "Store text selected using mouse" option is enabled but "Run automatic commands on selection" is disabled.

Fixes #2651