### PR TITLE
Update GitHub runner image

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             buildname: Linux-GCC
             compiler: g++
             compiler_package: g++
@@ -20,7 +20,7 @@ jobs:
             with_native_notifications: true
             cmake_preset: Debug
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             buildname: Linux-Clang
             compiler: clang++
             compiler_package: clang

--- a/utils/github/install-linux.sh
+++ b/utils/github/install-linux.sh
@@ -25,8 +25,8 @@ if [[ $WITH_QT6 == true ]]; then
     )
 else
     qt_packages=(
-        qt5-default
-
+        qtbase5-dev
+        qtbase5-dev-tools
         qtbase5-private-dev
         qtdeclarative5-dev
         qttools5-dev


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be unsupported by April 1.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/