### PR TITLE
Added Irish translation

### DIFF
--- a/translations/copyq_ga.ts
+++ b/translations/copyq_ga.ts
@@ -1,0 +1,2877 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ga">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../src/ui/aboutdialog.ui" line="14"/>
+        <source>About</source>
+        <translation>Maidir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="84"/>
+        <source>Clipboard Manager</source>
+        <translation>Bainisteoir Gearrthaisce</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="91"/>
+        <source>Author</source>
+        <translation>Údar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="92"/>
+        <source>E-mail</source>
+        <translation>Ríomhphost</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="93"/>
+        <source>Web</source>
+        <translation>Gréasán</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="94"/>
+        <source>Donate</source>
+        <translation>Tabhair síntiús</translation>
+    </message>
+</context>
+<context>
+    <name>ActionDialog</name>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="14"/>
+        <source>Action Dialog</source>
+        <translation>Dialóg Gníomhaíochta</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="33"/>
+        <source>Co&amp;mmand:</source>
+        <translation>O&amp;rdú:</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="58"/>
+        <source>Standard &amp;input:</source>
+        <translation>Ionchur ca&amp;ighdeánach:</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="68"/>
+        <source>Store standard o&amp;utput:</source>
+        <translation>Stóráil asch&amp;ur caighdeánach:</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="78"/>
+        <source>Send data of given media type to standard input of command (leave empty to turn off)</source>
+        <translation>Seol sonraí de chineál áirithe meán chuig ionchur caighdeánach ordaithe (fág folamh le múchadh)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="85"/>
+        <source>Create items from standard output of the program (leave empty to turn off)</source>
+        <translation>Cruthaigh míreanna ó aschur caighdeánach an chláir (fág folamh le múchadh)</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="102"/>
+        <source>&amp;Separator for new items:</source>
+        <translation>&amp;Deighilteoir le haghaidh míreanna nua:</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actiondialog.ui" line="112"/>
+        <source>&lt;p&gt;Regular expression for splitting output into multiple items.&lt;\p&gt;
+&lt;p&gt;Use &lt;b&gt;\n&lt;/b&gt; to store each line to separate item.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Slonn rialta chun aschur a roinnt ina mhíreanna iolracha. &lt;\p&gt;
+&lt;p&gt;Bain úsáid &lt;b&gt;as\n&lt;/b&gt; chun gach líne a stóráil chun mír a scaradh.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Save items in tab with given name (leave empty to save in the current tab)</source>
+        <translation>Sábháil míreanna sa chluaisín leis an ainm tugtha (fág folamh le sábháil sa chluaisín reatha)</translation>
+    </message>
+    <message>
+        <source>\n</source>
+        <translation>\n</translation>
+    </message>
+    <message>
+        <source>Output &amp;tab:</source>
+        <translation>Cluaisín &amp;Aschuir:</translation>
+    </message>
+</context>
+<context>
+    <name>ActionHandler</name>
+    <message>
+        <location filename="../src/gui/actionhandler.cpp" line="118"/>
+        <source>Exit code: %1</source>
+        <translation>Cód scoir: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/actionhandler.cpp" line="128"/>
+        <source>Command %1</source>
+        <translation>Ordú %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/actionhandler.cpp" line="158"/>
+        <source>Error: %1</source>
+        <translation>Earráid: %1</translation>
+    </message>
+</context>
+<context>
+    <name>ActionHandlerDialog</name>
+    <message>
+        <location filename="../src/ui/actionhandlerdialog.ui" line="14"/>
+        <source>Process Manager</source>
+        <translation>Bainisteoir Próisis</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actionhandlerdialog.ui" line="22"/>
+        <source>Filter</source>
+        <translation>Scagaire</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/actionhandlerdialog.ui" line="32"/>
+        <source>&amp;Terminate Selected</source>
+        <translation>&amp;Foirceannadh Roghnaithe</translation>
+    </message>
+</context>
+<context>
+    <name>AddCommandDialog</name>
+    <message>
+        <location filename="../src/ui/addcommanddialog.ui" line="14"/>
+        <source>Add Commands</source>
+        <translation>Cuir Orduithe leis</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="63"/>
+        <source>Show/hide main window</source>
+        <translation>Taispeáin/folaigh an phríomhfhuinneog</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="64"/>
+        <source>Show the tray menu</source>
+        <translation>Taispeáin roghchlár an tráidire</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="65"/>
+        <source>Show main window under mouse cursor</source>
+        <translation>Taispeáin an phríomhfhuinneog faoi chúrsóir na luiche</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="66"/>
+        <source>Edit clipboard</source>
+        <translation>Cuir gearrthaisce in eagar</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="67"/>
+        <source>Edit first item</source>
+        <translation>Cuir an chéad mhír in eagar</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="68"/>
+        <source>Copy second item</source>
+        <translation>Cóipeáil an dara mír</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="69"/>
+        <source>Show action dialog</source>
+        <translation>Taispeáin dialóg gníomhaíochta</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="70"/>
+        <source>Create new item</source>
+        <translation>Cruthaigh mír nua</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="71"/>
+        <source>Copy next item</source>
+        <translation>Cóipeáil an chéad mhír eile</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="72"/>
+        <source>Copy previous item</source>
+        <translation>Cóipeáil an mhír roimhe seo</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="73"/>
+        <source>Paste clipboard as plain text</source>
+        <translation>Greamaigh an gearrthaisce mar ghnáth-théacs</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="74"/>
+        <source>Disable clipboard storing</source>
+        <translation>Díchumasaigh stóráil ghearrthaisce</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="75"/>
+        <source>Enable clipboard storing</source>
+        <translation>Cumasaigh stóráil ghearrthaisce</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="76"/>
+        <source>Paste and copy next</source>
+        <translation>Greamaigh agus cóipeáil an chéad cheann eile</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="77"/>
+        <source>Paste and copy previous</source>
+        <translation>Greamaigh agus cóipeáil roimhe seo</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="78"/>
+        <source>Take screenshot</source>
+        <translation>Tóg pictiúr</translation>
+    </message>
+    <message>
+        <location filename="../src/common/globalshortcutcommands.cpp" line="79"/>
+        <source>Paste current date and time</source>
+        <translation>Greamaigh an dáta agus an t-am reatha</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="40"/>
+        <source>New command</source>
+        <translation>Ordú nua</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="47"/>
+        <source>Ignore items with no or single character</source>
+        <translation>Déan neamhaird de mhíreanna gan carachtar nó carachtar amháin</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="84"/>
+        <source>Open in &amp;Browser</source>
+        <translation>Oscail sa &amp;Bhrabhsálaí</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="92"/>
+        <source>Paste as Plain Text</source>
+        <translation>Greamaigh mar Ghnáth-Théacs</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="100"/>
+        <source>Autoplay videos</source>
+        <translation>Físeáin a sheinm go huathoibríoch</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="109"/>
+        <source>Copy URL (web address) to other tab</source>
+        <translation>Cóipeáil URL (seoladh gréasáin) go cluaisín eile</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="116"/>
+        <source>Create thumbnail (needs ImageMagick)</source>
+        <translation>Cruthaigh mionsamhail (teastaíonn ImageMagic uaidh)</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="124"/>
+        <source>Create QR Code from URL (needs qrencode)</source>
+        <translation>Cruthaigh Cód QR ó URL (teastaíonn qrencode uaidh)</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="151"/>
+        <source>Ignore copied files</source>
+        <translation>Déan neamhaird de chomhaid chóipeáilte</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="160"/>
+        <source>Ignore *&quot;Password&quot;* window</source>
+        <translation>Déan neamhaird d&apos;fhuinneog *&quot;Pasfhocal&quot;*</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="161"/>
+        <source>Password</source>
+        <translation>Pasfhocal</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="169"/>
+        <source>Move to Trash</source>
+        <translation>Bog go dtí an Bruscar</translation>
+    </message>
+    <message>
+        <location filename="../src/common/predefinedcommands.cpp" line="172"/>
+        <source>(trash)</source>
+        <translation>(bruscar)</translation>
+    </message>
+    <message>
+        <source>Clear Current Tab</source>
+        <translation>Glan an Cluaisín Reatha</translation>
+    </message>
+    <message>
+        <source>Tasks</source>
+        <translation>Tascanna</translation>
+    </message>
+    <message>
+        <source>Add to %1 tab</source>
+        <translation>Cuir le cluaisín %1</translation>
+    </message>
+    <message>
+        <source>Move to %1 tab</source>
+        <translation>Bog go dtí cluaisín %1</translation>
+    </message>
+</context>
+<context>
+    <name>ClipboardBrowser</name>
+    <message>
+        <source>Cannot add new items to tab %1. Please remove items manually to make space.</source>
+        <translation>Ní féidir míreanna nua a chur leis an gcluaisín %1. Bain míreanna de láimh le do thoil chun spás a dhéanamh.</translation>
+    </message>
+    <message>
+        <source>Discard Changes?</source>
+        <translation>Cuir athruithe i leataobh?</translation>
+    </message>
+    <message>
+        <source>Do you really want to &lt;strong&gt;discard changes&lt;/strong&gt;?</source>
+        <translation>An bhfuil fonn ort &lt;strong&gt;athruithe a chaitheamh i leataobh&lt;/strong&gt; i ndáiríre?</translation>
+    </message>
+</context>
+<context>
+    <name>ClipboardClient</name>
+    <message>
+        <source>Connection lost!</source>
+        <translation>Ceangal caillte!</translation>
+    </message>
+    <message>
+        <source>Cannot connect to server! Start CopyQ server first.</source>
+        <translation>Ní féidir ceangal leis an bhfreastalaí! Tosaigh freastalaí CopyQ ar dtús.</translation>
+    </message>
+</context>
+<context>
+    <name>ClipboardDialog</name>
+    <message>
+        <source>Clipboard Content</source>
+        <translation>Ábhar an Ghearrthaisce</translation>
+    </message>
+    <message>
+        <source>&amp;Formats:</source>
+        <translation>&amp;Formáidí:</translation>
+    </message>
+    <message>
+        <source>C&amp;ontent:</source>
+        <translation>Á&amp;bhar:</translation>
+    </message>
+    <message>
+        <location filename="../src/ui/clipboarddialog.ui" line="205"/>
+        <source>Remove Format</source>
+        <translation>Bain Formáid</translation>
+    </message>
+    <message>
+        <source>Item Content</source>
+        <translation>Ábhar na Míre</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;Size:&lt;/strong&gt; %1 bytes</source>
+        <translation>&lt;strong&gt;Méid:&lt;/strong&gt; %1 beart</translation>
+    </message>
+</context>
+<context>
+    <name>ClipboardServer</name>
+    <message>
+        <source>CopyQ server is already running.</source>
+        <translation>Tá freastalaí CopyQ ag rith cheana féin.</translation>
+    </message>
+    <message>
+        <source>Cancel Active Commands</source>
+        <translation>Cealaigh Orduithe Gníomhacha</translation>
+    </message>
+    <message>
+        <source>Cancel active commands and exit?</source>
+        <translation>Cealaigh orduithe gníomhacha agus scoir?</translation>
+    </message>
+    <message>
+        <source>Cancel Exiting</source>
+        <translation>Cealaigh Scoir</translation>
+    </message>
+    <message>
+        <source>Exit Anyway</source>
+        <translation>Scoir Mar Sin Féin</translation>
+    </message>
+</context>
+<context>
+    <name>CommandDialog</name>
+    <message>
+        <source>Commands</source>
+        <translation>Orduithe</translation>
+    </message>
+    <message>
+        <source>Define new commands that can be either invoked automatically on new clipboard content or by user from menu or using system shortcut.</source>
+        <translation>Sainmhínigh orduithe nua ar féidir iad a agairt go huathoibríoch ar ábhar gearrthaisce nua nó ag an úsáideoir ón roghchlár nó ag baint úsáide as aicearra córais.</translation>
+    </message>
+    <message>
+        <source>&amp;Load Commands…</source>
+        <translation>&amp;Lódáil Orduithe…</translation>
+    </message>
+    <message>
+        <source>Sa&amp;ve Selected…</source>
+        <translation>S&amp;ábháil Roghnaithe…</translation>
+    </message>
+    <message>
+        <source>Copy Selected</source>
+        <translation>Cóipeáil Roghnaithe</translation>
+    </message>
+    <message>
+        <source>Paste Commands</source>
+        <translation>Greamaigh Orduithe</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes</source>
+        <translation>Athruithe Gan Sábháil</translation>
+    </message>
+    <message>
+        <source>Command dialog has unsaved changes.</source>
+        <translation>Tá athruithe gan sábháil ag dialóg ordaithe.</translation>
+    </message>
+    <message>
+        <source>Open Files with Commands</source>
+        <translation>Oscail Comhaid le hOrduithe</translation>
+    </message>
+    <message>
+        <source>Commands (*.ini);; CopyQ Configuration (copyq.conf copyq-*.conf)</source>
+        <translation>Orduithe (*.ini);; Cumraíocht CopyQ (copyq.conf, copyq-*.conf)</translation>
+    </message>
+    <message>
+        <source>Save Selected Commands</source>
+        <translation>Sábháil Orduithe Roghnaithe</translation>
+    </message>
+    <message>
+        <source>Commands (*.ini)</source>
+        <translation>Orduithe (*.ini)</translation>
+    </message>
+    <message>
+        <source>&amp;Find:</source>
+        <translation>&amp;Aimsigh:</translation>
+    </message>
+</context>
+<context>
+    <name>CommandHelpButton</name>
+    <message>
+        <source>Command contains list of programs with arguments which will be executed. For example:</source>
+        <translation>Tá liosta de na cláir le hargóintí a fhorghníomhófar san ordú. Mar shampla:</translation>
+    </message>
+    <message>
+        <source>Program argument %1 will be substituted for item text.</source>
+        <translation>Cuirfear argóint chláir %1 in ionad téacs na míre.</translation>
+    </message>
+    <message>
+        <source>Character %1 can be used to pass standard output to the next program.</source>
+        <translation>Is féidir carachtar %1 a úsáid chun aschur caighdeánach a aistriú chuig an gcéad chlár eile.</translation>
+    </message>
+    <message>
+        <source>Following syntax can be used to pass rest of the command as single parameter.</source>
+        <translation>Is féidir an chomhréir seo a úsáid chun an chuid eile den ordú a rith mar pharaiméadar aonair.</translation>
+    </message>
+    <message>
+        <source>This gives same output as %1 but is more useful for longer commands.</source>
+        <translation>Tugann sé seo an t-aschur céanna le %1 ach tá sé níos úsáidí le haghaidh orduithe níos faide.</translation>
+    </message>
+    <message>
+        <source>Functions listed below can be used as in following commands.</source>
+        <translation>Is féidir feidhmeanna atá liostaithe thíos a úsáid mar atá sna horduithe seo a leanas.</translation>
+    </message>
+    <message>
+        <source>Show command help (F1)</source>
+        <translation>Taispeáin cabhair ordaithe (F1)</translation>
+    </message>
+    <message>
+        <source>&amp;clipboard</source>
+        <translation>&amp;gearrthaisce</translation>
+    </message>
+</context>
+<context>
+    <name>CommandWidget</name>
+    <message>
+        <source>Command name shown in menu</source>
+        <translation>Ainm an ordaithe a thaispeántar sa roghchlár</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Cineál:</translation>
+    </message>
+    <message>
+        <source>Run the command automatically if clipboard has new content</source>
+        <translation>Rith an t-ordú go huathoibríoch má tá ábhar nua ag an ngearrthaisce</translation>
+    </message>
+    <message>
+        <source>Auto&amp;matic</source>
+        <translation>Uathoib&amp;ríoch</translation>
+    </message>
+    <message>
+        <source>Show command in context menu of matching items</source>
+        <translation>Taispeáin an t-ordú i roghchlár comhthéacs na míreanna comhoiriúnacha</translation>
+    </message>
+    <message>
+        <source>In M&amp;enu</source>
+        <translation>Sa R&amp;oghchlár</translation>
+    </message>
+    <message>
+        <source>Global Shortcut</source>
+        <translation>Aicearra Domhanda:</translation>
+    </message>
+    <message>
+        <source>Script</source>
+        <translation>Script</translation>
+    </message>
+    <message>
+        <source>Display</source>
+        <translation>Taispeáint</translation>
+    </message>
+    <message>
+        <source>&amp;Shortcut:</source>
+        <translation>&amp;Aicearra:</translation>
+    </message>
+    <message>
+        <source>&amp;Global Shortcut:</source>
+        <translation>&amp;Aicearra Domhanda:</translation>
+    </message>
+    <message>
+        <source>Comman&amp;d</source>
+        <translation>Or&amp;dú</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced</source>
+        <translation>&amp;Casta</translation>
+    </message>
+    <message>
+        <source>Match Items</source>
+        <translation>Meaitseáil Míreanna</translation>
+    </message>
+    <message>
+        <source>&amp;Content:</source>
+        <translation>&amp;Ábhar:</translation>
+    </message>
+    <message>
+        <source>Skips the command if the input text does not match this regular expression (leave empty to match everything).
+
+%2 through %9 (or argument[1] and up in script) in Command and Filter will be replaced with the captured texts.
+
+Examples:
+
+- Match URL: ^(https?|ftp)://
+- Match PDF filenames: \.pdf$
+- Match single character: ^.$
+- Match remote multimedia: ^http://.*\.(ogv|vlc|mp4|mp3)$</source>
+        <translation>Scipeáil an t-ordú mura bhfuil an téacs ionchuir ag teacht leis an slonn rialta seo (fág folamh chun gach rud a mheaitseáil).
+
+Cuirfear na téacsanna gafa in ionad %2 trí %9 (nó argóint [1] agus suas sa script) in Ordú agus Scagaire.
+
+Samplaí:
+
+- Meaitseáil URL: ^(https?|ftp)://
+- Meaitseáil ainmneacha comhaid PDF: \.pdf$
+- Meaitseáil carachtar aonair: ^.$
+- Meaitseáil ilmheán iargúlta: ^http://.*\. (ogv|vlc|mp4|mp3)$</translation>
+    </message>
+    <message>
+        <source>&amp;Window:</source>
+        <translation>&amp;Fuinneog:</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Use command only for items copied to clipboard from window with title text that matches this regular expression (leave empty to match any window). On macOS, this contains the application name followed by a dash (&amp;quot;-&amp;quot;) then the window title. E.g. &amp;quot;Safari - GitHub&amp;quot;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Úsáid an t-ordú ach amháin le haghaidh míreanna a chóipeáiltear go gearrthaisce ón bhfuinneog le téacs teidil a mheaitseálann an slonn rialta seo (fág folamh chun aon fhuinneog a mheaitseáil). Ar macOS, tá ainm an fheidhmchláir agus Fleasc (&amp;quot;-&amp;quot;) ina dhiaidh sin teideal na fuinneoige. M.sh. &amp;quot;Safari - GitHub&amp;quot;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>For&amp;mat:</source>
+        <translation>For&amp;máid:</translation>
+    </message>
+    <message>
+        <source>Data of this MIME type will be sent to standard input of command.
+Leave empty to disable this.</source>
+        <translation>Seolfar sonraí den chineál MIME seo chuig ionchur caighdeánach ordaithe.
+Fág folamh chun é seo a dhíchumasú.</translation>
+    </message>
+    <message>
+        <source>&amp;Filter:</source>
+        <translation>&amp;Scagaire:</translation>
+    </message>
+    <message>
+        <source>Skips the command if the filter command fails with non-zero exit code.</source>
+        <translation>Scipeáil an t-ordú má theipeann ar an ordú scagaire le cód scoir nach nialasach.</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Gníomh</translation>
+    </message>
+    <message>
+        <source>Cop&amp;y to tab:</source>
+        <translation>Cóipeái&amp;l chuig cluaisín:</translation>
+    </message>
+    <message>
+        <source>Name of tab to copy new items into (leave empty not to copy)</source>
+        <translation>Ainm an chluaisín le míreanna nua a chóipeáil ann (fág folamh gan cóipeáil)</translation>
+    </message>
+    <message>
+        <source>Remove matching item
+
+Note: If this is applied automatically, no other automatic commands are executed.</source>
+        <translation>Bain mír meaitseála
+
+Tabhair faoi deara: Má chuirtear é seo i bhfeidhm go huathoibríoch, ní fhorghníomhaítear aon orduithe uathoibríocha eile.</translation>
+    </message>
+    <message>
+        <source>&amp;Remove Item</source>
+        <translation>&amp;Bain Mír</translation>
+    </message>
+    <message>
+        <source>Menu Action</source>
+        <translation>Gníomh Roghchláir</translation>
+    </message>
+    <message>
+        <source>Hide window after command is activated from context menu of an item</source>
+        <translation>Folaigh fuinneog tar éis ordú a ghníomhachtú ó roghchlár comhthéacs míre</translation>
+    </message>
+    <message>
+        <source>&amp;Hide main window after activation</source>
+        <translation>&amp;Folaigh an phríomhfhuinneog tar éis dó a ghníomhachtú</translation>
+    </message>
+    <message>
+        <source>Command options</source>
+        <translation>Roghanna ordaithe</translation>
+    </message>
+    <message>
+        <source>O&amp;utput:</source>
+        <translation>Asch&amp;ur:</translation>
+    </message>
+    <message>
+        <source>Create items from standard output of the program (leave empty to disable)</source>
+        <translation>Cruthaigh míreanna ó aschur caighdeánach an chláir (fág folamh le díchumasú)</translation>
+    </message>
+    <message>
+        <source>&amp;Separator:</source>
+        <translation>&amp;Deighilteoir:</translation>
+    </message>
+    <message>
+        <source>Separator to match for splitting the output to multiple items</source>
+        <translation>Deighilteoir le meaitseáil chun an t-aschur a scoilteadh go míreanna iolracha</translation>
+    </message>
+    <message>
+        <source>Save items in tab with given name (leave empty to save in first tab)</source>
+        <translation>Sábháil míreanna sa chluaisín le hainm tugtha (fág folamh le sábháil sa chéad chluaisín)</translation>
+    </message>
+    <message>
+        <source>Show action dialog before executing the command</source>
+        <translation>Taispeáin dialóg gníomhaíochta sula ndéantar an t-ordú a rith</translation>
+    </message>
+    <message>
+        <source>&amp;Wait</source>
+        <translation>&amp;Fan</translation>
+    </message>
+    <message>
+        <source>Change item, don&apos;t create any new items</source>
+        <translation>Athraigh míre, ná cruthaigh aon mhíreanna nua</translation>
+    </message>
+    <message>
+        <source>Tr&amp;ansform</source>
+        <translation>Cl&amp;aochlú</translation>
+    </message>
+    <message>
+        <source>Show Advanced</source>
+        <translation>Taispeáin Casta</translation>
+    </message>
+    <message>
+        <source>&amp;Name:</source>
+        <translation>&amp;Ainm:</translation>
+    </message>
+    <message>
+        <source>\n</source>
+        <translation>\n</translation>
+    </message>
+    <message>
+        <source>Output &amp;tab:</source>
+        <translation>Cluaisín &amp;Aschuir:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabAppearance</name>
+    <message>
+        <source>Tooltips</source>
+        <translation>Leideanna uirlisí</translation>
+    </message>
+    <message>
+        <source>Found</source>
+        <translation>Aimsithe</translation>
+    </message>
+    <message>
+        <source>Selected</source>
+        <translation>Roghnaithe</translation>
+    </message>
+    <message>
+        <source>Number</source>
+        <translation>Uimhir</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Gnáth</translation>
+    </message>
+    <message>
+        <source>Editor</source>
+        <translation>Eagarthóir</translation>
+    </message>
+    <message>
+        <source>Alternate</source>
+        <translation>Malartach</translation>
+    </message>
+    <message>
+        <source>Notification</source>
+        <translation>Fógra</translation>
+    </message>
+    <message>
+        <source>Show &amp;Number</source>
+        <translation>Taispeáin &amp;Uimhir</translation>
+    </message>
+    <message>
+        <source>Show scrollbars</source>
+        <translation>Taispeáin barraí scrollaithe</translation>
+    </message>
+    <message>
+        <source>S&amp;crollbars</source>
+        <translation>S&amp;barraí scrollbharra</translation>
+    </message>
+    <message>
+        <source>Use icons from desktop environment whenever possible</source>
+        <translation>Bain úsáid as deilbhíní ó thimpeallacht deisce nuair is féidir</translation>
+    </message>
+    <message>
+        <source>S&amp;ystem Icons</source>
+        <translation>D&amp;eilbhíní Córais</translation>
+    </message>
+    <message>
+        <source>&amp;Antialias</source>
+        <translation>&amp;Antialias</translation>
+    </message>
+    <message>
+        <source>S&amp;et colors for tabs, tool bar and menus</source>
+        <translation>Soc&amp;raigh dathanna do chluaisíní, barra uirlisí agus biachláir</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Theme</source>
+        <translation>&amp;Athshocraigh Téama</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Téama:</translation>
+    </message>
+    <message>
+        <source>&amp;Load Theme</source>
+        <translation>&amp;Luchtaigh Téama</translation>
+    </message>
+    <message>
+        <source>&amp;Save Theme</source>
+        <translation>&amp;Sábháil Téama</translation>
+    </message>
+    <message>
+        <source>Edit current theme in external editor</source>
+        <translation>Cuir an téama reatha in eagarthóir seachtrach</translation>
+    </message>
+    <message>
+        <source>E&amp;dit Theme</source>
+        <translation>C&amp;uir an Téama in Eagar</translation>
+    </message>
+    <message>
+        <source>Preview:</source>
+        <translation>Réamhamharc:</translation>
+    </message>
+    <message>
+        <source>Open Theme File</source>
+        <translation>Oscail Comhad Téama</translation>
+    </message>
+    <message>
+        <source>Save Theme File As</source>
+        <translation>Sábháil Comhad Téama Mar</translation>
+    </message>
+    <message>
+        <source>No External Editor</source>
+        <translation>Gan Eagarthóir Seachtrach</translation>
+    </message>
+    <message>
+        <source>Set external editor command first!</source>
+        <translation>Socraigh ordú eagarthóra seachtrach ar dtús!</translation>
+    </message>
+    <message>
+        <source>Search string is %1.</source>
+        <translation>Is é teaghrán cuardaigh %1.</translation>
+    </message>
+    <message>
+        <source>Select an item and
+press F2 to edit.</source>
+        <translation>Roghnaigh mír agus
+brúigh F2 le cur in eagar.</translation>
+    </message>
+    <message>
+        <source>Example item %1</source>
+        <translation>Mír shampla %1</translation>
+    </message>
+    <message>
+        <source>Some random notes (Shift+F2 to edit)</source>
+        <translation>Roinnt nótaí randamacha (Shift+F2 a chur in eagar)</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation>Cúlra</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation>Cló</translation>
+    </message>
+    <message>
+        <source>Foreground</source>
+        <translation>Túlra</translation>
+    </message>
+    <message>
+        <source>Abc</source>
+        <translation>Abc</translation>
+    </message>
+    <message>
+        <source>item</source>
+        <translation>mír</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabGeneral</name>
+    <message>
+        <source>&amp;Language:</source>
+        <translation>&amp;Teanga:</translation>
+    </message>
+    <message>
+        <source>Break text if it&apos;s too long to fit on line</source>
+        <translation>Briseadh téacs má tá sé rófhada le bheith oiriúnach ar líne</translation>
+    </message>
+    <message>
+        <source>Wrap l&amp;ong text</source>
+        <translation>Fill téac&amp;s fada</translation>
+    </message>
+    <message>
+        <source>Keep main window above other windows</source>
+        <translation>Coinnigh an phríomhfhuinneog os cionn fuinneoga eile</translation>
+    </message>
+    <message>
+        <source>Alwa&amp;ys on Top</source>
+        <translation>I gcónaí a&amp;r a Bharr</translation>
+    </message>
+    <message>
+        <source>Close main window when other application has focus</source>
+        <translation>Dún an phríomhfhuinneog nuair a bhíonn fócas ag feidhmchlár eile</translation>
+    </message>
+    <message>
+        <source>Close When Unfocused</source>
+        <translation>Dún Nuair nach bhfuil Dírithe</translation>
+    </message>
+    <message>
+        <source>Enable to open windows on current screen. Disable to open windows where they were last closed</source>
+        <translation>Cumasaigh fuinneoga a oscailt ar an scáileán reatha. Díchumasaigh chun fuinneoga a oscailt san áit ar dúnadh iad go deireanach</translation>
+    </message>
+    <message>
+        <source>O&amp;pen windows on current screen</source>
+        <translation>Fuinneoga O&amp;peann ar an scáileán reatha</translation>
+    </message>
+    <message>
+        <source>Confirm application exit</source>
+        <translation>Deimhnigh scoir an fheidhmchláir</translation>
+    </message>
+    <message>
+        <source>Confirm application e&amp;xit</source>
+        <translation>Deimhnigh s&amp;coir an fheidhmchláir</translation>
+    </message>
+    <message>
+        <source>Run the application on system startup</source>
+        <translation>Rith an feidhmchlár ag tosú an chórais</translation>
+    </message>
+    <message>
+        <source>&amp;Autostart</source>
+        <translation>&amp;Uaththosú</translation>
+    </message>
+    <message>
+        <source>Navigation style / Keymap:</source>
+        <translation>Stíl nascleanúna / Eochairléarscáil:</translation>
+    </message>
+    <message>
+        <source>Support for Vi navigation (keys H, J, K, L, / and more) and Emacs navigation (Ctrl+N, P, V and more)</source>
+        <translation>Tacaíocht do nascleanúint Vi (eochracha H, J, K, L, / agus níos mó) agus nascleanúint Emacs (Ctrl + N, P, V agus níos mó)</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>Réamhshocrú</translation>
+    </message>
+    <message>
+        <source>Vi</source>
+        <translation>Vi</translation>
+    </message>
+    <message>
+        <source>Emacs</source>
+        <translation>Emacs</translation>
+    </message>
+    <message>
+        <source>Save and restore history of item filters</source>
+        <translation>Sábháil agus athchóirigh stair scagairí míreanna</translation>
+    </message>
+    <message>
+        <source>Save Filter History</source>
+        <translation>Sábháil Stair na Scagaire</translation>
+    </message>
+    <message>
+        <source>Automatically show popup to complete function, type and variable names in commands</source>
+        <translation>Taispeáin aníos go huathoibríoch chun ainmneacha feidhme, cineáil agus athróg in orduithe a chomhlánú</translation>
+    </message>
+    <message>
+        <source>Auto-complete Commands</source>
+        <translation>Comhlánaigh Orduithe Uathoibríoch</translation>
+    </message>
+    <message>
+        <source>Clipboard Manipulation</source>
+        <translation>Ionramháil Gearrthaisce</translation>
+    </message>
+    <message>
+        <source>Allow to paste copied content the same way as mouse selections (usually by pressing middle mouse button)</source>
+        <translation>Ceadaigh ábhar cóipeáilte a ghreamú ar an mbealach céanna le roghnúcháin luiche (de ghnáth trí chnaipe lár na luiche a bhrú)</translation>
+    </message>
+    <message>
+        <source>(&amp;3) Paste clipboard with mouse</source>
+        <translation>(&amp;3) Greamaigh gearrthaisce le luch</translation>
+    </message>
+    <message>
+        <source>Allow to paste mouse selections using shortcut (usually Ctrl+V or Shift+Insert)</source>
+        <translation>Ceadaigh roghanna luiche a ghreamú ag baint úsáide as aicearra (Ctrl+V nó Shift+Ionsáigh de ghnáth)</translation>
+    </message>
+    <message>
+        <source>(&amp;4) Paste mouse selection with keyboard</source>
+        <translation>(&amp;4) Greamaigh roghnúchán luiche le méarchlár</translation>
+    </message>
+    <message>
+        <source>Save clipboard in history</source>
+        <translation>Sábháil gearrthaisce sa stair</translation>
+    </message>
+    <message>
+        <source>(&amp;1) Store clipboard</source>
+        <translation>(&amp;1) Stóráil gearrthaisce</translation>
+    </message>
+    <message>
+        <source>Save text selected with mouse (primary selection) in history</source>
+        <translation>Sábháil an téacs roghnaithe leis an luch (príomhroghnú) sa stair</translation>
+    </message>
+    <message>
+        <source>(&amp;2) Store text selected using mouse</source>
+        <translation>(&amp;2) Stóráil an téacs roghnaithe ag baint úsáide as an luch</translation>
+    </message>
+    <message>
+        <source>(&amp;5) Run automatic commands on selection</source>
+        <translation>(&amp;5) Rith orduithe uathoibríocha ar roghnú</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabHistory</name>
+    <message>
+        <source>Maximum &amp;number of items in history:</source>
+        <translation>Uaslíon na mírea&amp;nna sa stair:</translation>
+    </message>
+    <message>
+        <source>Maximum number of items in each tab</source>
+        <translation>Uasmhéid míreanna i ngach cluaisín</translation>
+    </message>
+    <message>
+        <source>&amp;Unload tab after an interval in minutes:</source>
+        <translation>&amp;Díluchtaigh cluaisín tar éis eatramh i nóiméid:</translation>
+    </message>
+    <message>
+        <source>Unload each tab from memory after specified number of minutes of inactivity.
+
+Set to 0 not to unload tabs.</source>
+        <translation>Díluchtaigh gach cluaisín ón gcuimhne tar éis líon sonraithe nóiméad neamhghníomhaíochta.
+
+Socraigh go 0 gan cluaisíní a dhíluchtú.</translation>
+    </message>
+    <message>
+        <source>External editor command (%&amp;1 is file to edit):</source>
+        <translation>Ordú eagarthóra seachtrach (is comhad é %&amp;1 le cur in eagar):</translation>
+    </message>
+    <message>
+        <source>External editor command (%1 is file to edit).
+  Examples:
+    gedit %1
+    notepad %1
+    gvim -f %1
+    xterm -e vim %1</source>
+        <translation>Ordú eagarthóra seachtrach (is comhad é %1 le cur in eagar).
+  Samplaí:
+    gedit %1
+    Ceap nótaí %1
+    gvim -f %1
+    xterm -e vim %1</translation>
+    </message>
+    <message>
+        <source>Ta&amp;b for storing clipboard:</source>
+        <translation>Cl&amp;uaisín chun an ghearrthaisce a stóráil:</translation>
+    </message>
+    <message>
+        <source>Name of tab that will automatically store new clipboard content.
+
+Leave empty to disable automatic storing.</source>
+        <translation>Ainm an chluaisín a stórálfaidh ábhar nua gearrthaisce go huathoibríoch.
+
+Fág folamh chun stóráil uathoibríoch a dhíchumasú.</translation>
+    </message>
+    <message>
+        <source>Leave unchecked for Return key to save edited item and Ctrl+Return create new line.
+
+Note: Edited items can be saved with F2 disregarding this option.</source>
+        <translation>Fág gan seiceáil le haghaidh Return eochair chun mír eagarthóireachta a shábháil agus Ctrl+Return cruthaigh líne nua.
+
+Tabhair faoi deara: Is féidir míreanna curtha in eagar a shábháil le F2 gan aird a thabhairt ar an rogha seo.</translation>
+    </message>
+    <message>
+        <source>Sa&amp;ve edited item with Ctrl+Return and create new line with Return key</source>
+        <translation>&amp;Sábháil an mhír curtha in eagar le Ctrl+Return agus cruthaigh líne nua le heochrach Return</translation>
+    </message>
+    <message>
+        <source>Show single line description of each item.
+
+Use Item Preview to display whole items.</source>
+        <translation>Taispeáin cur síos líne amháin ar gach míre.
+
+Bain úsáid as Réamhamharc Míreanna chun míreanna iomlána a thaispeáint.</translation>
+    </message>
+    <message>
+        <source>Sho&amp;w simple items</source>
+        <translation>Taispeái&amp;n míreanna simplí</translation>
+    </message>
+    <message>
+        <source>Enable searching for numbers, otherwise pressing a digit key activates item on that position</source>
+        <translation>Cumasaigh cuardach le haghaidh uimhreacha, nó cuirtear mír ar an suíomh sin i ngníomh nuair a bhrúnn tú eochair dhigit</translation>
+    </message>
+    <message>
+        <source>S&amp;earch for numbers</source>
+        <translation>Cu&amp;ardaigh uimhreacha</translation>
+    </message>
+    <message>
+        <source>Activate item with single click</source>
+        <translation>Gníomhachtaigh mír le cliceáil amháin</translation>
+    </message>
+    <message>
+        <source>After item is activated (double-click or Enter key), copy it to clipboard and ...</source>
+        <translation>Tar éis an mhír a ghníomhachtú (cliceáil faoi dhó nó Iontráil eochair), cóipeáil é go gearrthaisce agus ...</translation>
+    </message>
+    <message>
+        <source>Move item to the top of the list after it is activated</source>
+        <translation>Bog mír go barr an liosta tar éis é a ghníomhachtú</translation>
+    </message>
+    <message>
+        <source>Move item to the t&amp;op</source>
+        <translation>Bog an mhír go b&amp;arr</translation>
+    </message>
+    <message>
+        <source>Close main window after item is activated</source>
+        <translation>Dún an phríomhfhuinneog tar éis an mhír a ghníomhachtú</translation>
+    </message>
+    <message>
+        <source>&amp;Close main window</source>
+        <translation>&amp;Dún an phríomhfhuinneog</translation>
+    </message>
+    <message>
+        <source>Focus last window after item is activated</source>
+        <translation>Dírigh ar an bhfuinneog dheireanach tar éis an mhír a ghníomhachtú</translation>
+    </message>
+    <message>
+        <source>&amp;Focus last window</source>
+        <translation>&amp;Dírigh thar an bhfuinneog</translation>
+    </message>
+    <message>
+        <source>Paste to current window after item is activated</source>
+        <translation>Greamaigh go dtí an fhuinneog reatha tar éis an mhír a ghníomhachtú</translation>
+    </message>
+    <message>
+        <source>&amp;Paste to current window</source>
+        <translation>&amp;Greamaigh go dtí an fhuinneog reatha</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabLayout</name>
+    <message>
+        <source>Show/Hide</source>
+        <translation>Taispeáin/Folaigh</translation>
+    </message>
+    <message>
+        <source>Hide tabs (press Alt key to show)</source>
+        <translation>Folaigh cluaisíní (brúigh eochair Alt le taispeáint)</translation>
+    </message>
+    <message>
+        <source>Hi&amp;de tabs</source>
+        <translation>Fola&amp;igh cluaisíní</translation>
+    </message>
+    <message>
+        <source>Hide toolbar</source>
+        <translation>Folaigh barra uirlisí</translation>
+    </message>
+    <message>
+        <source>Hide too&amp;lbar</source>
+        <translation>Folaigh freisin &amp;lbarra</translation>
+    </message>
+    <message>
+        <source>Hide tool&amp;bar labels</source>
+        <translation>Folaigh lipéid &amp;bharra uirlisí</translation>
+    </message>
+    <message>
+        <source>Hide main window when closed</source>
+        <translation>Folaigh an phríomhfhuinneog nuair a bhíonn sé dúnta</translation>
+    </message>
+    <message>
+        <source>Hide &amp;main window</source>
+        <translation>Folaigh an &amp;phríomhfhuinneog</translation>
+    </message>
+    <message>
+        <source>Layout and Transparency</source>
+        <translation>Leagan Amach agus Trédhearcacht</translation>
+    </message>
+    <message>
+        <source>Show tree with tabs instead of tab bar</source>
+        <translation>Taispeáin crann le cluaisíní in ionad barra cluaisíní</translation>
+    </message>
+    <message>
+        <source>Tab T&amp;ree</source>
+        <translation>Crann na gCl&amp;uaisíní</translation>
+    </message>
+    <message>
+        <source>&amp;Focused transparency:</source>
+        <translation>&amp;Trédhearcacht dhírithe:</translation>
+    </message>
+    <message>
+        <source>Transparency of main window if focused.
+
+Note: This is not supported on all systems.</source>
+        <translation>Trédhearcacht na príomhfhuinneog má tá sé dírithe.
+
+Tabhair faoi deara: Ní thacaítear leis seo ar gach córas.</translation>
+    </message>
+    <message>
+        <source>&amp;Unfocused transparency:</source>
+        <translation>Trédhearcacht &amp;neamhdhírithe:</translation>
+    </message>
+    <message>
+        <source>Transparency of main window if unfocused.
+
+Note: This is not supported on all systems.</source>
+        <translation>Trédhearcacht na príomhfhuinneog mura bhfuil sé dírithe.
+
+Tabhair faoi deara: Ní thacaítear leis seo ar gach córas.</translation>
+    </message>
+    <message>
+        <source>Show number of items in tabs</source>
+        <translation>Taispeáin líon na míreanna i gcluaisíní</translation>
+    </message>
+    <message>
+        <source>Sho&amp;w Item Count</source>
+        <translation>Taispeái&amp;n Líon na Míreanna</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabNotifications</name>
+    <message>
+        <source>&amp;Notification position:</source>
+        <translation>&amp;Suíomh an fhógra:</translation>
+    </message>
+    <message>
+        <source>Position on screen for notifications</source>
+        <translation>Suíomh ar an scáileán le haghaidh fógraí</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>Barr</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>Bun</translation>
+    </message>
+    <message>
+        <source>Top Right</source>
+        <translation>Barr ar Dheis</translation>
+    </message>
+    <message>
+        <source>Bottom Right</source>
+        <translation>Bun ar Dheis</translation>
+    </message>
+    <message>
+        <source>Bottom Left</source>
+        <translation>Bun ar Chlé</translation>
+    </message>
+    <message>
+        <source>Top Left</source>
+        <translation>Barr ar Chlé</translation>
+    </message>
+    <message>
+        <source>Int&amp;erval in seconds to display notifications:</source>
+        <translation>E&amp;atramh i soicindí chun fógraí a thaispeáint:</translation>
+    </message>
+    <message>
+        <source>Interval in seconds to display notification for new clipboard content or if item is copied to clipboard (only if main window is closed).
+
+Set to 0 to disable this.
+
+Set to -1 to keep visible until clicked.</source>
+        <translation>Eatramh i soicind chun fógra a thaispeáint maidir le hábhar nua an ghearrthaisce nó má chóipeáiltear an mhír go gearrthaisce (ach amháin má tá an phríomhfhuinneog dúnta).
+
+Socraigh go 0 chun é seo a dhíchumasú.
+
+Socraigh go -1 chun é a choinneáil infheicthe go dtí go gcliceáiltear air.</translation>
+    </message>
+    <message>
+        <source>Num&amp;ber of lines for clipboard notification:</source>
+        <translation>Líon agus líon na línte le haghaidh fógra gearrthaisce:</translation>
+    </message>
+    <message>
+        <source>Number of lines to show for new clipboard content.
+
+Set to 0 to disable.</source>
+        <translation>Líon na línte le taispeáint d&apos;ábhar nua an ghearrthaisce
+
+Socraigh go 0 le díchumasú.</translation>
+    </message>
+    <message>
+        <source>&amp;Use native notifications</source>
+        <translation>&amp;Úsáid fógraí dúchasacha</translation>
+    </message>
+    <message>
+        <source>Notification Geometry (in screen points)</source>
+        <translation>Geoiméadracht Fógra (i bpointí scáileáin)</translation>
+    </message>
+    <message>
+        <source>Hori&amp;zontal offset:</source>
+        <translation>Fritháireamh &amp;criosaithe:</translation>
+    </message>
+    <message>
+        <source>Notification distance from left or right screen edge in screen points</source>
+        <translation>Fad fógra ó imeall an scáileáin chlé nó ar dheis i bpointí scáileáin</translation>
+    </message>
+    <message>
+        <source>&amp;Vertical offset:</source>
+        <translation>&amp;Fritháireamh ingearach:</translation>
+    </message>
+    <message>
+        <source>Notification distance from top or bottom screen edge in screen points</source>
+        <translation>Fad fógra ó imeall barr nó bun an scáileáin i bpointí scáileáin</translation>
+    </message>
+    <message>
+        <source>Maximum &amp;width:</source>
+        <translation>Leithead &amp;uasta:</translation>
+    </message>
+    <message>
+        <source>Maximum width for notification in screen points</source>
+        <translation>Uasleithead le haghaidh fógra i bpointí scáileáin</translation>
+    </message>
+    <message>
+        <source>Ma&amp;ximum height:</source>
+        <translation>Aird&amp;e uasta:</translation>
+    </message>
+    <message>
+        <source>Maximum height for notification in screen points</source>
+        <translation>Uasairde le haghaidh fógra i bpointí scáileáin</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigTabTray</name>
+    <message>
+        <source>Don&apos;t show tray icon; minimize window when closed</source>
+        <translation>Ná taispeáin deilbhín tráidire; Íoslaghdaigh an fhuinneog nuair a bhíonn sé dúnta</translation>
+    </message>
+    <message>
+        <source>Disabl&amp;e tray</source>
+        <translation>Díchumasaigh an tráidir&amp;e</translation>
+    </message>
+    <message>
+        <source>Show command for current clipboard content in tray menu</source>
+        <translation>Taispeáin an t-ordú don ábhar gearrthaisce reatha sa roghchlár tráidire</translation>
+    </message>
+    <message>
+        <source>Sho&amp;w commands for clipboard content</source>
+        <translation>Taispeáin &amp;orduithe le haghaidh ábhar an ghearrthaisce</translation>
+    </message>
+    <message>
+        <source>N&amp;umber of items in tray menu:</source>
+        <translation>Líon na &amp;míreanna sa roghchlár tráidire:</translation>
+    </message>
+    <message>
+        <source>Number of items in tray menu</source>
+        <translation>Líon na míreanna sa roghchlár tráidire</translation>
+    </message>
+    <message>
+        <source>Show items from current tab in tray menu</source>
+        <translation>Taispeáin míreanna ón táb reatha sa roghchlár tráidire</translation>
+    </message>
+    <message>
+        <source>Show cu&amp;rrent tab in menu,</source>
+        <translation>Taispeáin cluaisín cuairt sa roghchlár,</translation>
+    </message>
+    <message>
+        <source>or &amp;choose other tab:</source>
+        <translation>nó &amp;roghnaigh cluaisín eile:</translation>
+    </message>
+    <message>
+        <source>Name of tab to show in tray menu (empty for the first tab)</source>
+        <translation>Ainm an chluaisín le taispeáint sa roghchlár tráidire (folamh don chéad chluaisín)</translation>
+    </message>
+    <message>
+        <source>Paste item to current window after selecting it in menu</source>
+        <translation>Greamaigh mír go dtí an fhuinneog reatha tar éis é a roghnú sa roghchlár</translation>
+    </message>
+    <message>
+        <source>&amp;Paste activated item to current window</source>
+        <translation>&amp;Greamaigh mír ghníomhachtaithe san fhuinneog reatha</translation>
+    </message>
+    <message>
+        <source>Show image preview next to menu items</source>
+        <translation>Taispeáin réamhamharc íomhá in aice le míreanna roghchláir</translation>
+    </message>
+    <message>
+        <source>Sh&amp;ow image preview as menu item icon</source>
+        <translation>Réamhamharc íomhá mar dheilbhín míre r&amp;oghchláir</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigurationManager</name>
+    <message>
+        <source>Preferences</source>
+        <translation>Sainroghanna</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Ginearálta</translation>
+    </message>
+    <message>
+        <source>Layout</source>
+        <translation>Leagan Amach</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation>Stair</translation>
+    </message>
+    <message>
+        <source>Tray</source>
+        <translation>Tráidire</translation>
+    </message>
+    <message>
+        <source>Notifications</source>
+        <translation>Fógraí</translation>
+    </message>
+    <message>
+        <source>Tabs</source>
+        <translation>Cluaisíní</translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation>Míreanna</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation>Aicearraí</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Cuma</translation>
+    </message>
+    <message>
+        <source>Invalid value for option &quot;%1&quot;</source>
+        <translation>Luach neamhbhailí don rogha &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Reset preferences?</source>
+        <translation>Athshocraigh sainroghanna?</translation>
+    </message>
+    <message>
+        <source>This action will reset all your preferences (in all tabs) to default values.&lt;br /&gt;&lt;br /&gt;Do you really want to &lt;strong&gt;reset all preferences&lt;/strong&gt;?</source>
+        <translation>Athshocróidh an gníomh seo do chuid sainroghanna go léir (i ngach cluaisín) go luachanna réamhshocraithe.&lt;br /&gt;&lt;br /&gt;An bhfuil fonn ort &lt;strong&gt;gach rogha a athshocrú&lt;/strong&gt; i ndáiríre?</translation>
+    </message>
+    <message>
+        <source>Restart Required</source>
+        <translation>Atosaigh ag teastáil</translation>
+    </message>
+    <message>
+        <source>Language will be changed after application is restarted.</source>
+        <translation>Athrófar an teanga tar éis an t-iarratas a atosú.</translation>
+    </message>
+</context>
+<context>
+    <name>FileWatcher</name>
+    <message>
+        <source>Failed to create synchronization directory &quot;%1&quot;!</source>
+        <translation>Theip ar chomhadlann sioncrónaithe &quot;%1&quot; a chruthú!</translation>
+    </message>
+</context>
+<context>
+    <name>IconSelectButton</name>
+    <message>
+        <source>Select Icon…</source>
+        <translation>Roghnaigh Deilbhín…</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>IconSelectDialog</name>
+    <message>
+        <source>Select Icon</source>
+        <translation>Roghnaigh Deilbhín</translation>
+    </message>
+    <message>
+        <source>Browse...</source>
+        <translation>Brabhsáil...</translation>
+    </message>
+    <message>
+        <source>Open Icon file</source>
+        <translation>Oscail Comhad Deilbhín</translation>
+    </message>
+    <message>
+        <source>Image Files (*.png *.jpg *.jpeg *.bmp *.ico *.svg)</source>
+        <translation>Comhaid Íomhá (*.png *.jpg *.jpeg *.bmp *.ico *.svg)</translation>
+    </message>
+</context>
+<context>
+    <name>ImportExportDialog</name>
+    <message>
+        <source>&amp;All</source>
+        <translation>&amp;Gach rud</translation>
+    </message>
+    <message>
+        <source>&amp;Tabs:</source>
+        <translation>&amp;Cluaisíní:</translation>
+    </message>
+    <message>
+        <source>Co&amp;nfiguration</source>
+        <translation>Cu&amp;mraíocht</translation>
+    </message>
+    <message>
+        <source>Co&amp;mmands</source>
+        <translation>Or&amp;duithe</translation>
+    </message>
+</context>
+<context>
+    <name>ItemEditor</name>
+    <message>
+        <source>Editor command failed (see logs)</source>
+        <translation>Theip ar ordú an eagarthóra (féach logaí)</translation>
+    </message>
+</context>
+<context>
+    <name>ItemEncryptedLoader</name>
+    <message>
+        <source>Encryption failed!</source>
+        <translation>Theip ar chriptiú!</translation>
+    </message>
+    <message>
+        <source>To share encrypted items on other computer or session, you&apos;ll need these secret key files (keep them in a safe place):</source>
+        <translation>Chun míreanna criptithe a roinnt ar ríomhaire nó ar sheisiún eile, beidh na comhaid eochair rúnda seo ag teastáil uait (coinnigh in áit shábháilte iad):</translation>
+    </message>
+    <message>
+        <source>GnuPG must be installed to view encrypted tabs.</source>
+        <translation>Ní mór GnuPG a shuiteáil chun cluaisíní criptithe a fheiceáil.</translation>
+    </message>
+    <message>
+        <source>Encrypt (needs GnuPG)</source>
+        <translation>Criptigh (teastaíonn GnuPG uaidh)</translation>
+    </message>
+    <message>
+        <source>Ctrl+L</source>
+        <translation>Ctrl+L</translation>
+    </message>
+    <message>
+        <source>Decrypt</source>
+        <translation>Díchriptiú</translation>
+    </message>
+    <message>
+        <source>Decrypt and Copy</source>
+        <translation>Díchriptiú agus Cóipeáil</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+L</source>
+        <translation>Ctrl+Shift+L</translation>
+    </message>
+    <message>
+        <source>Decrypt and Paste</source>
+        <translation>Díchriptigh agus Greamaigh</translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation>Iontráil</translation>
+    </message>
+    <message>
+        <source>Failed to generate keys.</source>
+        <translation>Theip ar eochracha a ghiniúint.</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation>Críochnaithe</translation>
+    </message>
+    <message>
+        <source>Creating new keys (this may take a few minutes)...</source>
+        <translation>Eochracha nua á chruthú (d&apos;fhéadfadh sé seo cúpla nóiméad a thógáil)...</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cuir ar ceal</translation>
+    </message>
+    <message>
+        <source>Setting new password...</source>
+        <translation>Pasfhocal nua á shocrú...</translation>
+    </message>
+    <message>
+        <source>Encryption keys &lt;strong&gt;must be generated&lt;/strong&gt; before item encryption can be used.</source>
+        <translation>Ní mór eochracha criptithe a &lt;strong&gt;ghiniúint&lt;/strong&gt; sular féidir criptiú míreanna a úsáid.</translation>
+    </message>
+    <message>
+        <source>Generate New Keys...</source>
+        <translation>Cruthaigh Eochracha Nua...</translation>
+    </message>
+    <message>
+        <source>Change Password...</source>
+        <translation>Athraigh Pasfhocal...</translation>
+    </message>
+    <message>
+        <source>Decryption failed!</source>
+        <translation>Theip ar dhíchriptiú!</translation>
+    </message>
+    <message>
+        <source>Encryption</source>
+        <translation>Criptiú</translation>
+    </message>
+    <message>
+        <source>Encrypt items and tabs.</source>
+        <translation>Criptigh míreanna agus cluaisíní.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>Earráid: %1</translation>
+    </message>
+</context>
+<context>
+    <name>ItemEncryptedSettings</name>
+    <message>
+        <source>To encrypt and decrypt items add appropriate commands under Commands tab.</source>
+        <translation>Chun míreanna a chriptiú agus a dhíchriptiú, cuir orduithe cuí leis faoin gcluaisín Orduithe.</translation>
+    </message>
+    <message>
+        <source>Sharing Encrypted Items and Tabs</source>
+        <translation>Míreanna agus Cluaisíní Criptithe á roinnt</translation>
+    </message>
+    <message>
+        <source>Encrypted Tabs</source>
+        <translation>Cluaisíní Criptithe</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Specify names of tabs (one per line) which will be automatically encrypted and decrypted.&lt;/p&gt;
+&lt;p&gt;Set unload tab interval in History tab to safely unload decrypted items from memory.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Sonraigh ainmneacha cluaisíní (ceann in aghaidh na líne) a chripteofar agus a dhíchripteofar go huathoibríoch.&lt;/p&gt;
+&lt;p&gt;Socraigh eatramh cluaisín díluchtaithe sa chluaisín Stair chun míreanna díchriptithe a dhíluchtú go sábháilte ón gcuimhne.&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ItemFactory</name>
+    <message>
+        <source>Corrupted Tab</source>
+        <translation>Cluaisín Truaillithe</translation>
+    </message>
+    <message>
+        <source>Not all items in the tab &lt;strong&gt;%1&lt;/strong&gt; were loaded successfully. Do you still want to load the tab and potentially lose some items?</source>
+        <translation>Níor luchtaíodh gach mír sa chluaisín&lt;strong&gt;%1&lt;/strong&gt; go rathúil. An bhfuil tú fós ag iarraidh an cluaisín a luchtú agus roinnt míreanna a chailleadh?</translation>
+    </message>
+</context>
+<context>
+    <name>ItemFakeVimLoader</name>
+    <message>
+        <source>FakeVim</source>
+        <translation>FakeVim</translation>
+    </message>
+    <message>
+        <source>FakeVim plugin is part of Qt Creator</source>
+        <translation>Tá an breiseán FakeVim mar chuid de Qt Creator</translation>
+    </message>
+    <message>
+        <source>Emulate Vim editor while editing items.</source>
+        <translation>Aithris a dhéanamh ar eagarthóir Vim agus míreanna á n-eagarthóireacht agat.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemFakeVimSettings</name>
+    <message>
+        <source>Enable FakeVim for Editing Items</source>
+        <translation>Cumasaigh FakeVim le haghaidh Eagarthóireacht Míreanna</translation>
+    </message>
+    <message>
+        <source>Path to Configuration File:</source>
+        <translation>Conair chuig Comhad Cumraíochta:</translation>
+    </message>
+</context>
+<context>
+    <name>ItemImageLoader</name>
+    <message>
+        <source>Images</source>
+        <translation>Íomhánna</translation>
+    </message>
+    <message>
+        <source>Display images.</source>
+        <translation>Taispeáin íomhánna.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemImageSettings</name>
+    <message>
+        <source>Maximum Image &amp;Width:</source>
+        <translation>Uasleithead Ío&amp;mhá:</translation>
+    </message>
+    <message>
+        <source>Maximum width of image displayed in history (set to zero for original size)</source>
+        <translation>Uasleithead na híomhá a thaispeántar sa stair (socraithe go nialas don bhunmhéid)</translation>
+    </message>
+    <message>
+        <source>Maximum Image &amp;Height:</source>
+        <translation>Uasmhéid Íomhá &amp;Airde:</translation>
+    </message>
+    <message>
+        <source>Maximum height of image displayed in history (set to zero for original size)</source>
+        <translation>Uasairde na híomhá a thaispeántar sa stair (socraithe go nialas don bhunmhéid)</translation>
+    </message>
+    <message>
+        <source>&amp;Image editor command:</source>
+        <translation>Ordú &amp;eagarthóra íomhá:</translation>
+    </message>
+    <message>
+        <source>Editor command for supported image formats other than SVG.</source>
+        <translation>Ordú eagarthóra le haghaidh formáidí íomhá tacaithe seachas SVG.</translation>
+    </message>
+    <message>
+        <source>&amp;SVG editor command:</source>
+        <translation>Ordú eagarthóra &amp;SVG:</translation>
+    </message>
+    <message>
+        <source>Editor command for SVG image format.</source>
+        <translation>Ordú eagarthóra le haghaidh formáid íomhá SVG.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemNotesLoader</name>
+    <message>
+        <source>Notes</source>
+        <translation>Nótaí</translation>
+    </message>
+    <message>
+        <source>Display notes for items.</source>
+        <translation>Taispeáin nótaí le haghaidh míreanna.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemNotesSettings</name>
+    <message>
+        <source>Notes Position</source>
+        <translation>Suíomh na Nótaí</translation>
+    </message>
+    <message>
+        <source>Abo&amp;ve Item</source>
+        <translation>M&amp;ír Thuas</translation>
+    </message>
+    <message>
+        <source>Below Ite&amp;m</source>
+        <translation>Thío&amp;s Mír</translation>
+    </message>
+    <message>
+        <source>Beside Ite&amp;m</source>
+        <translation>In aice leis an &amp;Mír</translation>
+    </message>
+    <message>
+        <source>Show Too&amp;l Tip</source>
+        <translation>Taispeáin L&amp;eid Uirlis</translation>
+    </message>
+</context>
+<context>
+    <name>ItemOrderList</name>
+    <message>
+        <source>&amp;Add</source>
+        <translation>C&amp;uir leis</translation>
+    </message>
+    <message>
+        <source>Move up</source>
+        <translation>Bog suas</translation>
+    </message>
+    <message>
+        <source>Move down</source>
+        <translation>Bog síos</translation>
+    </message>
+    <message>
+        <source>Move to the top</source>
+        <translation>Bog go dtí an barr</translation>
+    </message>
+    <message>
+        <source>Move to the bottom</source>
+        <translation>Bog go dtí an bun</translation>
+    </message>
+    <message>
+        <source>&amp;Remove</source>
+        <translation>&amp;Bain</translation>
+    </message>
+</context>
+<context>
+    <name>ItemPinnedLoader</name>
+    <message>
+        <source>Cannot Remove Pinned Items</source>
+        <translation>Ní féidir Míreanna Greamaithe a Bhaint</translation>
+    </message>
+    <message>
+        <source>Unpin items first to remove them.</source>
+        <translation>Díphionnaigh míreanna ar dtús chun iad a bhaint.</translation>
+    </message>
+    <message>
+        <source>Pin</source>
+        <translation>Bioráin</translation>
+    </message>
+    <message>
+        <source>Unpin</source>
+        <translation>Díphionnaigh</translation>
+    </message>
+    <message>
+        <source>Pinned Items</source>
+        <translation>Míreanna Greamaithe</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Pin items to lock them in current row and avoid deletion (unless unpinned).&lt;/p&gt;&lt;p&gt;Provides shortcuts and scripting functionality.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Bioráin míreanna chun iad a ghlasáil sa tsraith reatha agus iad a sheachaint (mura bhfuil siad neamhphionáilte).&lt;/p&gt;&lt;p&gt;Soláthraíonn aicearraí agus feidhmiúlacht scriptithe.&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ItemSyncLoader</name>
+    <message>
+        <source>Open Directory for Synchronization</source>
+        <translation>Oscail Comhadlann le haghaidh Sioncrónaithe</translation>
+    </message>
+    <message>
+        <source>Failed to create synchronization directory</source>
+        <translation>Theip ar chomhadlann sioncrónaithe a chruthú</translation>
+    </message>
+    <message>
+        <source>Synchronize</source>
+        <translation>Sioncrónaigh</translation>
+    </message>
+    <message>
+        <source>Synchronize items and notes with a directory on disk.</source>
+        <translation>Sioncrónaigh míreanna agus nótaí le comhadlann ar dhiosca.</translation>
+    </message>
+    <message>
+        <source>Browse...</source>
+        <translation>Brabhsáil...</translation>
+    </message>
+</context>
+<context>
+    <name>ItemSyncSaver</name>
+    <message>
+        <source>Failed to synchronize tab &quot;%1&quot; with directory &quot;%2&quot;!</source>
+        <translation>Theip ar an gcluaisín &quot;%1&quot; a shioncronú le comhadlann &quot;%2&quot;!</translation>
+    </message>
+    <message>
+        <source>Remove Items?</source>
+        <translation>Bain Míríreanna?</translation>
+    </message>
+    <message>
+        <source>Do you really want to &lt;strong&gt;remove items and associated files&lt;/strong&gt;?</source>
+        <translation>An bhfuil fonn ort &lt;strong&gt;míreanna agus comhaid ghaolmhara a bhaint&lt;/strong&gt;?</translation>
+    </message>
+</context>
+<context>
+    <name>ItemSyncSettings</name>
+    <message>
+        <source>Synchronization Tabs and Directories</source>
+        <translation>Cluaisíní agus Eolairí Sioncrónaithe</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Synchronize contents of &lt;strong&gt;tab&lt;/strong&gt; with directory with given &lt;strong&gt;path&lt;/strong&gt;.&lt;/p&gt;
+&lt;p&gt;Set &lt;strong&gt;empty path&lt;/strong&gt; not to save items in &lt;strong&gt;tab&lt;/strong&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Sioncrónaigh inneachar an &lt;strong&gt;chluaisín&lt;/strong&gt; leis an gcomhadlann leis an &lt;strong&gt;gcosán&lt;/strong&gt; tugtha.&lt;/p&gt;
+&lt;p&gt;Socraigh &lt;strong&gt;cosán folamh&lt;/strong&gt; gan míreanna a shábháil sa &lt;strong&gt;chluaisín&lt;/strong&gt;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Tab Name</source>
+        <translation>Ainm an Chluaisín</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Conair</translation>
+    </message>
+    <message>
+        <source>Files to Item Data Formats</source>
+        <translation>Comhaid go Formáidí Sonraí Míreanna</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Set media type to &lt;strong&gt;-&lt;/strong&gt; (minus character) to ignore files. Any other unknown or hidden files are ignored.&lt;/p&gt;
+&lt;p&gt;Example: Load &lt;strong&gt;txt&lt;/strong&gt; file extension as &lt;strong&gt;text/plain&lt;/strong&gt; media type.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Socraigh cineál meán go &lt;strong&gt;-&lt;/strong&gt; (lúide carachtar) chun neamhaird a dhéanamh de chomhaid. Déantar neamhaird ar aon chomhaid anaithnid nó i bhfolach eile.&lt;/p&gt;
+&lt;p&gt;Sampla: Luchtaigh síneadh comhaid &lt;strong&gt;txt&lt;/strong&gt; mar chineál &lt;strong&gt;téacs / meán plain&lt;/strong&gt;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Extensions</source>
+        <translation>Eisínteachtaí</translation>
+    </message>
+    <message>
+        <source>Item Media Type</source>
+        <translation>Cineál Meán Míre</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTagsLoader</name>
+    <message>
+        <source>Add a Tag</source>
+        <translation>Cuir Clib leis</translation>
+    </message>
+    <message>
+        <source>Remove a Tag</source>
+        <translation>Bain Clib</translation>
+    </message>
+    <message>
+        <source>Toggle Tag %1</source>
+        <translation>Scoránaigh Clib %1</translation>
+    </message>
+    <message>
+        <source>Cannot Remove Items With a Locked Tag</source>
+        <translation>Ní féidir míreanna a bhfuil clib faoi ghlas acu a bhaint</translation>
+    </message>
+    <message>
+        <source>Untag items first to remove them.</source>
+        <translation>Díchlibeáil míreanna ar dtús chun iad a bhaint.</translation>
+    </message>
+    <message>
+        <source>Clear all tags</source>
+        <translation>Glan na clibeanna go léir</translation>
+    </message>
+    <message>
+        <source>Tags</source>
+        <translation>Clibeanna</translation>
+    </message>
+    <message>
+        <source>Display tags for items.</source>
+        <translation>Taispeáin clibeanna le haghaidh míreanna.</translation>
+    </message>
+    <message>
+        <source>Important</source>
+        <translation>Tábhachtach</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTagsSettings</name>
+    <message>
+        <source>Menu items for adding and removing custom tags can be added and customized in Commands dialog.</source>
+        <translation>Is féidir míreanna roghchláir chun clibeanna saincheaptha a chur leis agus a bhaint agus iad a shaincheapadh i dialóg Orduithe.</translation>
+    </message>
+    <message>
+        <source>More info is available on &lt;a href=&quot;https://copyq.readthedocs.io/en/latest/tags.html&quot;&gt;wiki page&lt;/a&gt;.</source>
+        <translation>Tá tuilleadh eolais ar fáil ar an &lt;a href=&quot;https://copyq.readthedocs.io/en/latest/tags.html&quot;&gt;leathanach vicí&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <source>Tag Name</source>
+        <translation>Ainm Clibeanna</translation>
+    </message>
+    <message>
+        <source>Match</source>
+        <translation>Meaitseáil</translation>
+    </message>
+    <message>
+        <source>Style Sheet</source>
+        <translation>Bileog Stíle</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Dath</translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation>Deilbhín</translation>
+    </message>
+    <message>
+        <source>Lock</source>
+        <translation>Faoi Ghlas</translation>
+    </message>
+    <message>
+        <source>Avoid removing item</source>
+        <translation>Seachain mír a bhaint</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTextLoader</name>
+    <message>
+        <source>Text</source>
+        <translation>Téacs</translation>
+    </message>
+    <message>
+        <source>Display plain text and simple HTML items.</source>
+        <translation>Taispeáin gnáththéacs agus míreanna HTML simplí.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTextSettings</name>
+    <message>
+        <source>Save and display HTML and rich text</source>
+        <translation>Sábháil agus taispeáin HTML agus téacs saibhir</translation>
+    </message>
+    <message>
+        <source>Maximum number of lines to display (0 to show all):</source>
+        <translation>Uaslíon na línte le taispeáint (0 chun gach rud a thaispeáint):</translation>
+    </message>
+    <message>
+        <source>Maximum height in pixels (0 for no limit):</source>
+        <translation>Airde uasta i bpicteilíní (0 le haghaidh gan teorainn):</translation>
+    </message>
+    <message>
+        <source>Default style sheet:</source>
+        <translation>Bileog stíl réamhshocraithe:</translation>
+    </message>
+</context>
+<context>
+    <name>LogDialog</name>
+    <message>
+        <source>Log</source>
+        <translation>Logáil</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>CopyQ Items (*.cpq)</source>
+        <translation>Míreanna CopyQ (*.cpq)</translation>
+    </message>
+    <message>
+        <source>&amp;Show/Hide</source>
+        <translation>&amp;Taispeáin/Folaigh</translation>
+    </message>
+    <message>
+        <source>Exit?</source>
+        <translation>Scoir?</translation>
+    </message>
+    <message>
+        <source>Do you want to &lt;strong&gt;exit&lt;/strong&gt; CopyQ?</source>
+        <translation>An bhfuil fonn ort CopyQ &lt;strong&gt;a scoIr&lt;/strong&gt;?</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;Comhad</translation>
+    </message>
+    <message>
+        <source>&amp;Item</source>
+        <translation>&amp;Mír</translation>
+    </message>
+    <message>
+        <source>&amp;Tabs</source>
+        <translation>&amp;Cluaisíní</translation>
+    </message>
+    <message>
+        <source>Rename &amp;Group %1</source>
+        <translation>Athainmnigh &amp;Grúpa %1</translation>
+    </message>
+    <message>
+        <source>Re&amp;name Tab %1</source>
+        <translation>Athainm&amp;nigh Cluaisín %1</translation>
+    </message>
+    <message>
+        <source>Re&amp;move Tab %1</source>
+        <translation>Ba&amp;in Cluaisín %1</translation>
+    </message>
+    <message>
+        <source>Remove Group %1</source>
+        <translation>Bain Grúpa %1</translation>
+    </message>
+    <message>
+        <source>Options for Import</source>
+        <translation>Roghanna le hIompórtáil</translation>
+    </message>
+    <message>
+        <source>Options for Export</source>
+        <translation>Roghanna le haghaidh Easpórtála</translation>
+    </message>
+    <message>
+        <source>Export Error</source>
+        <translation>Earráid Easpórtála</translation>
+    </message>
+    <message>
+        <source>Failed to export file %1!</source>
+        <translation>Theip ar easpórtáil an chomhaid %1!</translation>
+    </message>
+    <message>
+        <source>Import Error</source>
+        <translation>Earráid Iompórtála</translation>
+    </message>
+    <message>
+        <source>Failed to import file %1!</source>
+        <translation>Theip ar iompórtáil an chomhaid %1!</translation>
+    </message>
+    <message>
+        <source>Remove All Tabs in Group?</source>
+        <translation>Bain gach cluaisín sa ghrúpa?</translation>
+    </message>
+    <message>
+        <source>Do you want to remove &lt;strong&gt;all tabs&lt;/strong&gt; in group &lt;strong&gt;%1&lt;/strong&gt;?</source>
+        <translation>An bhfuil fonn ort &lt;strong&gt;gach cluaisín&lt;/strong&gt; i ngrúpa&lt;strong&gt;%1&lt;/strong&gt; a bhaint?</translation>
+    </message>
+    <message>
+        <source>Remove Tab?</source>
+        <translation>Bain Cluaisín?</translation>
+    </message>
+    <message>
+        <source>Do you want to remove tab &lt;strong&gt;%1&lt;/strong&gt;?</source>
+        <translation>An bhfuil fonn ort cluaisín&lt;strong&gt;%1&lt;/strong&gt; a bhaint?</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>&amp;Cuir in Eagar</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Cabhair</translation>
+    </message>
+    <message>
+        <source>&amp;New Tab</source>
+        <translation>&amp;Cluaisín Nua</translation>
+    </message>
+    <message>
+        <source>&amp;Change Tab Icon</source>
+        <translation>&amp;Athraigh Deilbhín an Chluaisín</translation>
+    </message>
+    <message>
+        <source>&amp;Clipboard: %1</source>
+        <translation>&amp;gearrthaisce: %1</translation>
+    </message>
+    <message>
+        <source>CopyQ Error</source>
+        <translation>Earráid CopyQ</translation>
+    </message>
+</context>
+<context>
+    <name>Proxy</name>
+    <message>
+        <source>Information</source>
+        <translation>Eolas</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>&amp;New Item</source>
+        <translation>&amp;Mír Nua</translation>
+    </message>
+    <message>
+        <source>&amp;Import...</source>
+        <translation>&amp;Iompórtáil...</translation>
+    </message>
+    <message>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <source>&amp;Export...</source>
+        <translation>&amp;Easpórtáil...</translation>
+    </message>
+    <message>
+        <source>&amp;Preferences...</source>
+        <translation>&amp;Sainroghanna...</translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation>Ctrl+P</translation>
+    </message>
+    <message>
+        <source>C&amp;ommands...</source>
+        <translation>Or&amp;duithe...</translation>
+    </message>
+    <message>
+        <source>F6</source>
+        <translation>F6</translation>
+    </message>
+    <message>
+        <source>Show &amp;Clipboard Content</source>
+        <translation>Taispeáin Ábhar an &amp;Ghearrthaisce</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+C</source>
+        <translation>Ctrl+Shift+C</translation>
+    </message>
+    <message>
+        <source>&amp;Show Preview</source>
+        <translation>&amp;Taispeáin Réamhamharc</translation>
+    </message>
+    <message>
+        <source>F7</source>
+        <translation>F7</translation>
+    </message>
+    <message>
+        <source>&amp;Toggle Clipboard Storing</source>
+        <translation>&amp;Scoránaigh Stóráil Gearrthaisce</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+X</source>
+        <translation>Ctrl+Shift+X</translation>
+    </message>
+    <message>
+        <source>P&amp;rocess Manager</source>
+        <translation>Bainisteoir P&amp;róisis</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Z</source>
+        <translation>Ctrl+Shift+Z</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>S&amp;coir</translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <source>&amp;Sort Selected Items</source>
+        <translation>&amp;Sórtáil Míreanna Roghnaithe</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <source>&amp;Reverse Selected Items</source>
+        <translation>&amp;Droim ar ais Míreanna Roghnaithe</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+R</source>
+        <translation>Ctrl+Shift+R</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Items</source>
+        <translation>&amp;Greamaigh Míreanna</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Selected Items</source>
+        <translation>&amp;Cóipeáil Míreanna Roghnaithe</translation>
+    </message>
+    <message>
+        <source>&amp;Find</source>
+        <translation>&amp;Aimsigh</translation>
+    </message>
+    <message>
+        <source>Save Item</source>
+        <translation>Sábháil Mír</translation>
+    </message>
+    <message>
+        <source>Cancel Editing</source>
+        <translation>Cealaigh Eagarthóireacht</translation>
+    </message>
+    <message>
+        <source>Undo</source>
+        <translation>Cealaigh</translation>
+    </message>
+    <message>
+        <source>Redo</source>
+        <translation>Déan arís</translation>
+    </message>
+    <message>
+        <source>Bold</source>
+        <translation>Cló trom</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>Iodálach</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>Faoi líne</translation>
+    </message>
+    <message>
+        <source>Strikethrough</source>
+        <translation>Stríoc tríd</translation>
+    </message>
+    <message>
+        <source>Erase Style</source>
+        <translation>Scrios Stíl</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>Cuardaigh</translation>
+    </message>
+    <message>
+        <source>&amp;Show Content...</source>
+        <translation>Taispeáin Ábhar...</translation>
+    </message>
+    <message>
+        <source>F4</source>
+        <translation>F4</translation>
+    </message>
+    <message>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <source>Edit &amp;Notes</source>
+        <translation>Cuir &amp;Nótaí in Eagar</translation>
+    </message>
+    <message>
+        <source>Shift+F2</source>
+        <translation>Shift+F2</translation>
+    </message>
+    <message>
+        <source>E&amp;dit with Editor</source>
+        <translation>Cuir in Ea&amp;gar leis an Eagarthóir</translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation>Ctrl+E</translation>
+    </message>
+    <message>
+        <source>&amp;Action...</source>
+        <translation>&amp;Gníomh...</translation>
+    </message>
+    <message>
+        <source>F5</source>
+        <translation>F5</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>Bog Suas</translation>
+    </message>
+    <message>
+        <source>Ctrl+Up</source>
+        <translation>Ctrl+Suas</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>Bog Síos</translation>
+    </message>
+    <message>
+        <source>Ctrl+Down</source>
+        <translation>Ctrl+Síos</translation>
+    </message>
+    <message>
+        <source>Move to Top</source>
+        <translation>Bog go barr</translation>
+    </message>
+    <message>
+        <source>Ctrl+Home</source>
+        <translation>Ctrl+Baile</translation>
+    </message>
+    <message>
+        <source>Move to Bottom</source>
+        <translation>Bog go Bun</translation>
+    </message>
+    <message>
+        <source>Ctrl+End</source>
+        <translation>Ctrl+Deireadh</translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation>Ctrl+T</translation>
+    </message>
+    <message>
+        <source>R&amp;ename Tab</source>
+        <translation>Cluaisín &amp;Ainm</translation>
+    </message>
+    <message>
+        <source>Ctrl+F2</source>
+        <translation>Ctrl+F2</translation>
+    </message>
+    <message>
+        <source>Re&amp;move Tab</source>
+        <translation>Bai&amp;n an Cluaisín</translation>
+    </message>
+    <message>
+        <source>Ctrl+W</source>
+        <translation>Ctrl+W</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+T</source>
+        <translation>Ctrl+Shift+T</translation>
+    </message>
+    <message>
+        <source>Ne&amp;xt Tab</source>
+        <translation>An Chluaisín E&amp;ile</translation>
+    </message>
+    <message>
+        <source>&amp;Previous Tab</source>
+        <translation>&amp;Cluaisín Roimhe Seo</translation>
+    </message>
+    <message>
+        <source>&amp;Show Log</source>
+        <translation>&amp;Taispeáin Loga</translation>
+    </message>
+    <message>
+        <source>F12</source>
+        <translation>F12</translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation>&amp;Maidir</translation>
+    </message>
+    <message>
+        <source>Open Item Context Menu</source>
+        <translation>Roghchlár Comhthéacs Míre Oscailte</translation>
+    </message>
+    <message>
+        <source>Tab %1 is corrupted or some CopyQ plugins are missing!</source>
+        <translation>Tá Cluaisín %1 truaillithe nó tá roinnt breiseán CopyQ ar iarraidh!</translation>
+    </message>
+    <message>
+        <source>Session name must contain at most 16 characters
+which can be letters, digits, &apos;-&apos; or &apos;_&apos;!</source>
+        <translation>Ní mór 16 charachtar ar a mhéad a bheith in ainm an tseisiúin
+a d&apos;fhéadfadh a bheith ina litreacha, digití, &apos;-&apos; nó &apos;_&apos;!</translation>
+    </message>
+    <message>
+        <source>&amp;clipboard</source>
+        <translation>&amp;gearrthaisce</translation>
+    </message>
+    <message>
+        <source>&lt;HIDDEN&gt;</source>
+        <translation>&lt;HIDDEN&gt;</translation>
+    </message>
+    <message>
+        <source>%1 (%n lines)</source>
+        <translation>%1 (%n líne)</translation>
+    </message>
+    <message>
+        <source>&lt;IMAGE&gt;</source>
+        <translation>&lt;IMAGE&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;ITEMS&gt;</source>
+        <translation>&lt;ITEMS&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;EMPTY&gt;</source>
+        <translation>&lt;EMPTY&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;DATA&gt;</source>
+        <translation>&lt;DATA&gt;</translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation>Cúlspás</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Scrios</translation>
+    </message>
+    <message>
+        <source>Escape</source>
+        <translation>Éalú</translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation>Cló</translation>
+    </message>
+    <message>
+        <source>Foreground</source>
+        <translation>Túlra</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation>Cúlra</translation>
+    </message>
+    <message>
+        <source>A&amp;ctivate Items</source>
+        <translation>G&amp;níomhachtaigh Míreanna</translation>
+    </message>
+    <message>
+        <source>&amp;Remove</source>
+        <translation>&amp;Bain</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>&amp;Cuir in Eagar</translation>
+    </message>
+    <message>
+        <source>&amp;New Tab</source>
+        <translation>Cluaisín &amp;Nua</translation>
+    </message>
+    <message>
+        <source>&amp;Change Tab Icon</source>
+        <translation>&amp;Athraigh Deilbhín an Chluaisín</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Ar dheis</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>Ar chlé</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Cabhair</translation>
+    </message>
+    <message>
+        <source>Shift+F10</source>
+        <translation>Shift+F10</translation>
+    </message>
+    <message>
+        <source>Text Copied (%n lines)</source>
+        <translation>Téacs Cóipeáilte (%n líne)</translation>
+    </message>
+    <message>
+        <source>Text Copied</source>
+        <translation>Téacs Cóipeáilte</translation>
+    </message>
+    <message>
+        <source>Data Copied</source>
+        <translation>Sonraí Cóipeáilte</translation>
+    </message>
+</context>
+<context>
+    <name>Scriptable</name>
+    <message>
+        <source>Show main window and optionally open tab with given name.</source>
+        <translation>Taispeáin an phríomhfhuinneog agus oscail an cluaisín le hainm tugtha.</translation>
+    </message>
+    <message>
+        <source>NAME</source>
+        <translation>AINM</translation>
+    </message>
+    <message>
+        <source>Hide main window.</source>
+        <translation>Folaigh an phríomhfhuinneog.</translation>
+    </message>
+    <message>
+        <source>Show or hide main window.</source>
+        <translation>Taispeáin nó folaigh an phríomhfhuinneog.</translation>
+    </message>
+    <message>
+        <source>Open context menu.</source>
+        <translation>Oscail roghchlár comhthéacs.</translation>
+    </message>
+    <message>
+        <source>Exit server.</source>
+        <translation>Scoir an freastalaí.</translation>
+    </message>
+    <message>
+        <source>Disable or enable clipboard content storing.</source>
+        <translation>Cumasaigh nó díchumasaigh stóráil ábhar ar an ngearrthaisce.</translation>
+    </message>
+    <message>
+        <source>Print clipboard content.</source>
+        <translation>Priontáil ábhar an ghearrthaisce .</translation>
+    </message>
+    <message>
+        <source>MIME</source>
+        <translation>MIME</translation>
+    </message>
+    <message>
+        <source>Print X11 selection content.</source>
+        <translation>Priontáil ábhar roghnúcháin X11.</translation>
+    </message>
+    <message>
+        <source>Paste clipboard to current window
+(may not work with some applications).</source>
+        <translation>Greamaigh gearrthaisce san fhuinneog reatha
+(b&apos;fhéidir nach n-oibreoidh sé le roinnt feidhmchlár).</translation>
+    </message>
+    <message>
+        <source>Copy clipboard from current window
+(may not work with some applications).</source>
+        <translation>Cóipeáil gearrthaisce ón bhfuinneog reatha
+(b&apos;fhéidir nach n-oibreoidh sé le roinnt feidhmchlár).</translation>
+    </message>
+    <message>
+        <source>Set clipboard text.</source>
+        <translation>Socraigh téacs an ghearrthaisce seo.</translation>
+    </message>
+    <message>
+        <source>TEXT</source>
+        <translation>TÉACS</translation>
+    </message>
+    <message>
+        <source>Set clipboard content.</source>
+        <translation>Socraigh ábhar an ghearrthaisce .</translation>
+    </message>
+    <message>
+        <source>DATA</source>
+        <translation>SONRAÍ</translation>
+    </message>
+    <message>
+        <source>Print amount of items in current tab.</source>
+        <translation>Priontáil méid na míreanna sa chluaisín reatha.</translation>
+    </message>
+    <message>
+        <source>Copy item in the row to clipboard.</source>
+        <translation>Cóipeáil mír sa ró chuig an ghearrthaisce.</translation>
+    </message>
+    <message>
+        <source>ROW</source>
+        <translation>RÓ</translation>
+    </message>
+    <message>
+        <source>Copy next item from current tab to clipboard.</source>
+        <translation>Cóipeáil an chéad mhír eile ón gcluaisín reatha go dtí an gearrthaisce seo.</translation>
+    </message>
+    <message>
+        <source>Copy previous item from current tab to clipboard.</source>
+        <translation>Cóipeáil an mhír roimhe seo ón gcluaisín reatha go dtí an gearrthaisce seo.</translation>
+    </message>
+    <message>
+        <source>Add text into clipboard.</source>
+        <translation>Cuir téacs isteach sa ghearrthaisce.</translation>
+    </message>
+    <message>
+        <source>Insert text into given row.</source>
+        <translation>Cuir isteach téacs i sraith áirithe.</translation>
+    </message>
+    <message>
+        <source>Remove items in given rows.</source>
+        <translation>Bain míreanna i sraitheanna áirithe.</translation>
+    </message>
+    <message>
+        <source>ROWS</source>
+        <translation>SRAITHEANNA</translation>
+    </message>
+    <message>
+        <source>Edit items or edit new one.
+Value -1 is for current text in clipboard.</source>
+        <translation>Cuir míreanna in eagar nó cuir ceann nua in eagar.
+Tá luach -1 don téacs reatha sa ghearrthaisce .</translation>
+    </message>
+    <message>
+        <source>Set separator for items on output.</source>
+        <translation>Socraigh deighilteoir d&apos;ítimí ar an aschur.</translation>
+    </message>
+    <message>
+        <source>SEPARATOR</source>
+        <translation>DEIGHILTEOIR</translation>
+    </message>
+    <message>
+        <source>Print raw data of clipboard or item in row.</source>
+        <translation>Priontáil sonraí amh an ghearrthaisce nó na míre i ndiaidh a chéile.</translation>
+    </message>
+    <message>
+        <source>Write raw data to given row.</source>
+        <translation>Scríobh sonraí amh chuig an am a chéile áirithe.</translation>
+    </message>
+    <message>
+        <source>Show action dialog.</source>
+        <translation>Taispeáin dialóg gníomhaíochta.</translation>
+    </message>
+    <message>
+        <source>Run PROGRAM on item text in the rows.
+Use %1 in PROGRAM to pass text as argument.</source>
+        <translation>Rith CLÁR ar théacs míre sna sraitheanna.
+Bain úsáid as %1 i gCLÁR chun téacs a phasáil mar argóint.</translation>
+    </message>
+    <message>
+        <source>PROGRAM</source>
+        <translation>CLÁR</translation>
+    </message>
+    <message>
+        <source>Show tray popup message for TIME milliseconds.</source>
+        <translation>Taispeáin teachtaireacht aníos tráidire ar feadh milleasoicind TIME.</translation>
+    </message>
+    <message>
+        <source>TITLE</source>
+        <translation>TEIDEAL</translation>
+    </message>
+    <message>
+        <source>MESSAGE</source>
+        <translation>TEACHTAIREACHT</translation>
+    </message>
+    <message>
+        <source>TIME</source>
+        <translation>AM</translation>
+    </message>
+    <message>
+        <source>List available tab names.</source>
+        <translation>Liostaigh ainmneacha na gcluaisíní atá ar fáil.</translation>
+    </message>
+    <message>
+        <source>Run command on tab with given name.
+Tab is created if it doesn&apos;t exist.
+Default is the first tab.</source>
+        <translation>Rith an t-ordú ar an gcluaisín leis an ainm tugtha.
+Cruthaítear cluaisín mura bhfuil sé ann.
+Is é an réamhshocrú an chéad chluaisín.</translation>
+    </message>
+    <message>
+        <source>COMMAND</source>
+        <translation>ORDÚ</translation>
+    </message>
+    <message>
+        <source>Remove tab.</source>
+        <translation>Bain cluaisín.</translation>
+    </message>
+    <message>
+        <source>Rename tab.</source>
+        <translation>Athainmnigh cluaisín.</translation>
+    </message>
+    <message>
+        <source>NEW_NAME</source>
+        <translation>AINM_NUA</translation>
+    </message>
+    <message>
+        <source>Export items to file.</source>
+        <translation>Easpórtáil míreanna go comhad.</translation>
+    </message>
+    <message>
+        <source>FILE_NAME</source>
+        <translation>FILE_NAME</translation>
+    </message>
+    <message>
+        <source>Import items from file.</source>
+        <translation>Iompórtáil míreanna ó chomhad.</translation>
+    </message>
+    <message>
+        <source>List all options.</source>
+        <translation>Liostaigh na roghanna go léir.</translation>
+    </message>
+    <message>
+        <source>Get option value.</source>
+        <translation>Faigh luach rogha.</translation>
+    </message>
+    <message>
+        <source>OPTION</source>
+        <translation>ROGHA</translation>
+    </message>
+    <message>
+        <source>Set option value.</source>
+        <translation>Socraigh luach rogha.</translation>
+    </message>
+    <message>
+        <source>VALUE</source>
+        <translation>LUACH</translation>
+    </message>
+    <message>
+        <source>Evaluate script.</source>
+        <translation>Script a mheas.</translation>
+    </message>
+    <message>
+        <source>SCRIPT</source>
+        <translation>SCRIPT</translation>
+    </message>
+    <message>
+        <source>ARGUMENTS</source>
+        <translation>ARGÓINTÍ</translation>
+    </message>
+    <message>
+        <source>Starts or connects to application instance with given session name.</source>
+        <translation>Tosaíonn nó nascann sé le sampla feidhmchláir le hainm seisiúin tugtha.</translation>
+    </message>
+    <message>
+        <source>SESSION</source>
+        <translation>SEISIÚN</translation>
+    </message>
+    <message>
+        <source>Print help for COMMAND or all commands.</source>
+        <translation>Priontáil cabhair le haghaidh COMMAND nó gach ordú.</translation>
+    </message>
+    <message>
+        <source>Print version of program and libraries.</source>
+        <translation>Priontáil leagan den chlár agus de na leabharlanna.</translation>
+    </message>
+    <message>
+        <source>Run application tests (append --help argument for more info).</source>
+        <translation>Rith tástálacha feidhmchláir (cuir argóint --help leis le haghaidh tuilleadh eolais).</translation>
+    </message>
+    <message>
+        <source>Start server in background before running a command.</source>
+        <translation>Tosaigh an freastalaí sa chúlra sula ritheann tú ordú.</translation>
+    </message>
+    <message>
+        <source>Usage: copyq [%1]</source>
+        <translation>Úsáid: copyq [%1]</translation>
+    </message>
+    <message>
+        <source>Starts server if no command is specified.</source>
+        <translation>Tosaíonn an freastalaí mura bhfuil aon ordú sonraithe.</translation>
+    </message>
+    <message>
+        <source>  COMMANDs:</source>
+        <translation>  ORDUITHE:</translation>
+    </message>
+    <message>
+        <source>NOTES:</source>
+        <translation>NÓTAÍ:</translation>
+    </message>
+    <message>
+        <source>  - Use dash argument (-) to read data from standard input.</source>
+        <translation>  - Bain úsáid as argóint fleasc (-) chun sonraí a léamh ó ionchur caighdeánach.</translation>
+    </message>
+    <message>
+        <source>  - Use double-dash argument (--) to read all following arguments without
+    expanding escape sequences (i.e. \n, \t and others).</source>
+        <translation>  - Úsáid argóint fleasc dúbailte (--) chun gach argóint seo a leanas a léamh gan
+    seichimh éalaithe a leathnú (i.e. \n, \t agus eile).</translation>
+    </message>
+    <message>
+        <source>  - Use ? for MIME to print available MIME types (default is &quot;text/plain&quot;).</source>
+        <translation>  - Bain úsáid as? chun MIME chun cineálacha MIME atá ar fáil a phriontáil (is é &quot;text/plain&quot; an réamhshocrú).</translation>
+    </message>
+    <message>
+        <source>Invalid number of arguments!</source>
+        <translation>Líon neamhbhailí argóintí!</translation>
+    </message>
+    <message>
+        <source>Cannot save to file &quot;%1&quot;!</source>
+        <translation>Ní féidir sábháil i gcomhad &quot;%1&quot;!</translation>
+    </message>
+    <message>
+        <source>Cannot import file &quot;%1&quot;!</source>
+        <translation>Ní féidir comhad &quot;%1&quot; a iompórtáil!</translation>
+    </message>
+    <message>
+        <source>CopyQ Clipboard Manager</source>
+        <translation>Bainisteoir Gearrthaisce CopyQ</translation>
+    </message>
+    <message>
+        <source>Command not found!</source>
+        <translation>Níor aimsíodh an t-ordú!</translation>
+    </message>
+    <message>
+        <source>Terminating server.
+</source>
+        <translation>Ag críochnú an fhreastalaí.
+</translation>
+    </message>
+    <message>
+        <source>Invalid option &quot;%1&quot;!</source>
+        <translation>Rogha neamhbhailí &quot;%1&quot;!</translation>
+    </message>
+    <message>
+        <source>Exception</source>
+        <translation>Eisceacht</translation>
+    </message>
+    <message>
+        <source>Exception in %1</source>
+        <translation>Eisceacht i %1</translation>
+    </message>
+    <message>
+        <source>Failed to copy to clipboard!</source>
+        <translation>Theip ar chóipeáil chuig an ghearrthaisce!</translation>
+    </message>
+</context>
+<context>
+    <name>ScriptableProxy</name>
+    <message>
+        <source>Tab with given name doesn&apos;t exist!</source>
+        <translation>Níl cluaisín le hainm tugtha ann!</translation>
+    </message>
+    <message>
+        <source>Tab name cannot be empty!</source>
+        <translation>Ní féidir ainm an chluaisín a bheith folamh!</translation>
+    </message>
+    <message>
+        <source>Tab with given name already exists!</source>
+        <translation>Tá cluaisín le hainm tugtha ann cheana!</translation>
+    </message>
+    <message>
+        <source>*Clipboard Storing Disabled*</source>
+        <translation>*Stóráil ar an nGearrthaisce Díchumasaithe*</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutButton</name>
+    <message>
+        <source>Add shortcut</source>
+        <translation>Cuir aicearra leis</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutDialog</name>
+    <message>
+        <source>New Shortcut</source>
+        <translation>Aicearra Nua</translation>
+    </message>
+    <message>
+        <source>Remove Shortcut</source>
+        <translation>Bain Aicearra</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsWidget</name>
+    <message>
+        <source>Gl&amp;obal</source>
+        <translation>D&amp;omhanda</translation>
+    </message>
+    <message>
+        <source>Global shortcuts can be triggered from any application.</source>
+        <translation>Is féidir aicearraí domhanda a spreagadh ó aon fheidhmchlár.</translation>
+    </message>
+    <message>
+        <source>A&amp;pplication</source>
+        <translation>Fei&amp;dhmchlár</translation>
+    </message>
+    <message>
+        <source>Application shortcuts can only be triggered from the main window.</source>
+        <translation>Ní féidir aicearraí feidhmchláir a ghníomhachtú ach ón bpríomhfhuinneog.</translation>
+    </message>
+    <message>
+        <source>Shortcut already exists!</source>
+        <translation>Tá aicearra ann cheana!</translation>
+    </message>
+    <message>
+        <source>&amp;Find:</source>
+        <translation>&amp;Aimsigh:</translation>
+    </message>
+</context>
+<context>
+    <name>TabDialog</name>
+    <message>
+        <source>Tab name must be non-empty and unique.&lt;br /&gt;
+Tab &lt;b&gt;No&amp;amp;tes&lt;/b&gt; can be opened using &lt;b&gt;Alt+T&lt;/b&gt;.&lt;br /&gt;
+Use &lt;b&gt;/&lt;/b&gt; as path separator in tree view tab layout.</source>
+        <translation>Caithfidh ainm an chluaisín a bheith neamhfholamh agus uathúil.&lt;br /&gt;
+Is féidir &lt;b&gt;Uimhreacha Cluaisín&lt;/b&gt; a oscailt ag baint úsáide as &lt;b&gt;Alt+T&lt;/b&gt;.&lt;br /&gt;
+Bain úsáid &lt;b&gt;as /&lt;/b&gt; mar dheighilteoir cosáin i leagan amach cluaisín amharc crann.</translation>
+    </message>
+    <message>
+        <source>New Tab</source>
+        <translation>Cluaisín Nua</translation>
+    </message>
+    <message>
+        <source>Rename Tab</source>
+        <translation>Athainmnigh Cluaisín</translation>
+    </message>
+    <message>
+        <source>Rename Tab Group</source>
+        <translation>Athainmnigh Grúpa Cluaisíní</translation>
+    </message>
+    <message>
+        <source>&amp;Name:</source>
+        <translation>&amp;Ainm:</translation>
+    </message>
+</context>
+<context>
+    <name>TabPropertiesWidget</name>
+    <message>
+        <source>&amp;Maximum number of items:</source>
+        <translation>&amp;Uasmhéid míreanna:</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation>réamhshocraithe</translation>
+    </message>
+    <message>
+        <source>&amp;Save Items</source>
+        <translation>&amp;Sábháil Míreanna</translation>
+    </message>
+</context>
+<context>
+    <name>TrayMenu</name>
+    <message>
+        <source>Press &apos;/&apos; to search</source>
+        <translation>Brúigh &apos;/&apos; chun cuardach a dhéanamh</translation>
+    </message>
+    <message>
+        <source>Type to search</source>
+        <translation>Clóscríobh chun cuardach a dhéanamh</translation>
+    </message>
+    <message>
+        <source>&amp;%1. %2</source>
+        <translation>&amp;%1. %2</translation>
+    </message>
+</context>
+<context>
+    <name>Utils::FilterLineEdit</name>
+    <message>
+        <source>Regular Expression</source>
+        <translation>Slonn Rialta</translation>
+    </message>
+    <message>
+        <source>Case Insensitive</source>
+        <translation>Cás Neamhíogair</translation>
+    </message>
+</context>
+<context>
+    <name>CommandCompleter</name>
+    <message>
+        <source>Ctrl+Space</source>
+        <translation>Ctrl+Spás</translation>
+    </message>
+</context>
+<context>
+    <name>FilterCompleter</name>
+    <message>
+        <source>Alt+Down</source>
+        <translation>Alt+Síos</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Added Irish (ga) translation for CopyQ

This PR adds support for the Irish language.  I created copyq_ga.ts using utils/lupdate.sh, following the project’s instructions for adding a new language. Since Weblate was unavailable, the file was created and translated manually. It has been verified locally using Qt Linguist.