### PR TITLE
Add wastebin feature for creating burner secrets

### DIFF
--- a/src/common/appconfig.h
+++ b/src/common/appconfig.h
@@ -543,6 +543,22 @@ struct frameless_window : Config<bool> {
     }
 };
 
+struct wastebin_enabled : Config<bool> {
+    static QString name() { return QStringLiteral("wastebin_enabled"); }
+    static Value defaultValue() { return false; }
+    static const char *description() {
+        return "Enable 'Create burner secret in wastebin' feature in context menu";
+    }
+};
+
+struct wastebin_endpoint : Config<QString> {
+    static QString name() { return QStringLiteral("wastebin_endpoint"); }
+    static Value defaultValue() { return QStringLiteral("https://bin.rso.dev"); }
+    static const char *description() {
+        return "Wastebin endpoint URL for uploading burner secrets";
+    }
+};
+
 } // namespace Config
 
 class AppConfig final

--- a/src/gui/configurationmanager.cpp
+++ b/src/gui/configurationmanager.cpp
@@ -344,6 +344,9 @@ void ConfigurationManager::initOptions()
     bind<Config::close_on_unfocus_delay_ms>();
 
     bind<Config::frameless_window>();
+
+    bind<Config::wastebin_enabled>(m_tabGeneral->checkBoxWastebinEnabled);
+    bind<Config::wastebin_endpoint>(m_tabGeneral->lineEditWastebinEndpoint);
 }
 
 template <typename Config, typename Widget>

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -35,6 +35,7 @@ class Theme;
 class TrayMenu;
 class ToolBar;
 class QModelIndex;
+class QNetworkReply;
 struct NotificationButton;
 
 Q_DECLARE_METATYPE(QPersistentModelIndex)
@@ -497,6 +498,11 @@ private:
     void moveDown();
     void moveToTop();
     void moveToBottom();
+
+    void createWastebinSecret();
+    QString generateRandomPassword();
+    void uploadToWastebin(const QString &text, const QString &endpoint, const QString &password);
+    void handleWastebinResponse(QNetworkReply *reply, const QString &password);
 
     void onBrowserCreated(ClipboardBrowser *browser);
     void onBrowserLoaded(ClipboardBrowser *browser);

--- a/src/gui/menuitems.cpp
+++ b/src/gui/menuitems.cpp
@@ -128,6 +128,9 @@ MenuItems menuItems()
     addMenuItem( items, Actions::Item_MoveToBottom, QObject::tr("Move to Bottom"),
                   QStringLiteral("move_to_bottom"),  QObject::tr("Ctrl+End"), QStringLiteral("go-bottom"), IconAnglesDown );
 
+    addMenuItem( items, Actions::Item_CreateWastebinSecret, QObject::tr("Create &Burner Secret in Wastebin"),
+                  QStringLiteral("create_wastebin_secret"), QKeySequence(), QStringLiteral(""), IconGlobe );
+
     addMenuItem( items, Actions::Tabs_NewTab, QObject::tr("&New Tab"),
                   QStringLiteral("new_tab"), QObject::tr("Ctrl+T"), QStringLiteral(":/images/tab_new") );
     addMenuItem( items, Actions::Tabs_RenameTab, QObject::tr("R&ename Tab"),

--- a/src/gui/menuitems.h
+++ b/src/gui/menuitems.h
@@ -56,6 +56,8 @@ enum Id {
     Item_MoveToTop,
     Item_MoveToBottom,
 
+    Item_CreateWastebinSecret,
+
     Tabs_NewTab,
     Tabs_RenameTab,
     Tabs_RemoveTab,

--- a/src/ui/configtabgeneral.ui
+++ b/src/ui/configtabgeneral.ui
@@ -288,6 +288,49 @@
        </widget>
       </item>
       <item>
+       <widget class="QGroupBox" name="groupBoxWastebin">
+        <property name="title">
+         <string>Wastebin</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayoutWastebin">
+         <item>
+          <widget class="QCheckBox" name="checkBoxWastebinEnabled">
+           <property name="toolTip">
+            <string>Enable 'Create burner secret in wastebin' feature in context menu</string>
+           </property>
+           <property name="text">
+            <string>Enable Wastebin Feature</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutWastebinEndpoint">
+           <item>
+            <widget class="QLabel" name="labelWastebinEndpoint">
+             <property name="text">
+              <string>Wastebin Endpoint:</string>
+             </property>
+             <property name="buddy">
+              <cstring>lineEditWastebinEndpoint</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEditWastebinEndpoint">
+             <property name="toolTip">
+              <string>Wastebin endpoint URL for uploading burner secrets</string>
+             </property>
+             <property name="text">
+              <string>https://bin.rso.dev</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This update introduces a new feature that allows users to create burner secrets in a wastebin. It includes the addition of configuration options for enabling the feature and specifying the wastebin endpoint. The context menu is updated to include an action for creating a wastebin secret, and the necessary logic for handling uploads and responses is implemented in the main window.

Key changes:
- Added `wastebin_enabled` and `wastebin_endpoint` configuration options.
- Implemented `createWastebinSecret`, `uploadToWastebin`, and `handleWastebinResponse` methods in `MainWindow`.
- Updated UI to include controls for the wastebin feature in the general configuration tab.
- Added context menu action for creating a burner secret in the wastebin.