### PR TITLE
Update OS X build-from-source doc to using Qt6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 set(CMAKE_AUTOMOC ON)
 
-OPTION(WITH_QT6 "Enable Qt 6" OFF)
+OPTION(WITH_QT6 "Enable Qt 6" ON)
 if (WITH_QT6)
     set(QT_DEFAULT_MAJOR_VERSION 6)
     find_package(Qt6Widgets 6.1.0 REQUIRED)

--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -142,7 +142,7 @@ In older versions, create solution manually by running ``cmake -G "Visual Studio
 Building and Packaging for OS X
 -------------------------------
 
-On OS X, required Qt 5 libraries and utilities can be easily installed with `Homebrew <https://brew.sh/>`__.
+On OS X, required Qt 6 libraries and utilities can be easily installed with `Homebrew <https://brew.sh/>`__.
 
 ::
 
@@ -164,9 +164,19 @@ Build with the following commands:
 
 ::
 
-    cmake -DCMAKE_PREFIX_PATH="$(brew --prefix qt5)" .
+    cmake -DCMAKE_PREFIX_PATH="$(brew --prefix qt6)" .
     cmake --build .
     cpack
+
+To build with Qt 5 (make sure to install qt@5 yourself):
+
+::
+
+
+    cmake -DCMAKE_PREFIX_PATH="$(brew --prefix qt5)" -DWITH_QT6=OFF .
+    cmake --build .
+    cpack
+
 
 This will produce a self-contained application bundle ``CopyQ.app``
 which can then be copied or moved into ``/Applications``.


### PR DESCRIPTION
Reason for this PR:
* The current OS X build dependency specified in the `Homebrew` formulae defaults to `Qt6` instead of `Qt5`. Therefore, `Qt6` should be used as the default in `CMake` commands and docs.

What changed:

* In `CMakeLists.txt`, change `WITH_QT6` to `ON`.
* Update the OS X build-from-source docs accordingly.

Tests:

* Tested on macOS 14.5; the build succeeded without problem.

Behaviour before this change:

* Followed docs precisely, build failed at the `CMake` stage with error: “Could not find a package configuration file provided by Qt5Widgets.”