### PR TITLE
itemSync: Fix redundant UI updates

### DIFF
--- a/plugins/itemsync/filewatcher.cpp
+++ b/plugins/itemsync/filewatcher.cpp
@@ -80,6 +80,11 @@ public:
         return dataMap.value(m_format).toByteArray();
     }
 
+    bool operator==(const SyncDataFile &other) const {
+        return m_path == other.m_path
+            && m_format == other.m_format;
+    }
+
 private:
     QString m_path;
     QString m_format;

--- a/src/item/serialize.cpp
+++ b/src/item/serialize.cpp
@@ -51,6 +51,10 @@ public:
         return f.readAll();
     }
 
+    bool operator==(const DataFile &other) const {
+        return m_path == other.m_path;
+    }
+
 private:
     QString m_path;
 };


### PR DESCRIPTION
Missing comparison operator on custom private data caused triggering redundant updates because the app incorrectly assumed that the data always changed.

Fixes #2649