### PR TITLE
Center the item after editing notes

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1266,7 +1266,7 @@ void ClipboardBrowser::editNotes()
     if ( !ind.isValid() )
         return;
 
-    scrollTo(ind, PositionAtTop);
+    scrollTo(ind, PositionAtCenter);
     emit requestShow(this);
 
     editItem(ind, mimeItemNotes);


### PR DESCRIPTION
This is to avoid hiding the top items.