### PR TITLE
Support localizing command names

### DIFF
--- a/src/common/command.cpp
+++ b/src/common/command.cpp
@@ -3,6 +3,7 @@
 #include "command.h"
 
 #include <QDataStream>
+#include <QLocale>
 
 bool Command::operator==(const Command &other) const
 {
@@ -29,7 +30,8 @@ bool Command::operator==(const Command &other) const
         && globalShortcuts == other.globalShortcuts
         && tab == other.tab
         && outputTab == other.outputTab
-        && internalId == other.internalId;
+        && internalId == other.internalId
+        && nameLocalization == other.nameLocalization;
 }
 
 bool Command::operator!=(const Command &other) const {
@@ -57,6 +59,23 @@ int Command::type() const
     return type;
 }
 
+QString Command::localizedName() const
+{
+    static const QLocale locale;
+    static const QString code1 = locale.name();
+    static const int i = code1.indexOf('_');
+    static const QString code2 = i == -1 ? QString() : code1.mid(0, i);
+
+    const auto value = nameLocalization.value(code1);
+    if (!value.isEmpty())
+        return value;
+
+    if (code2.isEmpty())
+        return name;
+
+    return nameLocalization.value(code2, name);
+}
+
 QDataStream &operator<<(QDataStream &out, const Command &command)
 {
     out << command.name
@@ -82,7 +101,8 @@ QDataStream &operator<<(QDataStream &out, const Command &command)
         << command.globalShortcuts
         << command.tab
         << command.outputTab
-        << command.internalId;
+        << command.internalId
+        << command.nameLocalization;
     Q_ASSERT(out.status() == QDataStream::Ok);
     return out;
 }
@@ -112,7 +132,8 @@ QDataStream &operator>>(QDataStream &in, Command &command)
        >> command.globalShortcuts
        >> command.tab
        >> command.outputTab
-       >> command.internalId;
+       >> command.internalId
+       >> command.nameLocalization;
     Q_ASSERT(in.status() == QDataStream::Ok);
     return in;
 }

--- a/src/common/command.h
+++ b/src/common/command.h
@@ -3,6 +3,7 @@
 #ifndef COMMAND_H
 #define COMMAND_H
 
+#include <QMap>
 #include <QString>
 #include <QStringList>
 #include <QRegularExpression>
@@ -35,6 +36,8 @@ struct Command {
     bool operator!=(const Command &other) const;
 
     int type() const;
+
+    QString localizedName() const;
 
     /** Name or short description. Used for menu item. */
     QString name;
@@ -117,6 +120,8 @@ struct Command {
     QString outputTab;
 
     QString internalId;
+
+    QMap<QString, QString> nameLocalization;
 };
 
 QDataStream &operator<<(QDataStream &out, const Command &command);

--- a/src/gui/commandwidget.cpp
+++ b/src/gui/commandwidget.cpp
@@ -145,6 +145,7 @@ Command CommandWidget::command() const
     c.tab    = ui->comboBoxCopyToTab->currentText();
     c.outputTab = ui->comboBoxOutputTab->currentText();
     c.internalId = m_internalId;
+    c.nameLocalization = m_nameLocalization;
 
     return c;
 }
