### PR TITLE
macOS: Fix build - use macos-14 runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-14
             buildname: macOS 13
             bundle_suffix: '-macos-13'
             cmake_preset: macOS-13


### PR DESCRIPTION
This is due to Homebrew dropping the support for macOS 13.