### PR TITLE
Fix syntax colors for numbers with separators and / operator

### DIFF
--- a/src/common/navigationstyle.h
+++ b/src/common/navigationstyle.h
@@ -1,8 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#   include <QMetaType>
+#endif
+
 enum class NavigationStyle {
     Default,
     Vi,
     Emacs
 };
+
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+Q_DECLARE_METATYPE(NavigationStyle)
+#endif

--- a/src/gui/commandsyntaxhighlighter.cpp
+++ b/src/gui/commandsyntaxhighlighter.cpp
@@ -76,7 +76,7 @@ public:
         , m_reFunctions(createRegExp(scriptableFunctions()))
         , m_reKeywords(createRegExp(scriptableKeywords()))
         , m_reLabels(commandLabelRegExp())
-        , m_reConstants("\\b0x[0-9A-Fa-f]+|(?:\\b|%)\\d+|\\btrue\\b|\\bfalse\\b")
+        , m_reConstants(R"(\b0x[0-9A-Fa-f](?:_?[0-9A-Fa-f])*|(?:\b|%)\d(?:_?\d)*|\btrue\b|\bfalse\b)")
     {
     }
 
@@ -198,8 +198,14 @@ private:
                     if (i == -1)
                         i = text.size();
 
+                    --i;
                     format(a, i);
 
+                    setCurrentBlockState(Code);
+                } else if (c == '\n' || i + 1 == text.size()) {
+                    // The '/' was not regex start, since there is no ending
+                    // '/' on the same line.
+                    i = a;
                     setCurrentBlockState(Code);
                 }
             } else if (c == '\\') {


### PR DESCRIPTION
Correctly highlights JS formatted numbers with separators, for example:
`100_000`, `0x1234_abcd`

Avoids highlighting multiple lines as regular expression when `/` is
encountered. The syntax matching is still very trivial but should fix
many problems.