### PR TITLE
Allow processing clipboard containing "secrets"

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1465,7 +1465,8 @@ unlike in GUI, where row numbers start from 1 by default.
 
 .. js:function:: onClipboardChanged()
 
-   Called when clipboard or `Linux mouse selection`_ changes.
+   Called when clipboard or `Linux mouse selection`_ changes and is not set by
+   CopyQ, is not marked as hidden nor secret (see the other callbacks).
 
    Default implementation is:
 
@@ -1482,7 +1483,8 @@ unlike in GUI, where row numbers start from 1 by default.
 
 .. js:function:: onOwnClipboardChanged()
 
-   Called when clipboard or `Linux mouse selection`_ changes by a CopyQ instance.
+   Called when clipboard or `Linux mouse selection`_ is set by CopyQ and is not
+   marked as hidden nor secret (see the other callbacks).
 
    Owned clipboard data contains :js:data:`mimeOwner` format.
 
@@ -1490,11 +1492,27 @@ unlike in GUI, where row numbers start from 1 by default.
 
 .. js:function:: onHiddenClipboardChanged()
 
-   Called when hidden clipboard or `Linux mouse selection`_ changes.
+   Called when clipboard or `Linux mouse selection`_ changes and is marked as
+   hidden but not secret (see the other callbacks).
 
    Hidden clipboard data contains :js:data:`mimeHidden` format set to ``1``.
 
    Default implementation calls :js:func:`updateClipboardData`.
+
+.. js:function:: onSecretClipboardChanged()
+
+   Called if the clipboard or `Linux mouse selection`_ changes and contains a
+   password or other secret (for example, copied from clipboard manager).
+
+   The default implementation clears all data, so they are not accessible using
+   :js:func:`data` and :js:func:`dataFormats`, except :js:data:`mimeSecret`,
+   and calls :js:func:`updateClipboardData`.
+
+   **Be careful overriding** this function (via a Script command). Calling
+   `onClipboardChanged()` without clearing the data and without any further
+   checks can cause storing and processing secrets from password managers. On
+   the other hand, it can help to get access to the data copied, for example
+   from a web browser in private mode.
 
 .. js:function:: onClipboardUnchanged()
 
@@ -2211,8 +2229,6 @@ These MIME types values are assigned to global variables prefixed with
 .. js:data:: mimeSecret
 
    If set to ``1``, the clipboard contains a password or other secret (for example, copied from clipboard manager).
-
-   In such case, the data won't be available in the app, not even via calling ``data()`` script function.
 
 .. js:data:: mimeShortcut
 

--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -45,6 +45,11 @@ bool isClipboardDataHidden(const QVariantMap &data)
     return data.value(mimeHidden).toByteArray() == "1";
 }
 
