### PR TITLE
Docs: Remove invalid www from flatpak links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Install `copyq` package.
 
 ### Other Linux Distributions
 
-Install [Flatpak](https://www.flatpak.org/) and `com.github.hluk.copyq` from
+Install [Flatpak](https://flatpak.org/) and `com.github.hluk.copyq` from
 [Flathub](https://flathub.org/).
 
 ```bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ On **Fedora**, install "copyq" package:
 
     sudo dnf install copyq
 
-On other Linux distributions, you can use `Flatpak <https://www.flatpak.org/>`__
+On other Linux distributions, you can use `Flatpak <https://flatpak.org/>`__
 to install the app:
 
 .. code-block:: bash


### PR DESCRIPTION
The docs have links using the _www_ subdomain, but Flatpak does not use or redirect _www_.

This causes browser certificate warnings when trying to click from the CopyQ docs to Flatpak's site.

It seems [unlikely Flatpak will add support for a www subodmain](https://discourse.flathub.org/t/www-flathub-org-isnt-301ing-to-flathub-org/7941). 