### PR TITLE
Add Emacs navigation key-bindings support

### DIFF
--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -684,7 +684,7 @@ void ClipboardServer::loadSettings(AppConfig *appConfig)
     m_sharedData->editor = appConfig->option<Config::editor>();
     m_sharedData->maxItems = appConfig->option<Config::maxitems>();
     m_sharedData->textWrap = appConfig->option<Config::text_wrap>();
-    m_sharedData->navigationStyle = appConfig->option<Config::vi>();
+    m_sharedData->navigationStyle = appConfig->option<Config::navigation_style>();
     m_sharedData->saveOnReturnKey = !appConfig->option<Config::edit_ctrl_return>();
     m_sharedData->moveItemOnReturnKey = appConfig->option<Config::move>();
     m_sharedData->showSimpleItems = appConfig->option<Config::show_simple_items>();

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -684,7 +684,7 @@ void ClipboardServer::loadSettings(AppConfig *appConfig)
     m_sharedData->editor = appConfig->option<Config::editor>();
     m_sharedData->maxItems = appConfig->option<Config::maxitems>();
     m_sharedData->textWrap = appConfig->option<Config::text_wrap>();
-    m_sharedData->viMode = appConfig->option<Config::vi>();
+    m_sharedData->navigationStyle = appConfig->option<Config::vi>();
     m_sharedData->saveOnReturnKey = !appConfig->option<Config::edit_ctrl_return>();
     m_sharedData->moveItemOnReturnKey = appConfig->option<Config::move>();
     m_sharedData->showSimpleItems = appConfig->option<Config::show_simple_items>();

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -3,6 +3,7 @@
 #ifndef APPCONFIG_H
 #define APPCONFIG_H
 
+#include "common/navigationstyle.h"
 #include "common/settings.h"
 
 class QString;
@@ -120,12 +121,8 @@ struct confirm_exit : Config<bool> {
     static Value defaultValue() { return true; }
 };
 
