### PR TITLE
Make selected items follow the selected tab name in scripts

### DIFF
--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -1123,7 +1123,7 @@ QJSValue Scriptable::move()
         return throwError(argumentError());
     }
 
-    m_proxy->browserMoveSelected(row);
+    m_proxy->browserMoveSelected(row, m_tabName);
     return QJSValue();
 }
 
@@ -1675,7 +1675,7 @@ QJSValue Scriptable::setData()
         return false;
 
     if (!m_modifyDisplayDataOnly)
-        m_proxy->setSelectedItemsData(mime, m_data.value(mime));
+        m_proxy->setSelectedItemsData(mime, m_data.value(mime), m_tabName);
 
     return true;
 }
@@ -1688,7 +1688,7 @@ QJSValue Scriptable::removeData()
     m_data.remove(mime);
 
     if (!m_modifyDisplayDataOnly)
-        m_proxy->setSelectedItemsData(mime, QVariant());
+        m_proxy->setSelectedItemsData(mime, QVariant(), m_tabName);
 
     return true;
 }
@@ -1816,13 +1816,13 @@ QJSValue Scriptable::selectedTab()
 QJSValue Scriptable::selectedItems()
 {
     m_skipArguments = 0;
-    return toScriptValue( m_proxy->selectedItems(), m_engine );
+    return toScriptValue( m_proxy->selectedItems(m_tabName), m_engine );
 }
 
 QJSValue Scriptable::currentItem()
 {
     m_skipArguments = 0;
-    return m_proxy->currentItem();
+    return m_proxy->currentItem(m_tabName);
 }
 
 QJSValue Scriptable::selectedItemData()
@@ -1831,7 +1831,7 @@ QJSValue Scriptable::selectedItemData()
     if ( !toInt(argument(0), &selectedIndex) )
         return throwError(argumentError());
 
-    return toScriptValue( m_proxy->selectedItemData(selectedIndex), m_engine );
+    return toScriptValue( m_proxy->selectedItemData(selectedIndex, m_tabName), m_engine );
 }
 
 QJSValue Scriptable::setSelectedItemData()
@@ -1841,19 +1841,19 @@ QJSValue Scriptable::setSelectedItemData()
         return throwError(argumentError());
 
     const auto data = toDataMap( argument(1) );
-    return toScriptValue( m_proxy->setSelectedItemData(selectedIndex, data), m_engine );
+    return toScriptValue( m_proxy->setSelectedItemData(selectedIndex, data, m_tabName), m_engine );
 }
 
 QJSValue Scriptable::selectedItemsData()
 {
-    return toScriptValue( m_proxy->selectedItemsData().items, m_engine );
+    return toScriptValue( m_proxy->selectedItemsData(m_tabName).items, m_engine );
 }
 
 void Scriptable::setSelectedItemsData()
 {
     m_skipArguments = 1;
     const VariantMapList dataList{fromScriptValue<QVector<QVariantMap>>( argument(0), m_engine )};
-    m_proxy->setSelectedItemsData(dataList);
+    m_proxy->setSelectedItemsData(dataList, m_tabName);
 }
 
 QJSValue Scriptable::escapeHtml()

--- a/src/scriptable/scriptableproxy.h
+++ b/src/scriptable/scriptableproxy.h
@@ -147,7 +147,7 @@ public slots:
     void browserMoveToClipboard(const QString &tabName, int row);
     void browserSetCurrent(const QString &tabName, int arg1);
     QString browserRemoveRows(const QString &tabName, QVector<int> rows);
-    void browserMoveSelected(int targetRow);
+    void browserMoveSelected(int targetRow, const QString &tabName);
 
     void browserEditRow(const QString &tabName, int arg1, const QString &format);
     void browserEditNew(const QString &tabName, const QString &format, const QByteArray &content, bool changeClipboard);
@@ -186,17 +186,17 @@ public slots:
 
     QString tab(const QString &tabName);
 
-    int currentItem();
+    int currentItem(const QString &tabName);
     bool selectItems(const QString &tabName, const QVector<int> &rows);
 
-    QVector<int> selectedItems();
+    QVector<int> selectedItems(const QString &tabName);
     QString selectedTab();
 
-    QVariantMap selectedItemData(int selectedIndex);
-    bool setSelectedItemData(int selectedIndex, const QVariantMap &data);
+    QVariantMap selectedItemData(int selectedIndex, const QString &tabName);
+    bool setSelectedItemData(int selectedIndex, const QVariantMap &data, const QString &tabName);
 
