### PR TITLE
Introducing CopyQ Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![macOS Build Status](https://github.com/hluk/CopyQ/workflows/macOS%20Build/badge.svg?branch=master&event=push)](https://github.com/hluk/CopyQ/actions?query=branch%3Amaster+event%3Apush+workflow%3A%22macOS+Build%22)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/hluk/copyq?branch=master&svg=true)](https://ci.appveyor.com/project/hluk/copyq)
 [![Coverage Status](https://coveralls.io/repos/hluk/CopyQ/badge.svg?branch=master)](https://coveralls.io/r/hluk/CopyQ?branch=master)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20CopyQ%20Guru-006BFF)](https://gurubase.io/g/copyq)
 
 CopyQ is an advanced clipboard manager with powerful editing and scripting features.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CopyQ Guru](https://gurubase.io/g/copyq) to Gurubase. CopyQ Guru uses the data from this repo and data from the [docs](https://copyq.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "CopyQ Guru", which highlights that CopyQ now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CopyQ Guru in Gurubase, just let me know that's totally fine.