-struct vi : Config<bool> {
+struct vi : Config<NavigationStyle> {
     static QString name() { return QStringLiteral("vi"); }
-};
-
-struct emacs : Config<bool> {
-    static QString name() { return "emacs"; }
 };
 
 struct save_filter_history : Config<bool> {

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -121,8 +121,8 @@ struct confirm_exit : Config<bool> {
     static Value defaultValue() { return true; }
 };
 
-struct vi : Config<NavigationStyle> {
-    static QString name() { return QStringLiteral("vi"); }
+struct navigation_style : Config<NavigationStyle> {
+    static QString name() { return QStringLiteral("navigation_style"); }
 };
 
 struct save_filter_history : Config<bool> {

--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -124,6 +124,10 @@ struct vi : Config<bool> {
     static QString name() { return QStringLiteral("vi"); }
 };
 
+struct emacs : Config<bool> {
+    static QString name() { return "emacs"; }
+};
+
 struct save_filter_history : Config<bool> {
     static QString name() { return QStringLiteral("save_filter_history"); }
 };

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -726,6 +726,71 @@ bool handleViKey(QKeyEvent *event, QObject *eventReceiver)
     return true;
 }
 
+bool handleEmacsKey(QKeyEvent *event, QObject *eventReceiver)
+{
+    int key = event->key();
+    Qt::KeyboardModifiers mods = event->modifiers();
+
+    switch ( key ) {
+    case Qt::Key_V:
+        if (mods & Qt::ControlModifier) {
+            key = Qt::Key_PageDown;
+            mods = mods & ~Qt::ControlModifier;
+        } else if (mods & Qt::AltModifier) {
+            key = Qt::Key_PageUp;
+            mods = mods & ~Qt::AltModifier;
+        } else {
+        return false;
+    }
+    break;
+    case Qt::Key_N:
+        if (mods & Qt::ControlModifier) {
+            key = Qt::Key_Down;
+            mods = mods & ~Qt::ControlModifier;
+            break;
+        }
+        return false;
+    case Qt::Key_P:
+        if (mods & Qt::ControlModifier) {
+            key = Qt::Key_Up;
+            mods = mods & ~Qt::ControlModifier;
+            break;
+        }
+        return false;
+    case Qt::Key_Less:
+        if ((mods & Qt::AltModifier)) {
+            key = Qt::Key_Home;
+            mods = mods & ~(Qt::ShiftModifier | Qt::AltModifier);
+			break;
+        } else {
+            return false;
+        }
+    case Qt::Key_Greater:
+        if ((mods & Qt::AltModifier)) {
+            key = Qt::Key_End;
+            mods = mods & ~(Qt::ShiftModifier | Qt::AltModifier);
+			break;
+        } else {
+            return false;
+        }
+    case Qt::Key_G:
+        if (mods & Qt::ControlModifier) {
+            key = Qt::Key_Escape;
+            mods = mods & ~Qt::ControlModifier;
+            break;
+        }
+        return false;
+    default:
+        return false;
+    }
+
+    QKeyEvent event2(QEvent::KeyPress, key, mods, event->text());
+    QCoreApplication::sendEvent(eventReceiver, &event2);
+    event->accept();
+
+    return true;
+}
+
 bool canDropToTab(const QDropEvent &event)
 {
     const auto &data = *event.mimeData();

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -736,12 +736,14 @@ bool handleEmacsKey(QKeyEvent *event, QObject *eventReceiver)
         if (mods & Qt::ControlModifier) {
             key = Qt::Key_PageDown;
             mods = mods & ~Qt::ControlModifier;
-        } else if (mods & Qt::AltModifier) {
+            break;
+        }
+        if (mods & Qt::AltModifier) {
             key = Qt::Key_PageUp;
             mods = mods & ~Qt::AltModifier;
-        } else {
+            break;
+        }
         return false;
-    }
     break;
     case Qt::Key_N:
         if (mods & Qt::ControlModifier) {
@@ -761,18 +763,16 @@ bool handleEmacsKey(QKeyEvent *event, QObject *eventReceiver)
         if ((mods & Qt::AltModifier)) {
             key = Qt::Key_Home;
             mods = mods & ~(Qt::ShiftModifier | Qt::AltModifier);
-			break;
-        } else {
-            return false;
+            break;
         }
+        return false;
     case Qt::Key_Greater:
         if ((mods & Qt::AltModifier)) {
             key = Qt::Key_End;
             mods = mods & ~(Qt::ShiftModifier | Qt::AltModifier);
-			break;
-        } else {
-            return false;
+            break;
         }
+        return false;
     case Qt::Key_G:
         if (mods & Qt::ControlModifier) {
             key = Qt::Key_Escape;

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -79,6 +79,11 @@ bool isClipboardData(const QVariantMap &data);
 bool handleViKey(QKeyEvent *event, QObject *eventReceiver);
 
 /**
+ * Handle key for Emacs mode.
+ */
+bool handleEmacsKey(QKeyEvent *event, QObject *eventReceiver);
+
+/**
  * Return true only if tabs can accept the drag'n'drop event.
  */
 bool canDropToTab(const QDropEvent &event);

--- a/src/common/navigationstyle.h
+++ b/src/common/navigationstyle.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+enum class NavigationStyle {
+    Default,
+    Vi,
+    Emacs
+};

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1383,6 +1383,10 @@ void ClipboardBrowser::keyPressEvent(QKeyEvent *event)
         return;
     }
 
+    // translate keys for emacs mode
+    if (m_sharedData->emacsMode && handleEmacsKey(event, this))
+        return;
+
     const Qt::KeyboardModifiers mods = event->modifiers();
 
     if (mods == Qt::AltModifier)

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1378,13 +1378,13 @@ void ClipboardBrowser::keyPressEvent(QKeyEvent *event)
         return;
 
     // translate keys for vi mode
-    if (m_sharedData->viMode && handleViKey(event, this)) {
+    if (m_sharedData->navigationStyle == NavigationStyle::Vi && handleViKey(event, this)) {
         d.updateIfNeeded();
         return;
     }
 
     // translate keys for emacs mode
-    if (m_sharedData->emacsMode && handleEmacsKey(event, this))
+    if (m_sharedData->navigationStyle == NavigationStyle::Emacs && handleEmacsKey(event, this))
         return;
 
     const Qt::KeyboardModifiers mods = event->modifiers();

--- a/src/gui/clipboardbrowsershared.h
+++ b/src/gui/clipboardbrowsershared.h
@@ -2,6 +2,7 @@
 #ifndef CLIPBOARDBROWSERSHARED_H
 #define CLIPBOARDBROWSERSHARED_H
 
+#include "common/navigationstyle.h"
 #include "gui/menuitems.h"
 #include "gui/theme.h"
 
@@ -17,8 +18,7 @@ struct ClipboardBrowserShared {
     QString editor;
     int maxItems = 100;
     bool textWrap = true;
-    bool viMode = false;
-    bool emacsMode = false;
+    NavigationStyle navigationStyle = NavigationStyle::Default;
     bool saveOnReturnKey = false;
     bool moveItemOnReturnKey = false;
     bool showSimpleItems = false;

--- a/src/gui/clipboardbrowsershared.h
+++ b/src/gui/clipboardbrowsershared.h
@@ -18,6 +18,7 @@ struct ClipboardBrowserShared {
     int maxItems = 100;
     bool textWrap = true;
     bool viMode = false;
+    bool emacsMode = false;
     bool saveOnReturnKey = false;
     bool moveItemOnReturnKey = false;
     bool showSimpleItems = false;

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -258,6 +258,7 @@ void ConfigurationManager::initOptions()
     bind<Config::check_clipboard>(m_tabGeneral->checkBoxClip);
     bind<Config::confirm_exit>(m_tabGeneral->checkBoxConfirmExit);
     bind<Config::vi>(m_tabGeneral->checkBoxViMode);
+    bind<Config::emacs>(m_tabGeneral->checkBoxEmacsMode);
     bind<Config::save_filter_history>(m_tabGeneral->checkBoxSaveFilterHistory);
     bind<Config::autocompletion>(m_tabGeneral->checkBoxAutocompleteCommands);
     bind<Config::always_on_top>(m_tabGeneral->checkBoxAlwaysOnTop);

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -257,7 +257,7 @@ void ConfigurationManager::initOptions()
     bind<Config::move>(m_tabHistory->checkBoxMove);
     bind<Config::check_clipboard>(m_tabGeneral->checkBoxClip);
     bind<Config::confirm_exit>(m_tabGeneral->checkBoxConfirmExit);
-    bind<Config::vi>(m_tabGeneral->comboBoxNavigationStyle);
+    bind<Config::navigation_style>(m_tabGeneral->comboBoxNavigationStyle);
     bind<Config::save_filter_history>(m_tabGeneral->checkBoxSaveFilterHistory);
     bind<Config::autocompletion>(m_tabGeneral->checkBoxAutocompleteCommands);
     bind<Config::always_on_top>(m_tabGeneral->checkBoxAlwaysOnTop);

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -257,8 +257,7 @@ void ConfigurationManager::initOptions()
     bind<Config::move>(m_tabHistory->checkBoxMove);
     bind<Config::check_clipboard>(m_tabGeneral->checkBoxClip);
     bind<Config::confirm_exit>(m_tabGeneral->checkBoxConfirmExit);
-    bind<Config::vi>(m_tabGeneral->radioButtonViMode);
-    bind<Config::emacs>(m_tabGeneral->radioButtonEmacsMode);
+    bind<Config::vi>(m_tabGeneral->comboBoxNavigationStyle);
     bind<Config::save_filter_history>(m_tabGeneral->checkBoxSaveFilterHistory);
     bind<Config::autocompletion>(m_tabGeneral->checkBoxAutocompleteCommands);
     bind<Config::always_on_top>(m_tabGeneral->checkBoxAlwaysOnTop);
@@ -362,11 +361,6 @@ void ConfigurationManager::bind(const QString &optionKey, QCheckBox *obj, bool d
     m_options[optionKey] = Option(defaultValue, "checked", obj);
 }
 
-void ConfigurationManager::bind(const QString &optionKey, QRadioButton *obj, bool defaultValue)
-{
-    m_options[optionKey] = Option(defaultValue, "checked", obj);
-}
-
 void ConfigurationManager::bind(const QString &optionKey, QSpinBox *obj, int defaultValue)
 {
     m_options[optionKey] = Option(defaultValue, "value", obj);
@@ -380,6 +374,11 @@ void ConfigurationManager::bind(const QString &optionKey, QLineEdit *obj, const 
 void ConfigurationManager::bind(const QString &optionKey, QComboBox *obj, int defaultValue)
 {
     m_options[optionKey] = Option(defaultValue, "currentIndex", obj);
+}
+
+void ConfigurationManager::bind(const QString &optionKey, QComboBox *obj, NavigationStyle defaultValue)
+{
+    m_options[optionKey] = Option(static_cast<int>(defaultValue), "currentIndex", obj);
 }
 
 void ConfigurationManager::bind(const QString &optionKey, const QVariant &defaultValue, const char *description)

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -257,8 +257,8 @@ void ConfigurationManager::initOptions()
     bind<Config::move>(m_tabHistory->checkBoxMove);
     bind<Config::check_clipboard>(m_tabGeneral->checkBoxClip);
     bind<Config::confirm_exit>(m_tabGeneral->checkBoxConfirmExit);
-    bind<Config::vi>(m_tabGeneral->checkBoxViMode);
-    bind<Config::emacs>(m_tabGeneral->checkBoxEmacsMode);
+    bind<Config::vi>(m_tabGeneral->radioButtonViMode);
+    bind<Config::emacs>(m_tabGeneral->radioButtonEmacsMode);
     bind<Config::save_filter_history>(m_tabGeneral->checkBoxSaveFilterHistory);
     bind<Config::autocompletion>(m_tabGeneral->checkBoxAutocompleteCommands);
     bind<Config::always_on_top>(m_tabGeneral->checkBoxAlwaysOnTop);
@@ -358,6 +358,11 @@ void ConfigurationManager::bind()
 }
 
 void ConfigurationManager::bind(const QString &optionKey, QCheckBox *obj, bool defaultValue)
+{
+    m_options[optionKey] = Option(defaultValue, "checked", obj);
+}
+
+void ConfigurationManager::bind(const QString &optionKey, QRadioButton *obj, bool defaultValue)
 {
     m_options[optionKey] = Option(defaultValue, "checked", obj);
 }

--- a/src/gui/configurationmanager.h
+++ b/src/gui/configurationmanager.h
@@ -28,11 +28,11 @@ class Option;
 class ShortcutsWidget;
 class QAbstractButton;
 class QCheckBox;
-class QRadioButton;
 class QComboBox;
 class QLineEdit;
 class QListWidgetItem;
 class QSpinBox;
+enum class NavigationStyle;
 
 /**
  * Configuration dialog.
@@ -107,10 +107,10 @@ private:
     void bind();
 
     void bind(const QString &optionKey, QCheckBox *obj, bool defaultValue);
-    void bind(const QString &optionKey, QRadioButton *obj, bool defaultValue);
     void bind(const QString &optionKey, QSpinBox  *obj, int defaultValue);
     void bind(const QString &optionKey, QLineEdit *obj, const QString &defaultValue);
     void bind(const QString &optionKey, QComboBox *obj, int defaultValue);
+    void bind(const QString &optionKey, QComboBox *obj, NavigationStyle defaultValue);
     void bind(const QString &optionKey, const QVariant &defaultValue, const char *description);
 
     void updateTabComboBoxes();

--- a/src/gui/configurationmanager.h
+++ b/src/gui/configurationmanager.h
@@ -28,6 +28,7 @@ class Option;
 class ShortcutsWidget;
 class QAbstractButton;
 class QCheckBox;
+class QRadioButton;
 class QComboBox;
 class QLineEdit;
 class QListWidgetItem;
@@ -106,6 +107,7 @@ private:
     void bind();
 
     void bind(const QString &optionKey, QCheckBox *obj, bool defaultValue);
+    void bind(const QString &optionKey, QRadioButton *obj, bool defaultValue);
     void bind(const QString &optionKey, QSpinBox  *obj, int defaultValue);
     void bind(const QString &optionKey, QLineEdit *obj, const QString &defaultValue);
     void bind(const QString &optionKey, QComboBox *obj, int defaultValue);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1345,7 +1345,7 @@ void MainWindow::onSearchShowRequest(const QString &text)
 
     enterSearchMode();
 
-    if (!m_options.viMode || text != "/") {
+    if (m_options.navigationStyle != NavigationStyle::Vi || text != "/") {
         ui->searchBar->setText(text);
         ui->searchBar->end(false);
     }
@@ -2530,7 +2530,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
     if (m_options.hideTabs && key == Qt::Key_Alt)
         setHideTabs(false);
 
-    if (m_options.viMode) {
+    if (m_options.navigationStyle == NavigationStyle::Vi) {
         if (modifiers == Qt::ControlModifier && key == Qt::Key_BracketLeft) {
             onEscape();
             return;
@@ -2557,7 +2557,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         }
     }
 
-    if (m_options.emacsMode) {
+    if (m_options.navigationStyle == NavigationStyle::Emacs) {
         if ((modifiers == Qt::ControlModifier && key == Qt::Key_G)
             || (key == Qt::Key_Escape)) {
             onEscape();
@@ -2714,15 +2714,9 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
     setAlwaysOnTop(this, alwaysOnTop);
     setAlwaysOnTop(m_commandDialog.data(), alwaysOnTop);
 
-    // Vi mode
-    m_options.viMode = appConfig->option<Config::vi>();
-    m_trayMenu->setViModeEnabled(m_options.viMode);
-    m_menu->setViModeEnabled(m_options.viMode);
-
-    // Emacs mode
-    m_options.emacsMode = appConfig->option<Config::emacs>();
-    m_trayMenu->setEmacsModeEnabled(m_options.emacsMode);
-    m_menu->setEmacsModeEnabled(m_options.emacsMode);
+    m_options.navigationStyle = appConfig->option<Config::vi>();
+    m_trayMenu->setNavigationStyle(m_options.navigationStyle);
+    m_menu->setNavigationStyle(m_options.navigationStyle);
 
     // Number search
     m_trayMenu->setNumberSearchEnabled(m_sharedData->numberSearch);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2564,8 +2564,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
             return;
         }
 
-        if (browseMode()) {
-            if (c && handleEmacsKey(event, c))
+        if (browseMode() && c && handleEmacsKey(event, c)) {
                 return;
         }
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2714,7 +2714,7 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
     setAlwaysOnTop(this, alwaysOnTop);
     setAlwaysOnTop(m_commandDialog.data(), alwaysOnTop);
 
-    m_options.navigationStyle = appConfig->option<Config::vi>();
+    m_options.navigationStyle = appConfig->option<Config::navigation_style>();
     m_trayMenu->setNavigationStyle(m_options.navigationStyle);
     m_menu->setNavigationStyle(m_options.navigationStyle);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1054,7 +1054,7 @@ void MainWindow::setScriptOverrides(const QVector<int> &overrides, int actionId)
 
 bool MainWindow::isScriptOverridden(int id) const
 {
-    return 
+    return
         // Assume everything is overridden until collectOverrides() finishes
         (m_actionCollectOverrides && m_actionCollectOverrides->isRunning() && m_overrides.isEmpty())
         || std::binary_search(m_overrides.begin(), m_overrides.end(), id);
@@ -2557,6 +2557,19 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         }
     }
 
+    if (m_options.emacsMode) {
+        if ((modifiers == Qt::ControlModifier && key == Qt::Key_G)
+            || (key == Qt::Key_Escape)) {
+            onEscape();
+            return;
+        }
+
+        if (browseMode()) {
+            if (c && handleEmacsKey(event, c))
+                return;
+        }
+    }
+
     if ( event->matches(QKeySequence::NextChild) ) {
          nextTab();
          return;
@@ -2706,6 +2719,11 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
     m_options.viMode = appConfig->option<Config::vi>();
     m_trayMenu->setViModeEnabled(m_options.viMode);
     m_menu->setViModeEnabled(m_options.viMode);
+
+    // Emacs mode
+    m_options.emacsMode = appConfig->option<Config::emacs>();
+    m_trayMenu->setEmacsModeEnabled(m_options.emacsMode);
+    m_menu->setEmacsModeEnabled(m_options.emacsMode);
 
     // Number search
     m_trayMenu->setNumberSearchEnabled(m_sharedData->numberSearch);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -72,6 +72,7 @@ struct MainWindowOptions {
 
     bool confirmExit = true;
     bool viMode = false;
+    bool emacsMode = false;
     bool trayCommands = false;
     bool trayCurrentTab = false;
     QString trayTabName;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -5,6 +5,7 @@
 
 #include "common/clipboardmode.h"
 #include "common/command.h"
+#include "common/navigationstyle.h"
 #include "gui/clipboardbrowsershared.h"
 #include "gui/menuitems.h"
 #include "item/persistentdisplayitem.h"
@@ -34,7 +35,6 @@ class Theme;
 class TrayMenu;
 class ToolBar;
 class QModelIndex;
-struct MainWindowOptions;
 struct NotificationButton;
 
 Q_DECLARE_METATYPE(QPersistentModelIndex)
@@ -71,8 +71,7 @@ struct MainWindowOptions {
     bool activatePastes() const { return itemActivationCommands & ActivatePastes; }
 
     bool confirmExit = true;
-    bool viMode = false;
-    bool emacsMode = false;
+    NavigationStyle navigationStyle = NavigationStyle::Default;
     bool trayCommands = false;
     bool trayCurrentTab = false;
     QString trayTabName;

--- a/src/gui/traymenu.h
+++ b/src/gui/traymenu.h
@@ -39,6 +39,9 @@ public:
     /** Handle Vi shortcuts. */
     void setViModeEnabled(bool enabled);
 
+    /** Handle Emacs shortcuts. */
+    void setEmacsModeEnabled(bool enabled);
+
     /** Enable searching for numbers. */
     void setNumberSearchEnabled(bool enabled);
 
@@ -83,6 +86,7 @@ private:
 
     bool m_omitPaste;
     bool m_viMode;
+    bool m_emacsMode;
     bool m_numberSearch;
 
     QString m_searchText;

--- a/src/gui/traymenu.h
+++ b/src/gui/traymenu.h
@@ -3,6 +3,8 @@
 #ifndef TRAYMENU_H
 #define TRAYMENU_H
 
+#include "common/navigationstyle.h"
+
 #include <QMenu>
 #include <QPointer>
 #include <QTimer>
@@ -36,11 +38,7 @@ public:
     /** Clear clipboard item actions and curstom actions. */
     void clearAllActions();
 
-    /** Handle Vi shortcuts. */
-    void setViModeEnabled(bool enabled);
-
-    /** Handle Emacs shortcuts. */
-    void setEmacsModeEnabled(bool enabled);
+    void setNavigationStyle(NavigationStyle style);
 
     /** Enable searching for numbers. */
     void setNumberSearchEnabled(bool enabled);
@@ -85,9 +83,8 @@ private:
     int m_clipboardItemActionCount;
 
     bool m_omitPaste;
-    bool m_viMode;
-    bool m_emacsMode;
     bool m_numberSearch;
+    NavigationStyle m_navigationStyle = NavigationStyle::Default;
 
     QString m_searchText;
 

--- a/src/ui/configtabgeneral.ui
+++ b/src/ui/configtabgeneral.ui
@@ -156,7 +156,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label_nav_style">
           <property name="text">
            <string>Navigation style / Keymap:</string>
           </property>

--- a/src/ui/configtabgeneral.ui
+++ b/src/ui/configtabgeneral.ui
@@ -151,40 +151,56 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBoxKeymap">
-        <property name="title">
-         <string>Navigation style / Keymap</string>
+       <layout class="QHBoxLayout" name="horizontalLayoutNavigationStyle">
+        <property name="bottomMargin">
+         <number>0</number>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QRadioButton" name="radioButtonViMode">
-           <property name="toolTip">
-            <string>Support for Vi navigation keys (H, J, K, L and more), slash (/) key to search</string>
-           </property>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Navigation style / Keymap:</string>
+          </property>
+          <property name="buddy">
+           <cstring>comboBoxNavigationStyle</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBoxNavigationStyle">
+          <property name="toolTip">
+           <string>Support for Vi navigation (keys H, J, K, L, / and more) and Emacs navigation (Ctrl+N, P, V and more)</string>
+          </property>
+          <item>
            <property name="text">
-            <string>Vi style navigation</string>
+            <string>Default</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QRadioButton" name="radioButtonEmacsMode">
-           <property name="toolTip">
-            <string>Support for Emacs navigation keys (Ctrl+N, P, V ... ) etc</string>
-           </property>
+          </item>
+          <item>
            <property name="text">
-            <string>Emacs style navigation</string>
+            <string>Vi</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QRadioButton" name="radioButtonNone">
+          </item>
+          <item>
            <property name="text">
-            <string>Default navigation</string>
+            <string>Emacs</string>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacerNavigationStyle">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QCheckBox" name="checkBoxSaveFilterHistory">
@@ -310,7 +326,7 @@
   <tabstop>checkBoxOpenWindowsOnCurrentScreen</tabstop>
   <tabstop>checkBoxConfirmExit</tabstop>
   <tabstop>checkBoxAutostart</tabstop>
-  <tabstop>groupBoxKeymap</tabstop>
+  <tabstop>comboBoxNavigationStyle</tabstop>
   <tabstop>checkBoxSaveFilterHistory</tabstop>
   <tabstop>checkBoxAutocompleteCommands</tabstop>
   <tabstop>checkBoxClip</tabstop>

--- a/src/ui/configtabgeneral.ui
+++ b/src/ui/configtabgeneral.ui
@@ -161,6 +161,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="checkBoxEmacsMode">
+        <property name="toolTip">
+         <string>Support for Emacs navigation keys (Ctrl+N, P, V ... ), Ctrl+S key to search</string>
+        </property>
+        <property name="text">
+         <string>&amp;Emacs style navigation</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="checkBoxSaveFilterHistory">
         <property name="toolTip">
          <string>Save and restore history of item filters</string>
@@ -285,6 +295,7 @@
   <tabstop>checkBoxConfirmExit</tabstop>
   <tabstop>checkBoxAutostart</tabstop>
   <tabstop>checkBoxViMode</tabstop>
+  <tabstop>checkBoxEmacsMode</tabstop>
   <tabstop>checkBoxSaveFilterHistory</tabstop>
   <tabstop>checkBoxAutocompleteCommands</tabstop>
   <tabstop>checkBoxClip</tabstop>

--- a/src/ui/configtabgeneral.ui
+++ b/src/ui/configtabgeneral.ui
@@ -151,23 +151,39 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="checkBoxViMode">
-        <property name="toolTip">
-         <string>Support for Vi navigation keys (H, J, K, L and more), slash (/) key to search</string>
+       <widget class="QGroupBox" name="groupBoxKeymap">
+        <property name="title">
+         <string>Navigation style / Keymap</string>
         </property>
-        <property name="text">
-         <string>&amp;Vi style navigation</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="checkBoxEmacsMode">
-        <property name="toolTip">
-         <string>Support for Emacs navigation keys (Ctrl+N, P, V ... ), Ctrl+S key to search</string>
-        </property>
-        <property name="text">
-         <string>&amp;Emacs style navigation</string>
-        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QRadioButton" name="radioButtonViMode">
+           <property name="toolTip">
+            <string>Support for Vi navigation keys (H, J, K, L and more), slash (/) key to search</string>
+           </property>
+           <property name="text">
+            <string>Vi style navigation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radioButtonEmacsMode">
+           <property name="toolTip">
+            <string>Support for Emacs navigation keys (Ctrl+N, P, V ... ) etc</string>
+           </property>
+           <property name="text">
+            <string>Emacs style navigation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radioButtonNone">
+           <property name="text">
+            <string>Default navigation</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -294,8 +310,7 @@
   <tabstop>checkBoxOpenWindowsOnCurrentScreen</tabstop>
   <tabstop>checkBoxConfirmExit</tabstop>
   <tabstop>checkBoxAutostart</tabstop>
-  <tabstop>checkBoxViMode</tabstop>
-  <tabstop>checkBoxEmacsMode</tabstop>
+  <tabstop>groupBoxKeymap</tabstop>
   <tabstop>checkBoxSaveFilterHistory</tabstop>
   <tabstop>checkBoxAutocompleteCommands</tabstop>
   <tabstop>checkBoxClip</tabstop>


### PR DESCRIPTION
Rebase and address review-comments on a very old abandoned change (PR#1039) 
* add emacs-style navigation keymap support (similar to existing Vi keymap support)
* convert the checkboxes to a set of radio-buttons (one of the open review comments)