### PR TITLE
Allow handling secret clipboard and other changes

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -2208,6 +2208,12 @@ These MIME types values are assigned to global variables prefixed with
 
        copyq copy application/x-copyq-hidden 1 plain/text "This is secret"
 
+.. js:data:: mimeSecret
+
+   If set to ``1``, the clipboard contains a password or other secret (for example, copied from clipboard manager).
+
+   In such case, the data won't be available in the app, not even via calling ``data()`` script function.
+
 .. js:data:: mimeShortcut
 
    Application or global shortcut which activated the command. Value: 'application/x-copyq-shortcut'.

--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -22,30 +22,15 @@ namespace {
 
 bool hasSameData(const QVariantMap &data, const QVariantMap &lastData)
 {
-    // Detect change also in case the data is unchanged but previously copied
-    // by CopyQ and now externally. This solves storing a copied text which was
-    // previously synchronized from selection to clipboard via CopyQ.
-    if (
-            !lastData.value(mimeOwner).toByteArray().isEmpty()
-            && data.value(mimeOwner).toByteArray().isEmpty()
-       )
-    {
-        return false;
-    }
-
     for (auto it = lastData.constBegin(); it != lastData.constEnd(); ++it) {
         const auto &format = it.key();
-        if ( !format.startsWith(COPYQ_MIME_PREFIX)
-             && !data.contains(format) )
-        {
+        if ( !data.contains(format) )
             return false;
-        }
     }
 
     for (auto it = data.constBegin(); it != data.constEnd(); ++it) {
         const auto &format = it.key();
-        if ( !format.startsWith(COPYQ_MIME_PREFIX)
-             && !data[format].toByteArray().isEmpty()
+        if ( !data[format].toByteArray().isEmpty()
              && data[format] != lastData.value(format) )
         {
             return false;
@@ -84,7 +69,7 @@ ClipboardMonitor::ClipboardMonitor(const QStringList &formats)
     m_ownerMonitor.setUpdateInterval(
         ownerUpdateInterval < 0 ? defaultOwnerUpdateInterval() : ownerUpdateInterval);
 
-    m_formats.append({mimeOwner, mimeWindowTitle, mimeItemNotes, mimeHidden});
+    m_formats.append({mimeOwner, mimeWindowTitle, mimeItemNotes, mimeHidden, mimeSecret});
     m_formats.removeDuplicates();
 
     connect( m_clipboard.get(), &PlatformClipboard::changed,

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -596,7 +596,7 @@ QString textLabelForData(const QVariantMap &data, const QFont &font, const QStri
 
     const QString notes = data.value(mimeItemNotes).toString();
 
-    if ( data.contains(mimeHidden) ) {
+    if ( data.contains(mimeHidden) || data.contains(mimeSecret) ) {
         label = QObject::tr("<HIDDEN>", "Label for hidden/secret clipboard content");
     } else if ( data.contains(mimeText) || data.contains(mimeUriList) ) {
         const QString text = getTextData(data);

--- a/src/common/mimetypes.cpp
+++ b/src/common/mimetypes.cpp
@@ -23,3 +23,4 @@ const QLatin1String mimeShortcut(COPYQ_MIME_PREFIX "shortcut");
 const QLatin1String mimeColor(COPYQ_MIME_PREFIX "color");
 const QLatin1String mimeOutputTab(COPYQ_MIME_PREFIX "output-tab");
 const QLatin1String mimeDisplayItemInMenu(COPYQ_MIME_PREFIX "display-item-in-menu");
+const QLatin1String mimeSecret(COPYQ_MIME_PREFIX "secret");

--- a/src/common/mimetypes.h
+++ b/src/common/mimetypes.h
@@ -26,3 +26,4 @@ extern const QLatin1String mimeShortcut;
 extern const QLatin1String mimeColor;
 extern const QLatin1String mimeOutputTab;
 extern const QLatin1String mimeDisplayItemInMenu;
+extern const QLatin1String mimeSecret;

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -117,7 +117,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("sha256sum", "sha256sum(data) -> `ByteArray`", "Returns SHA256 checksum of data.");
     addDocumentation("sha512sum", "sha512sum(data) -> `ByteArray`", "Returns SHA512 checksum of data.");
     addDocumentation("open", "open(url, ...) -> bool", "Tries to open URLs in appropriate applications.");
-    addDocumentation("execute", "execute(argument, ..., null, stdinData, ...) -> `FinishedCommand` or `undefined`", "Executes a command.");
+    addDocumentation("execute", "execute(argument, ..., null, stdinData, ...) -> `FinishedCommand`", "Executes a command.");
     addDocumentation("currentWindowTitle", "String currentWindowTitle() -> string", "Returns window title of currently focused window.");
     addDocumentation("currentClipboardOwner", "String currentClipboardOwner() -> string", "Returns name of the current clipboard owner.");
     addDocumentation("dialog", "dialog(...)", "Shows messages or asks user for input.");
@@ -204,6 +204,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("mimeSelectedItems", "mimeSelectedItems", "Selected items when invoking command from main window. Value: 'application/x-copyq-selected-items'.");
     addDocumentation("mimeCurrentItem", "mimeCurrentItem", "Current item when invoking command from main window. Value: 'application/x-copyq-current-item'.");
     addDocumentation("mimeHidden", "mimeHidden", "If set to `1`, the clipboard or item content will be hidden in GUI. Value: 'application/x-copyq-hidden'.");
+    addDocumentation("mimeSecret", "mimeSecret", "If set to `1`, the clipboard contains a password or other secret (for example, copied from clipboard manager).");
     addDocumentation("mimeShortcut", "mimeShortcut", "Application or global shortcut which activated the command. Value: 'application/x-copyq-shortcut'.");
     addDocumentation("mimeColor", "mimeColor", "Item color (same as the one used by themes). Value: 'application/x-copyq-color'.");
     addDocumentation("mimeOutputTab", "mimeOutputTab", "Name of the tab where to store new item. Value: 'application/x-copyq-output-tab'.");

--- a/src/platform/dummy/dummyclipboard.cpp
+++ b/src/platform/dummy/dummyclipboard.cpp
@@ -10,6 +10,17 @@
 #include <QMimeData>
 #include <QStringList>
 
+namespace {
+
+const QMimeData *createSecretData()
+{
+    auto data = new QMimeData();
+    data->setData(mimeSecret, QByteArrayLiteral("1"));
+    return data;
+}
+
+} // namespace
+
 QClipboard::Mode modeToQClipboardMode(ClipboardMode mode)
 {
     switch (mode) {
@@ -59,7 +70,8 @@ const QMimeData *DummyClipboard::mimeData(ClipboardMode mode) const
 
     if (isHidden(*data)) {
         log( QStringLiteral("Hiding secret %1 data").arg(modeText) );
-        return nullptr;
+        static const QMimeData *secretData = createSecretData();
+        return secretData;
     }
 
     COPYQ_LOG_VERBOSE( QStringLiteral("Got %1 data").arg(modeText) );

--- a/src/platform/x11/x11platformclipboard.cpp
+++ b/src/platform/x11/x11platformclipboard.cpp
@@ -269,11 +269,6 @@ void X11PlatformClipboard::updateClipboardData(X11PlatformClipboard::ClipboardDa
     }
     clipboardData->retry = 0;
 
-    // Ignore clipboard with secrets
-    const QByteArray passwordManagerHint = data->data(QStringLiteral("x-kde-passwordManagerHint"));
-    if ( passwordManagerHint == QByteArrayLiteral("secret") )
-        return;
-
     const QByteArray newDataTimestampData = data->data(QStringLiteral("TIMESTAMP"));
     quint32 newDataTimestamp = 0;
     if ( !newDataTimestampData.isEmpty() ) {

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -222,7 +222,8 @@ bool isInternalDataFormat(const QString &format)
         || format == mimeSelectedItems
         || format == mimeCurrentItem
         || format == mimeShortcut
-        || format == mimeOutputTab;
+        || format == mimeOutputTab
+        || format == mimeSecret;
 }
 
 QVariantMap copyWithoutInternalData(const QVariantMap &data) {

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -52,6 +52,7 @@ class Scriptable final : public QObject
     Q_PROPERTY(QJSValue mimeColor READ getMimeColor CONSTANT)
     Q_PROPERTY(QJSValue mimeOutputTab READ getMimeOutputTab CONSTANT)
     Q_PROPERTY(QJSValue mimeDisplayItemInMenu READ getMimeDisplayItemInMenu CONSTANT)
+    Q_PROPERTY(QJSValue mimeSecret READ getMimeSecret CONSTANT)
 
     Q_PROPERTY(QJSValue plugins READ getPlugins CONSTANT)
 
@@ -138,6 +139,7 @@ public:
     QJSValue getMimeColor() const { return mimeColor; }
     QJSValue getMimeOutputTab() const { return mimeOutputTab; }
     QJSValue getMimeDisplayItemInMenu() const { return mimeDisplayItemInMenu; }
+    QJSValue getMimeSecret() const { return mimeSecret; }
 
     QJSValue getPlugins();
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -306,6 +306,7 @@ private slots:
     void startServerAndRunCommand();
 
     void avoidStoringPasswords();
+    void scriptsForPasswords();
 
     void currentClipboardOwner();
 


### PR DESCRIPTION
Allows running scripts even if clipboard data was copied from a clipboard manager or an internal data format (`application/x-copyq-*`) changed.

Fixes #2746