### PR TITLE
Fix editing/getting UTF-8 text by default

### DIFF
--- a/src/common/contenttype.h
+++ b/src/common/contenttype.h
@@ -27,8 +27,6 @@ enum {
      */
     removeFormats,
 
-    hasText,
-    hasHtml,
     text,
     html,
     notes,

--- a/src/common/textdata.cpp
+++ b/src/common/textdata.cpp
@@ -77,6 +77,9 @@ QString getTextData(const QByteArray &bytes)
 
 QString getTextData(const QVariantMap &data, const QString &mime)
 {
+    if (mime.isEmpty())
+        return getTextData(data);
+
     const auto it = data.find(mime);
     if ( it != data.constEnd() )
         return getTextData( it->toByteArray() );

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1540,7 +1540,7 @@ void ClipboardBrowser::editSelected()
         QModelIndex ind = currentIndex();
         if ( ind.isValid() ) {
             emit requestShow(this);
-            editItem(ind, mimeText);
+            editItem(ind);
         }
     }
 }

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -329,7 +329,7 @@ class ClipboardBrowser final : public QListView
 
         void setEditorWidget(ItemEditorWidget *editor, bool changeClipboard = false);
 
-        void editItem(const QModelIndex &index, const QString &format, bool changeClipboard = false);
+        void editItem(const QModelIndex &index, const QString &format = QString(), bool changeClipboard = false);
 
         void updateEditorGeometry();
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -136,7 +136,7 @@ bool canPaste()
     return !QApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier);
 }
 
-bool matchData(const QRegularExpression &re, const QVariantMap &data, const QString &format)
+bool matchData(const QRegularExpression &re, const QVariantMap &data, const QString &format = QString())
 {
     if ( re.pattern().isEmpty() )
         return true;
@@ -166,7 +166,7 @@ bool canExecuteCommand(const Command &command, const QVariantMap &data, const QS
     }
 
     // Verify that and text matches given regexp.
-    if ( !matchData(command.re, data, mimeText) )
+    if ( !matchData(command.re, data) )
         return false;
 
     // Verify that window title matches given regexp.

--- a/src/item/clipboarditem.cpp
+++ b/src/item/clipboarditem.cpp
@@ -143,12 +143,6 @@ QVariant ClipboardItem::data(int role) const
 
     case contentType::data:
         return m_data; // copy-on-write, so this should be fast
-    case contentType::hasText:
-        return m_data.contains(mimeText)
-            || m_data.contains(mimeTextUtf8)
-            || m_data.contains(mimeUriList);
-    case contentType::hasHtml:
-        return m_data.contains(mimeHtml);
     case contentType::text:
         return getTextData(m_data);
     case contentType::html:

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -237,6 +237,16 @@ void ItemDelegate::updateItemSize(const QModelIndex &index, QSize itemWidgetSize
 ItemEditorWidget *ItemDelegate::createCustomEditor(
         QWidget *parent, const QModelIndex &index, const QString &format)
 {
+    // If format is empty, try to find most suitable text format to edit.
+    if ( format.isEmpty() ) {
+        const QVariantMap data = m_sharedData->itemFactory->data(index);
+        for (const auto &format2 : {mimeHtml, mimeTextUtf8, mimeText, mimeUriList}) {
+            if ( data.contains(format2) )
+                return createCustomEditor(parent, index, format2);
+        }
+        return nullptr;
+    }
+
     // Refuse editing non-text data
     if ( format != mimeItemNotes && !format.startsWith(QLatin1String("text/")) )
         return nullptr;

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -456,7 +456,7 @@ private:
     void getActionData(int actionId);
     void setActionData();
 
-    QByteArray getClipboardData(const QString &mime, ClipboardMode mode = ClipboardMode::Clipboard);
+    QByteArray getClipboardData(const QString &mime = QString(), ClipboardMode mode = ClipboardMode::Clipboard);
     bool hasClipboardFormat(const QString &mime, ClipboardMode mode = ClipboardMode::Clipboard);
 
     bool canSynchronizeSelection(ClipboardMode targetMode);

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2590,6 +2590,11 @@ QByteArray ScriptableProxy::getClipboardData(const QString &mime, ClipboardMode 
     if (mime == "?")
         return data->formats().join("\n").toUtf8() + '\n';
 
+    if (mime.isEmpty()) {
+        const auto dataMap = cloneData(data, {mimeTextUtf8, mimeText, mimeUriList});
+        return getTextData(dataMap).toUtf8();
+    }
+
     return cloneData(data, QStringList(mime)).value(mime).toByteArray();
 }
 
@@ -2652,6 +2657,9 @@ QByteArray ScriptableProxy::itemData(const QString &tabName, int i, const QStrin
 
     if (mime == mimeItems)
         return serializeData(data);
+
+    if (mime.isEmpty())
+        return getTextData(data).toUtf8();
 
     return data.value(mime).toByteArray();
 }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -56,6 +56,7 @@ private slots:
 
     void commandsAddRead();
     void commandsWriteRead();
+    void commandsReadUtf8ByDefault();
     void commandChange();
 
     void commandSetCurrentTab();

--- a/src/tests/tests_other.cpp
+++ b/src/tests/tests_other.cpp
@@ -792,7 +792,7 @@ void Tests::networkPost()
     const auto script = R"(
         r = NetworkRequest();
         r.headers['Content-Type'] = 'text/plain';
-        s = r.request('POST', 'https://httpbin.org/post?hello=1', 'Hello');
+        s = r.request('POST', 'https://httpbun.org/post?hello=1', 'Hello');
         json = s.data;
         try {
             data = JSON.parse(str(json));

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -227,6 +227,13 @@ void Tests::commandsWriteRead()
         CommandException, "Unexpected uneven number of mimeType/data arguments");
 }
 
+void Tests::commandsReadUtf8ByDefault()
+{
+    RUN("add({[mimeText]: 'A', [mimeTextUtf8]: 'B'})", "");
+    RUN("read(mimeText, 0)", "A");
+    RUN("read(0)", "B");
+}
+
 void Tests::commandChange()
 {
     RUN("add" << "C" << "B" << "A", "");


### PR DESCRIPTION
By default the app should provide UTF-8 text
(`text/plain;charset=utf-8`) and fallback to `text/plain` or if unavailable to `text/uri-list`.

Fixes #3093