-    VariantMapList selectedItemsData();
-    void setSelectedItemsData(const VariantMapList &dataList);
+    VariantMapList selectedItemsData(const QString &tabName);
+    void setSelectedItemsData(const VariantMapList &dataList, const QString &tabName);
 
     int createSelection(const QString &tabName);
     int selectionCopy(int id);
@@ -234,7 +234,7 @@ public slots:
 
     int inputDialog(const NamedValueList &values);
 
-    void setSelectedItemsData(const QString &mime, const QVariant &value);
+    void setSelectedItemsData(const QString &mime, const QVariant &value, const QString &tabName);
 
     void filter(const QString &text);
     QString filter();
@@ -299,6 +299,8 @@ signals:
 private:
     ClipboardBrowser *fetchBrowser(const QString &tabName);
 
+    ClipboardBrowser *selectedBrowser();
+
     QVariantMap itemData(const QString &tabName, int i);
     QByteArray itemData(const QString &tabName, int i, const QString &mime);
 
@@ -308,8 +310,8 @@ private:
     template<typename T>
     T getSelectionData(const QString &mime);
 
-    QPersistentModelIndex currentIndex();
-    QList<QPersistentModelIndex> selectedIndexes();
+    QPersistentModelIndex currentIndex(ClipboardBrowser *c = nullptr);
+    QList<QPersistentModelIndex> selectedIndexes(ClipboardBrowser *c = nullptr);
 
     ClipboardBrowser *browserForIndexes(const QList<QPersistentModelIndex> &indexes) const;
 

--- a/src/tests/tests_classes.cpp
+++ b/src/tests/tests_classes.cpp
@@ -332,8 +332,8 @@ void Tests::classItemSelectionGetCurrent()
     RUN("ItemSelection().tab", "CLIPBOARD\n");
     RUN(args << "ItemSelection().tab", tab1 + "\n");
 
-    RUN(args << "ItemSelection().current().tab", "CLIPBOARD\n");
-    RUN(args << "ItemSelection().current().str()", "ItemSelection(tab=\"CLIPBOARD\", rows=[])\n");
+    RUN(args << "ItemSelection().current().tab", tab1 + "\n");
+    RUN(args << "ItemSelection().current().str()", "ItemSelection(tab=\"" + tab1 + "\", rows=[])\n");
     RUN("setCurrentTab" << tab1, "");
     RUN(args << "ItemSelection().current().tab", tab1 + "\n");
     RUN(args << "ItemSelection().current().str()", "ItemSelection(tab=\"" + tab1 + "\", rows=[])\n");

--- a/src/tests/tests_other.cpp
+++ b/src/tests/tests_other.cpp
@@ -637,10 +637,11 @@ void Tests::selectedItems()
     RUN(args << "add" << "D" << "C" << "B" << "A", "");
     RUN(args << "setCurrentTab" << tab1 << "selectItems" << "1" << "2", "true\n");
     RUN("selectedTab", tab1 + "\n");
-    RUN("selectedItems", "1\n2\n");
-    RUN("currentItem", "2\n");
+    RUN(args << "selectedItems", "1\n2\n");
+    RUN(args << "currentItem", "2\n");
 
     const auto print = R"(
+        tab(selectedTab());
         print([selectedTab(), "c:" + currentItem(), "s:" + selectedItems()]);
         print("\\n")
     )";
@@ -661,7 +662,7 @@ void Tests::selectedItems()
     // underlying data needs to be loaded again using plugins.
     const QString tab2 = testTab(2);
     const auto rename = QString("renameTab('%1', '%2')").arg(tab1, tab2);
-    RUN(print << rename << print, tab1 + ",c:2,s:1,2\n" + tab1 + ",c:-1,s:-1,-1\n");
+    RUN(print << rename << print, tab1 + ",c:2,s:1,2\n" + tab1 + ",c:-1,s:\n");
 
     RUN(print, tab2 + ",c:0,s:0\n");
 }


### PR DESCRIPTION
This makes selections and current items/rows/data related only to the tab selected with `tab(...)` in scripts (this is still by default the selected tab when the command started).

This is a saner behavior than ignoring `tab(...)` in some script functions.

Affected script functions:

- `move()`
- `setData()`
- `removeData()`
- `selectedItems()`
- `selectedItemData()`
- `setSelectedItemData()`
- `setSelectedItemsData()`
- `currentItem()`
- `ItemSelection().current()`