### PR TITLE
Wayland: Use XWayland on GNOME if available

### DIFF
--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -254,6 +254,15 @@ QGuiApplication *X11Platform::createMonitorApplication(int &argc, char **argv)
 
 QGuiApplication *X11Platform::createClipboardProviderApplication(int &argc, char **argv)
 {
+    // WORKAROUND: On GNOME Wayland session, run clipboard monitor/provider
+    // processes in XWayland mode, because GNOME does not support the
+    // wlr-data-control protocol required for clipboard access.
+    if ( !qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")
+         && qgetenv("XAUTHORITY").contains("mutter-Xwayland") )
+    {
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+
     return new ApplicationExceptionHandler<QGuiApplication>(argc, argv);
 }
 


### PR DESCRIPTION
On GNOME Wayland session, this forces to run clipboard monitor/provider processes in XWayland mode, because GNOME does not support the wlr-data-control protocol required for clipboard access.

This behaviour can be skipped by settings QT_QPA_PLATFORM environment variable to "wayland" (or other value).