### PR TITLE
Add a hidden option to toggle window frame

### DIFF
--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -525,6 +525,14 @@ struct native_notifications : Config<bool> {
     static Value defaultValue() { return true; }
 };
 
+struct frameless_window : Config<bool> {
+    static QString name() { return QStringLiteral("frameless_window"); }
+    static Value defaultValue() { return false; }
+    static const char *description() {
+        return "Hide the main window frame and title if supported by the window manager";
+    }
+};
+
 } // namespace Config
 
 class AppConfig final

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -342,6 +342,8 @@ void ConfigurationManager::initOptions()
     bind<Config::restore_geometry>();
 
     bind<Config::close_on_unfocus_delay_ms>();
+
+    bind<Config::frameless_window>();
 }
 
 template <typename Config, typename Widget>


### PR DESCRIPTION
New `frameless_window` option enables the main window frame and title bar (if supported by the window manager):

    copyq toggleConfig frameless_window

Fixes #2570