### PR TITLE
Use more specific CMake build directory by default

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,6 +18,7 @@ jobs:
             compiler_package: g++
             with_qt6: false
             with_native_notifications: true
+            cmake_preset: Debug
 
           - os: ubuntu-20.04
             buildname: Linux-Clang
@@ -25,6 +26,7 @@ jobs:
             compiler_package: clang
             with_qt6: false
             with_native_notifications: true
+            cmake_preset: Debug
 
           - os: ubuntu-latest
             buildname: Qt 6
@@ -33,6 +35,7 @@ jobs:
             with_qt6: true
             with_native_notifications: false
             coverage: true
+            cmake_preset: Debug
             compiler_flags: >-
               --coverage
               -fprofile-arcs
@@ -70,8 +73,8 @@ jobs:
       - name: Build with CMake
         uses: lukka/run-cmake@v10
         with:
-          configurePreset: Debug
-          buildPreset: Debug
+          configurePreset: '${{ matrix.cmake_preset }}'
+          buildPreset: '${{ matrix.cmake_preset }}'
           configurePresetAdditionalArgs: >-
             [
             '-DCMAKE_CXX_COMPILER=${{matrix.compiler}}',
@@ -85,7 +88,7 @@ jobs:
         run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
 
       - name: Run tests
-        working-directory: '${{runner.workspace}}/install/bin'
+        working-directory: '${{runner.workspace}}/install/copyq/${{ matrix.cmake_preset }}/bin'
         run: '${{github.workspace}}/utils/github/test-linux.sh'
 
       - name: Update coverage
@@ -94,4 +97,4 @@ jobs:
           COVERALLS_REPO_TOKEN: '${{secrets.COVERALLS_REPO_TOKEN}}'
         run: >-
           '${{github.workspace}}/utils/github/coverage-linux.sh'
-          '${{runner.workspace}}/build'
+          '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-12
+          - os: macos-13
             buildname: macOS 10.15
             bundle_suffix: '-macos-10'
             cmake_preset: macOS-10
@@ -56,11 +56,11 @@ jobs:
         run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
 
       - name: Create macOS bundle
-        working-directory: '${{runner.workspace}}/build'
+        working-directory: '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}'
         run: '${{github.workspace}}/utils/github/bundle-macos.sh'
 
       - name: Upload macOS bundle
         uses: actions/upload-artifact@v4
         with:
           name: 'CopyQ${{ matrix.bundle_suffix }}.dmg'
-          path: '${{runner.workspace}}/build/CopyQ.dmg'
+          path: '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/CopyQ.dmg'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,8 +4,8 @@
         {
             "name": "Debug",
             "generator": "Ninja",
-            "binaryDir": "${sourceParentDir}/build",
-            "installDir": "${sourceParentDir}/install",
+            "binaryDir": "${sourceParentDir}/build/copyq/${presetName}",
+            "installDir": "${sourceParentDir}/install/copyq/${presetName}",
             "cacheVariables": {
                 "WITH_TESTS": "TRUE",
                 "PEDANTIC": "TRUE",
@@ -16,8 +16,8 @@
         {
             "name": "macOS-10",
             "generator": "Ninja",
-            "binaryDir": "${sourceParentDir}/build",
-            "installDir": "${sourceParentDir}/build",
+            "binaryDir": "${sourceParentDir}/build/copyq/${presetName}",
+            "installDir": "${sourceParentDir}/build/copyq/${presetName}",
             "cacheVariables": {
                 "WITH_QT6": "TRUE",
                 "WITH_TESTS": "TRUE",
@@ -31,8 +31,8 @@
         {
             "name": "macOS-12-m1",
             "generator": "Ninja",
-            "binaryDir": "${sourceParentDir}/build",
-            "installDir": "${sourceParentDir}/build",
+            "binaryDir": "${sourceParentDir}/build/copyq/${presetName}",
+            "installDir": "${sourceParentDir}/build/copyq/${presetName}",
             "cacheVariables": {
                 "WITH_QT6": "TRUE",
                 "WITH_TESTS": "TRUE",


### PR DESCRIPTION
Also bumps CI runner to "macos-13" because qt homebrew pre-built package for "macos-12" is no longer available, and the build takes too long.