### PR TITLE
Avoid directly deleting menu items

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -340,7 +340,7 @@ void deleteSubMenus(QObject *parent)
 {
     for (auto subMenu : parent->findChildren<QMenu*>()) {
         if (subMenu->parent() == parent)
-            delete subMenu;
+            subMenu->deleteLater();
     }
 }
 


### PR DESCRIPTION
This can potentially cause app to crash.