### PR TITLE
Drop unsupported Debian 10 and Ubuntu 20.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
-image: ubuntu:20.04
+image: ubuntu:24.04
 
 variables:
   BUILD_DIR: "build"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ xattr -d com.apple.quarantine /Applications/CopyQ.app
 codesign --force --deep --sign - /Applications/CopyQ.app
 ```
 
-### Debian 10+, Ubuntu 18.04+, and their derivatives
+### Debian 11+, Ubuntu 22.04+, and their derivatives
 
 Install `copyq` and `copyq-plugins` packages.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ Bump the version:
 
 Verify and push the changes:
 
-    for r in origin gitlab bitbucket; do git push --follow-tags $r master || break; done
+    for r in origin gitlab; do git push --follow-tags $r master || break; done
 
 # Launchpad: Build Ubuntu Packages
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ following commands (for details, see `issue #2652
     xattr -d com.apple.quarantine /Applications/CopyQ.app
     codesign --force --deep --sign - /Applications/CopyQ.app
 
-On Debian unstable, **Debian 10+**, **Ubuntu 18.04+** and later derivatives can
+On Debian unstable, **Debian 11+**, **Ubuntu 22.04+** and later derivatives can
 install stable version from official repositories:
 
 .. code-block:: bash

--- a/docs/source-code-overview.rst
+++ b/docs/source-code-overview.rst
@@ -196,7 +196,7 @@ CI servers.
     -  Builds and runs tests for Linux binaries.
 
 -  `GitLab CI <https://gitlab.com/CopyQ/CopyQ/builds>`__
-    -  Builds and runs tests for Ubuntu 16.04 binaries.
+    -  Builds and runs tests for Ubuntu 22.04 binaries.
     -  Screenshots are taken while GUI tests are running. These are
        available if a test fails.
 

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -1073,7 +1073,7 @@ void ScriptableProxy::exit()
 void ScriptableProxy::close()
 {
     INVOKE2(close, ());
-    m_wnd->close();
+    m_wnd->hideWindow();
 }
 
 bool ScriptableProxy::focusPrevious()

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -430,6 +430,8 @@ public:
             settings.beginGroup("Options");
             settings.setValue( Config::clipboard_tab::name(), clipboardTabName );
             settings.setValue( Config::close_on_unfocus::name(), false );
+            // Hide the main window even if there is no tray or minimize support.
+            settings.setValue( Config::hide_main_window::name(), true );
             // Exercise limiting rows in Process Manager dialog when testing.
             settings.setValue( Config::max_process_manager_rows::name(), 4 );
             settings.endGroup();

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -48,8 +48,7 @@ private slots:
 
     void commandVisible();
     void commandToggle();
-    void commandHide();
-    void commandShow();
+    void commandShowHide();
     void commandShowAt();
     void commandFocused();
 

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -137,14 +137,7 @@ void Tests::commandToggle()
     WAIT_ON_OUTPUT("visible", "true\n");
 }
 
-void Tests::commandHide()
-{
-    RUN("visible", "true\n");
-    RUN("hide", "");
-    WAIT_ON_OUTPUT("visible", "false\n");
-}
-
-void Tests::commandShow()
+void Tests::commandShowHide()
 {
     RUN("visible", "true\n");
     RUN("hide", "");

--- a/utils/debian/create_source_packages.sh
+++ b/utils/debian/create_source_packages.sh
@@ -2,7 +2,6 @@
 set -e
 
 distros=(
-    focal
     jammy
     noble
     oracular

--- a/utils/download_obs_packages.sh
+++ b/utils/download_obs_packages.sh
@@ -38,7 +38,6 @@ fi
 
 fetch_package "${pkg}_openSUSE_Tumbleweed${xrpm}" "$url/openSUSE_Tumbleweed/${pkg_rpm}"
 fetch_package "${pkg}_openSUSE_Leap_15.4${xrpm}"  "$url/15.4/x86_64/${project}-${version}-lp154.${rpm_version}${xrpm}"
-fetch_package "${pkg}_Debian_10${xdeb}"           "$url/Debian_10/${pkg_deb}"
 fetch_package "${pkg}_Debian_11${xdeb}"           "$url/Debian_11/${pkg_deb}"
 fetch_package "${pkg}_Debian_12${xdeb}"           "$url/Debian_12/${pkg_deb}"
 fetch_package "${pkg}_Raspbian_12${xdeb_armhf}"   "$url/Raspbian_12/${pkg_deb_armhf}"

--- a/utils/gitlab/test_gui-script.sh
+++ b/utils/gitlab/test_gui-script.sh
@@ -39,7 +39,7 @@ chmod 0700 "$XDG_RUNTIME_DIR"
 # Disable encryption tests because exporting GPG key asks for password.
 export COPYQ_TESTS_SKIP_ITEMENCRYPT=1
 
-export COPYQ_TESTS_RERUN_FAILED=0
+export COPYQ_TESTS_RERUN_FAILED=1
 export COPYQ_TESTS_NO_NETWORK=1
 "$INSTALL_PREFIX/bin/copyq" tests
 


### PR DESCRIPTION
These fail to build due to missing wayland protocol (wayland.xml).

---

Also makes hide() work same as toggle(). This also fixes unreliable tests.