### PR TITLE
Fix passing captured texts to automated commands

### DIFF
--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -1946,8 +1946,9 @@ QJSValue Scriptable::execute()
     connect( &action, &Action::actionOutput,
              this, &Scriptable::onExecuteOutput );
 
-    if ( !runAction(&action) || action.actionFailed() )
-        return QJSValue();
+    if ( !runAction(&action) || action.actionFailed() ) {
+        return throwError( QStringLiteral("Failed to run command") );
+    }
 
     if ( m_executeStdoutCallback.isCallable() ) {
         const auto arg = toScriptValue(m_executeStdoutLastLine, m_engine);

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -434,7 +434,7 @@ private:
     QJSValue eval(const QString &script);
     bool runAction(Action *action);
     bool runCommands(CommandType::CommandType type);
-    bool canExecuteCommand(const Command &command);
+    bool canExecuteCommand(const Command &command, QStringList *arguments);
     bool canExecuteCommandFilter(const QString &matchCommand);
     bool verifyClipboardAccess();
     void provideClipboard(ClipboardMode mode);

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -3845,7 +3845,7 @@ void Tests::automaticCommandRegExp()
 {
     const auto script = R"(
         setCommands([
-            { automatic: true, re: 'SHOULD BE CHANGED$', cmd: 'copyq: setData("text/plain", "CHANGED")' },
+            { automatic: true, re: 'SHOULD BE (CHANGED)$', cmd: 'copyq: setData(mimeText, arguments[1])' },
             { automatic: true, cmd: 'copyq: setData("DATA", "DONE")' },
         ])
         )";

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -199,6 +199,9 @@ bool testStderr(const QByteArray &stderrData, TestInterface::ReadStderrFlag flag
 
         // KNotification bug
         plain(R"(QtWarning: QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout)"),
+
+        // Warnings from itemsync plugin, not sure what it causes
+        regex(R"(QtWarning: Could not remove our own lock file .* maybe permissions changed meanwhile)"),
     };
     static QHash<QString, bool> ignoreLog;
 

--- a/src/ui/commandwidget.ui
+++ b/src/ui/commandwidget.ui
@@ -355,7 +355,7 @@
                   <property name="toolTip">
                    <string>Skips the command if the input text does not match this regular expression (leave empty to match everything).
 
-%2 through %9 in Command and Filter will be replaced with the captured texts.
+%2 through %9 (or argument[1] and up in script) in Command and Filter will be replaced with the captured texts.
 
 Examples:
 


### PR DESCRIPTION
Also, throw an error in execute() instead of returning invalid value.

Fixes #2707