### PR TITLE
Wayland: Fix copying inside the app

### DIFF
--- a/src/platform/x11/x11platformclipboard.h
+++ b/src/platform/x11/x11platformclipboard.h
@@ -21,7 +21,6 @@ public:
     QVariantMap data(ClipboardMode mode, const QStringList &formats) const override;
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
-    void setRawData(ClipboardMode mode, QMimeData *mimeData) override;
 
     bool isSelectionSupported() const override { return m_selectionSupported; }
 


### PR DESCRIPTION
Fixes deadlock when copy/pasting in CopyQ (for example: item to editor or search bar).

This relies on clipboard implementation in Qt.