+bool isClipboardDataSecret(const QVariantMap &data)
+{
+    return data.value(mimeSecret).toByteArray() == "1";
+}
+
 int defaultOwnerUpdateInterval()
 {
 #ifdef COPYQ_WS_X11
@@ -79,7 +84,8 @@ ClipboardMonitor::ClipboardMonitor(const QStringList &formats)
     m_storeSelection = config.option<Config::check_selection>();
     m_runSelection = config.option<Config::run_selection>();
 
-    m_clipboardToSelection = config.option<Config::copy_clipboard>();
+    m_clipboardToSelection = config.option<Config::copy_clipboard>()
+        && m_clipboard->isSelectionSupported();
     m_selectionToClipboard = config.option<Config::copy_selection>();
 
     if (!m_storeSelection && !m_runSelection && !m_selectionToClipboard) {
@@ -122,18 +128,14 @@ void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)
     auto clipboardData = mode == ClipboardMode::Clipboard
             ? &m_clipboardData : &m_selectionData;
 
-    if ( hasSameData(data, *clipboardData) ) {
+    const bool isDataUnchanged = hasSameData(data, *clipboardData);
+    if (!isDataUnchanged) {
+        *clipboardData = data;
 #ifdef HAS_MOUSE_SELECTIONS
-        if ( !m_runSelection && mode == ClipboardMode::Selection )
-            return;
-#endif
-        COPYQ_LOG( QString("Ignoring unchanged %1")
-                   .arg(mode == ClipboardMode::Clipboard ? "clipboard" : "selection") );
-        emit clipboardUnchanged(data);
+    } else if (isDataUnchanged && !m_runSelection && mode == ClipboardMode::Selection) {
         return;
+#endif
     }
-
-    *clipboardData = data;
 
     if ( !data.contains(mimeOwner)
         && !data.contains(mimeWindowTitle)
@@ -142,13 +144,31 @@ void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)
             data.insert(mimeWindowTitle, m_clipboardOwner.toUtf8());
     }
 
-    COPYQ_LOG( QString("%1 changed, owner is \"%2\"")
-               .arg(mode == ClipboardMode::Clipboard ? "Clipboard" : "Selection",
+    COPYQ_LOG( QStringLiteral("%1 changed, owner is: %2")
+               .arg(QLatin1String(mode == ClipboardMode::Clipboard ? "Clipboard" : "Selection"),
                     getTextData(data, mimeOwner)) );
+
+    const auto defaultTab = m_clipboardTab.isEmpty() ? defaultClipboardTabName() : m_clipboardTab;
+    setTextData(&data, defaultTab, mimeCurrentTab);
+
+#ifdef HAS_MOUSE_SELECTIONS
+    if (mode == ClipboardMode::Selection)
+        data.insert(mimeClipboardMode, QByteArrayLiteral("selection"));
+
+    if (mode == ClipboardMode::Clipboard ? m_storeClipboard : m_storeSelection) {
+#else
+    if (m_storeClipboard) {
+#endif
+        setTextData(&data, m_clipboardTab, mimeOutputTab);
+    }
+
+    if (isDataUnchanged) {
+        emit clipboardUnchanged(data);
+        return;
+    }
 
 #ifdef HAS_MOUSE_SELECTIONS
     if ( (mode == ClipboardMode::Clipboard ? m_clipboardToSelection : m_selectionToClipboard)
-        && m_clipboard->isSelectionSupported()
         && !data.contains(mimeOwner) )
     {
         const auto text = getTextData(data);
@@ -165,40 +185,20 @@ void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)
 
     // omit running run automatic commands when disabled
     if ( !m_runSelection && mode == ClipboardMode::Selection ) {
-        if ( m_storeSelection && !m_clipboardTab.isEmpty() ) {
-            data.insert(mimeClipboardMode, QByteArrayLiteral("selection"));
-            setTextData(&data, m_clipboardTab, mimeOutputTab);
+        if ( m_storeSelection && !m_clipboardTab.isEmpty() && !isClipboardDataSecret(data) )
             emit saveData(data);
-        }
         return;
     }
 #endif
 
-    if (mode != ClipboardMode::Clipboard) {
-        const QString modeName = mode == ClipboardMode::Selection
-                ? QStringLiteral("selection")
-                : QStringLiteral("find buffer");
-        data.insert(mimeClipboardMode, modeName);
-    }
-
-    // run automatic commands
-    if ( anySessionOwnsClipboardData(data) ) {
-        emit clipboardChanged(data, ClipboardOwnership::Own);
+    // run script callbacks
+    if ( isClipboardDataSecret(data) ) {
+        emit secretClipboardChanged(data);
     } else if ( isClipboardDataHidden(data) ) {
-        emit clipboardChanged(data, ClipboardOwnership::Hidden);
+        emit hiddenClipboardChanged(data);
+    } else if ( anySessionOwnsClipboardData(data) ) {
+        emit ownClipboardChanged(data);
     } else {
-        const auto defaultTab = m_clipboardTab.isEmpty() ? defaultClipboardTabName() : m_clipboardTab;
-        setTextData(&data, defaultTab, mimeCurrentTab);
-
-
-#ifdef HAS_MOUSE_SELECTIONS
-        if (mode == ClipboardMode::Clipboard ? m_storeClipboard : m_storeSelection) {
-#else
-        if (m_storeClipboard) {
-#endif
-            setTextData(&data, m_clipboardTab, mimeOutputTab);
-        }
-
-        emit clipboardChanged(data, ClipboardOwnership::Foreign);
+        emit clipboardChanged(data);
     }
 }

--- a/src/app/clipboardmonitor.h
+++ b/src/app/clipboardmonitor.h
@@ -4,17 +4,11 @@
 #define CLIPBOARDMONITOR_H
 
 #include "app/clipboardownermonitor.h"
+#include "common/clipboardmode.h"
 #include "common/common.h"
 #include "platform/platformnativeinterface.h"
-#include "platform/platformclipboard.h"
 
 #include <QVariantMap>
-
-enum class ClipboardOwnership {
-    Foreign,
-    Own,
-    Hidden,
-};
 
 class ClipboardMonitor final : public QObject
 {
@@ -27,7 +21,10 @@ public:
     void setClipboardOwner(const QString &owner);
 
 signals:
-    void clipboardChanged(const QVariantMap &data, ClipboardOwnership ownership);
+    void clipboardChanged(const QVariantMap &data);
+    void secretClipboardChanged(const QVariantMap &data);
+    void hiddenClipboardChanged(const QVariantMap &data);
+    void ownClipboardChanged(const QVariantMap &data);
     void clipboardUnchanged(const QVariantMap &data);
     void saveData(const QVariantMap &data);
     void synchronizeSelection(ClipboardMode sourceMode, uint sourceTextHash, uint targetTextHash);

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -153,9 +153,10 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("iconTagColor", "iconTagColor() -> string", "Get current tray and window tag color name.");
     addDocumentation("iconTagColor", "iconTagColor(colorName)", "Set current tray and window tag color name.");
     addDocumentation("loadTheme", "loadTheme(path)", "Loads theme from an INI file.");
-    addDocumentation("onClipboardChanged", "onClipboardChanged()", "Called when clipboard or `Linux mouse selection`_ changes.");
-    addDocumentation("onOwnClipboardChanged", "onOwnClipboardChanged()", "Called when clipboard or `Linux mouse selection`_ changes by a CopyQ instance.");
-    addDocumentation("onHiddenClipboardChanged", "onHiddenClipboardChanged()", "Called when hidden clipboard or `Linux mouse selection`_ changes.");
+    addDocumentation("onClipboardChanged", "onClipboardChanged()", "Called when clipboard or `Linux mouse selection`_ changes and is not set by CopyQ, is not marked as hidden nor secret (see the other callbacks).");
+    addDocumentation("onOwnClipboardChanged", "onOwnClipboardChanged()", "Called when clipboard or `Linux mouse selection`_ is set by CopyQ and is not marked as hidden nor secret (see the other callbacks).");
+    addDocumentation("onHiddenClipboardChanged", "onHiddenClipboardChanged()", "Called when clipboard or `Linux mouse selection`_ changes and is marked as hidden but not secret (see the other callbacks).");
+    addDocumentation("onSecretClipboardChanged", "onSecretClipboardChanged()", "Called if the clipboard or `Linux mouse selection`_ changes and contains a password or other secret (for example, copied from clipboard manager).");
     addDocumentation("onClipboardUnchanged", "onClipboardUnchanged()", "Called when clipboard or `Linux mouse selection`_ changes but data remained the same.");
     addDocumentation("onStart", "onStart()", "Called when application starts.");
     addDocumentation("onExit", "onExit()", "Called just before application exists.");

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -361,6 +361,7 @@ public slots:
     void onOwnClipboardChanged();
     void onHiddenClipboardChanged();
     void onClipboardUnchanged();
+    void onSecretClipboardChanged();
 
     void onStart() {}
     void onExit() {}
@@ -405,7 +406,10 @@ signals:
     void receiveData();
 
 private:
-    void onMonitorClipboardChanged(const QVariantMap &data, ClipboardOwnership ownership);
+    void onMonitorClipboardChanged(const QVariantMap &data);
+    void onMonitorSecretClipboardChanged(const QVariantMap &data);
+    void onMonitorHiddenClipboardChanged(const QVariantMap &data);
+    void onMonitorOwnClipboardChanged(const QVariantMap &data);
     void onMonitorClipboardUnchanged(const QVariantMap &data);
     void onSynchronizeSelection(ClipboardMode sourceMode, uint sourceTextHash, uint targetTextHash);
     void onFetchCurrentClipboardOwner(QString *title);

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -4854,14 +4854,13 @@ void Tests::startServerAndRunCommand()
 void Tests::avoidStoringPasswords()
 {
     TEST( m_test->setClipboard(secretData("secret")) );
-    waitFor(2 * waitMsPasteClipboard);
-    RUN("clipboard" << "?", mimeSecret + "\n");
+    WAIT_ON_OUTPUT("clipboard", "secret");
     RUN("read" << "0" << "1" << "2", "\n\n");
     RUN("count", "0\n");
 
     RUN("keys" << clipboardBrowserId << keyNameFor(QKeySequence::Paste), "");
     waitFor(waitMsPasteClipboard);
-    RUN("read" << "0" << "1" << "2", "\n\n");
+    RUN("read" << "0" << "1" << "2", "secret\n\n");
     RUN("count", "1\n");
 }
 
@@ -4870,15 +4869,14 @@ void Tests::scriptsForPasswords()
     const auto script = R"(
         setCommands([{
             isScript: true,
-            cmd: `global.updateClipboardData = function() {
-                if (data(mimeSecret) == "1") add("SECRET");
+            cmd: `global.onSecretClipboardChanged = function() {
+                add("SECRET");
             }`
         }])
         )";
     RUN(script, "");
     WAIT_ON_OUTPUT("commands().length", "1\n");
     TEST( m_test->setClipboard(secretData("secret")) );
-    waitFor(2 * waitMsPasteClipboard);
     WAIT_ON_OUTPUT("read" << "0" << "1" << "2", "SECRET\n\n");
     RUN("count", "1\n");
 }


### PR DESCRIPTION
This allows processing the "secret" clipboard data by overriding new `onSecretClipboardChanged()` script function.

Fixes #2787