@@ -153,6 +154,8 @@ void CommandWidget::setCommand(const Command &c)
 {
     m_internalId = c.internalId;
     const bool isEditable = !m_internalId.startsWith(QLatin1String("copyq_"));
+
+    m_nameLocalization = c.nameLocalization;
 
     ui->scrollAreaWidgetContents->setEnabled(isEditable);
     ui->commandEdit->setReadOnly(!isEditable);

--- a/src/gui/commandwidget.h
+++ b/src/gui/commandwidget.h
@@ -3,6 +3,7 @@
 #ifndef COMMANDWIDGET_H
 #define COMMANDWIDGET_H
 
+#include <QMap>
 #include <QWidget>
 
 namespace Ui {
@@ -64,6 +65,7 @@ private:
     Ui::CommandWidget *ui;
     bool m_showAdvanced = true;
     QString m_internalId;
+    QMap<QString, QString> m_nameLocalization;
 };
 
 #endif // COMMANDWIDGET_H

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1346,7 +1346,7 @@ void MainWindow::onActionDialogAccepted(const Command &command, const QStringLis
     auto act = new Action();
     act->setCommand(command.cmd, arguments);
     act->setInputWithFormat(data, command.input);
-    act->setName(command.name);
+    act->setName(command.localizedName());
     act->setData(data);
 
     if ( !command.output.isEmpty() ) {
@@ -1582,7 +1582,7 @@ void MainWindow::addCommandsToItemMenu(ClipboardBrowser *c)
     const auto commands = commandsForMenu(data, c->tabName(), m_menuCommands);
 
     for (const auto &command : commands) {
-        QString name = command.name;
+        QString name = command.localizedName();
         QMenu *_rootMenu, *currentMenu;
         std::tie(_rootMenu, currentMenu) = createSubMenus(&name, m_menuItem);
         auto act = new CommandAction(command, name, currentMenu);
@@ -1617,7 +1617,7 @@ void MainWindow::addCommandsToTrayMenu(const QVariantMap &clipboardData, QList<Q
     QList<QKeySequence> usedShortcuts;
 
     for (const auto &command : commands) {
-        QString name = command.name;
+        QString name = command.localizedName();
         QMenu *rootMenu, *currentMenu;
         std::tie(rootMenu, currentMenu) = createSubMenus(&name, m_trayMenu);
         auto act = new CommandAction(command, name, currentMenu);
@@ -4071,7 +4071,7 @@ Action *MainWindow::action(const QVariantMap &data, const Command &cmd, const QM
         auto act = new Action();
         act->setCommand( cmd.cmd, QStringList(getTextData(data)) );
         act->setInputWithFormat(data, cmd.input);
-        act->setName(cmd.name);
+        act->setName(cmd.localizedName());
         act->setData(data);
 
         if ( !cmd.output.isEmpty() ) {

--- a/src/scriptable/scriptvaluefactory.h
+++ b/src/scriptable/scriptvaluefactory.h
@@ -241,6 +241,11 @@ struct ScriptValueFactory<Command> {
         value.setProperty(QStringLiteral("outputTab"), command.outputTab);
         value.setProperty(QStringLiteral("internalId"), command.internalId);
 
+        QVariantMap nameLocalization;
+        for (auto it = command.nameLocalization.constBegin(); it != command.nameLocalization.constEnd(); ++it)
+            nameLocalization[it.key()] = it.value();
+        value.setProperty(QStringLiteral("nameLocalization"), ::toScriptValue(nameLocalization, engine));
+
         return value;
     }
 
@@ -272,6 +277,13 @@ struct ScriptValueFactory<Command> {
         ::fromScriptValueIfValid( value.property("tab"), engine, &command.tab );
         ::fromScriptValueIfValid( value.property("outputTab"), engine, &command.outputTab );
         ::fromScriptValueIfValid( value.property("internalId"), engine, &command.internalId );
+
+        QJSValue nameLocalization = value.property("nameLocalization");
+        QJSValueIterator it(nameLocalization);
+        while (it.hasNext()) {
+            it.next();
+            command.nameLocalization[it.name()] = it.value().toString();
+        }
 
         return command;
     }
@@ -338,4 +350,3 @@ struct ScriptValueFactory<QVariant> {
         return variant;
     }
 };
-


### PR DESCRIPTION
Only supported by manually editing the INI file.

```ini
[Command]
# Used as fallback if nothing below matches current language
Name = ...
Name_cs = ...
Name_fr = ...
Name_pt_BR = ...
# This would also match pt_PT language code
Name_pt = ...
```

Fixes #3032