### PR TITLE
Avoid expiring tab data if configuration changes

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -18,6 +18,7 @@
 #include "item/itemstore.h"
 #include "item/itemwidget.h"
 #include "item/persistentdisplayitem.h"
+#include "item/serialize.h"
 
 #include <QApplication>
 #include <QDrag>
@@ -35,7 +36,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
-#include <functional>
 #include <memory>
 
 namespace {
@@ -1658,7 +1658,7 @@ void ClipboardBrowser::setItemsData(const QMap<QPersistentModelIndex, QVariantMa
         m.setItemsData(itemsData);
 }
 
-bool ClipboardBrowser::loadItems()
+bool ClipboardBrowser::loadItems(const QByteArray &itemData)
 {
     if ( isLoaded() )
         return true;
@@ -1671,6 +1671,11 @@ bool ClipboardBrowser::loadItems()
 
     if ( !isLoaded() )
         return false;
+
+    if ( !itemData.isEmpty() ) {
+        QDataStream stream(itemData);
+        deserializeData(&m, &stream);
+    }
 
     d.rowsInserted(QModelIndex(), 0, m.rowCount());
     if ( hasFocus() )

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -181,7 +181,7 @@ class ClipboardBrowser final : public QListView
          * This function does nothing if model is disabled (e.g. loading failed previously).
          * @see setID, saveItems
          */
-        bool loadItems();
+        bool loadItems(const QByteArray &itemData = QByteArray());
 
         /**
          * Return true only if row is filtered and should be hidden.

--- a/src/gui/clipboardbrowserplaceholder.cpp
+++ b/src/gui/clipboardbrowserplaceholder.cpp
@@ -74,7 +74,7 @@ bool ClipboardBrowserPlaceholder::setTabName(const QString &tabName)
         if ( !m_browser->setTabName(tabName) )
             return false;
         reloadBrowser();
-    } else {
+    } else if (m_storeItems) {
         unloadBrowser();
         if ( !moveItems(m_tabName, tabName) ) {
             if ( isVisible() )

--- a/src/gui/clipboardbrowserplaceholder.cpp
+++ b/src/gui/clipboardbrowserplaceholder.cpp
@@ -6,10 +6,13 @@
 #include "common/log.h"
 #include "common/timer.h"
 #include "item/itemstore.h"
+#include "item/serialize.h"
 #include "gui/clipboardbrowser.h"
 #include "gui/iconfactory.h"
 #include "gui/icons.h"
 
+#include <QDataStream>
+#include <QIODevice>
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -41,7 +44,7 @@ ClipboardBrowser *ClipboardBrowserPlaceholder::createBrowser()
     c->setStoreItems(m_storeItems);
     c->setMaxItemCount(m_maxItemCount);
 
-    if ( !c->loadItems() ) {
+    if ( !c->loadItems(m_data) ) {
         createLoadButton();
         return nullptr;
     }
@@ -199,6 +202,14 @@ void ClipboardBrowserPlaceholder::unloadBrowser()
         return;
 
     COPYQ_LOG( QString("Tab \"%1\": Unloading").arg(m_tabName) );
+
+    // Keep unsaved items in memory until expiration.
+    m_data.clear();
+    if ( !m_storeItems && m_browser->isLoaded() ) {
+        QDataStream stream(&m_data, QIODevice::WriteOnly);
+        if ( !serializeData(*m_browser->model(), &stream) )
+            m_data.clear();
+    }
 
     // WORKAROUND: This is needed on macOS, to fix refocusing correct widget later.
     m_browser->clearFocus();

--- a/src/gui/clipboardbrowserplaceholder.h
+++ b/src/gui/clipboardbrowserplaceholder.h
@@ -5,6 +5,7 @@
 
 #include "gui/clipboardbrowsershared.h"
 
+#include <QByteArray>
 #include <QString>
 #include <QTimer>
 #include <QWidget>
@@ -82,4 +83,5 @@ private:
     ClipboardBrowserSharedPtr m_sharedData;
 
     QTimer m_timerExpire;
+    QByteArray m_data;
 };

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -640,6 +640,8 @@ private:
     void onItemClicked();
     void onItemDoubleClicked();
 
+    bool setTabName(ClipboardBrowserPlaceholder *placeholder, const QString &newName);
+
     ConfigurationManager *cm;
     Ui::MainWindow *ui;
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -430,6 +430,8 @@ signals:
 
     void sendActionData(int actionId, const QByteArray &bytes);
 
+    void clipboardTabChanged();
+
 protected:
     bool eventFilter(QObject *object, QEvent *ev) override;
     void keyPressEvent(QKeyEvent *event) override;
@@ -588,8 +590,6 @@ private:
 
     QAction *addTrayAction(Actions::Id id);
 
-    void updateTabIcon(const QString &newName, const QString &oldName);
-
     template <typename Receiver, typename ReturnType>
     QAction *addItemAction(Actions::Id id, Receiver *receiver, ReturnType (Receiver::* slot)());
 
@@ -640,7 +640,16 @@ private:
     void onItemClicked();
     void onItemDoubleClicked();
 
-    bool setTabName(ClipboardBrowserPlaceholder *placeholder, const QString &newName);
+    /**
+     * Update tab name in placeholder and configuration.
+     * Return true on success, false if setting tab name in placeholder failed
+     * (most likely failure to move the tab data).
+     */
+    bool updateTabName(
+        ClipboardBrowserPlaceholder *placeholder,
+        const QString &newName,
+        AppConfig *appConfig,
+        Tabs *tabs);
 
     ConfigurationManager *cm;
     Ui::MainWindow *ui;

--- a/src/gui/tabicons.cpp
+++ b/src/gui/tabicons.cpp
@@ -15,20 +15,7 @@
 
 namespace {
 
-QHash<QString, QString> tabIcons()
-{
-    QHash<QString, QString> icons;
-
-    Settings settings;
-    const int size = settings.beginReadArray("Tabs");
-    for(int i = 0; i < size; ++i) {
-        settings.setArrayIndex(i);
-        icons.insert(settings.value("name").toString(),
-                     settings.value("icon").toString());
-    }
-
-    return icons;
-}
+const QString tabsGroup = QStringLiteral("Tabs");
 
 QByteArray tabNameFromFileSuffix(QByteArray base64Suffix)
 {
@@ -68,7 +55,7 @@ QList<QString> savedTabs()
 QString getIconNameForTabName(const QString &tabName)
 {
     Settings settings;
-    const int size = settings.beginReadArray("Tabs");
+    const int size = settings.beginReadArray(tabsGroup);
     for(int i = 0; i < size; ++i) {
         settings.setArrayIndex(i);
         if (settings.value("name").toString() == tabName)
@@ -78,21 +65,23 @@ QString getIconNameForTabName(const QString &tabName)
     return QString();
 }
 
-void setIconNameForTabName(const QString &name, const QString &icon)
+void setIconNameForTabName(const QString &tabName, const QString &icon)
 {
-    QHash<QString, QString> icons = tabIcons();
-    icons[name] = icon;
-
     Settings settings;
-    settings.beginWriteArray("Tabs");
-    int i = 0;
-
-    for (auto it = icons.constBegin(); it != icons.constEnd(); ++it) {
-        settings.setArrayIndex(i++);
-        settings.setValue("name", it.key());
-        settings.setValue("icon", it.value());
+    const int size = settings.beginReadArray(tabsGroup);
+    for(int i = 0; i < size; ++i) {
+        settings.setArrayIndex(i);
+        if (settings.value("name").toString() == tabName) {
+            settings.setValue("icon", icon);
+            return;
+        }
     }
+    settings.endArray();
 
+    settings.beginWriteArray(tabsGroup, size + 1);
+    settings.setArrayIndex(size);
+    settings.setValue("name", tabName);
+    settings.setValue("icon", icon);
     settings.endArray();
 }
 

--- a/src/gui/tabicons.h
+++ b/src/gui/tabicons.h
@@ -14,7 +14,7 @@ QList<QString> savedTabs();
 
 QString getIconNameForTabName(const QString &tabName);
 
-void setIconNameForTabName(const QString &name, const QString &icon);
+void setIconNameForTabName(const QString &tabName, const QString &icon);
 
 QIcon getIconForTabName(const QString &tabName);
 

--- a/src/gui/tabtree.cpp
+++ b/src/gui/tabtree.cpp
@@ -591,11 +591,12 @@ void TabTree::dropEvent(QDropEvent *event)
 
         QList<QTreeWidgetItem*> newTabs;
         QList<int> indexes;
+        QList<QPersistentModelIndex> toDelete;
         for ( QTreeWidgetItemIterator it(topLevelItem(0)); *it; ++it ) {
             auto item = *it;
             // Remove empty groups.
             if ( isEmptyTabGroup(item) ) {
-                deleteItem(item);
+                toDelete.append(indexFromItem(item));
             } else {
                 const int oldIndex = getTabIndex(item);
                 if (oldIndex != -1) {
@@ -605,10 +606,19 @@ void TabTree::dropEvent(QDropEvent *event)
             }
         }
 
-        m_tabs = std::move(newTabs);
-        emit tabsMoved(oldPrefix, newPrefix, indexes);
+        for (const auto &index : toDelete) {
+            if (!index.isValid())
+                continue;
+
+            QTreeWidgetItem *item = itemFromIndex(index);
+            if (item)
+                deleteItem(item);
+        }
 
         updateSize();
+
+        m_tabs = std::move(newTabs);
+        emit tabsMoved(oldPrefix, newPrefix, indexes);
     } else {
         event->ignore();
     }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -328,6 +328,8 @@ private slots:
 
     void handleUnexpectedTypes();
 
+    void expireTabs();
+
 private:
     void navigationTestInit();
     void navigationTestDownUp(const QString &down, const QString &up);

--- a/src/tests/tests_expire.cpp
+++ b/src/tests/tests_expire.cpp
@@ -1,6 +1,59 @@
+#include "test_utils.h"
 #include "tests.h"
+
+#include "common/settings.h"
 
 void Tests::expireTabs()
 {
-    // TODO: Configure not storing items and expiration.
+    {
+        Settings settings;
+        settings.setValue("Options/tabs", QStringList{"temp1", clipboardTabName});
+        settings.setValue("Options/tray_tab", "temp1");
+        settings.beginWriteArray("Tabs");
+        settings.setArrayIndex(0);
+        settings.setValue("name", "temp1");
+        settings.setValue("icon", "x");
+        settings.setValue("store_items", false);
+        settings.endArray();
+    }
+
+    // Trigger configuration reload.
+    RUN("config('maxitems', 10)", "10\n");
+
+    RUN("tab", "temp1\n" + QString(clipboardTabName) + "\n");
+
+    RUN("add" << "A", "");
+
+    // Trigger configuration reload.
+    RUN("config('maxitems', 11)", "11\n");
+
+    #define VERIFY_TEMPORARY_TAB_EXIST(tabName) \
+    do { \
+        RUN("tab", QStringLiteral(tabName) + "\n" + QString(clipboardTabName) + "\n"); \
+        RUN("read(0)", "A"); \
+        RUN("size()", "1\n"); \
+        Settings settings; \
+        const QStringList expectedTabs{tabName, clipboardTabName}; \
+        QCOMPARE(settings.value("Options/tabs"), expectedTabs); \
+        QCOMPARE(settings.value("Options/tray_tab"), tabName); \
+        settings.beginReadArray("Tabs"); \
+        settings.setArrayIndex(0); \
+        QCOMPARE(settings.value("name"), tabName); \
+        QCOMPARE(settings.value("icon"), "x"); \
+        QCOMPARE(settings.value("store_items").toBool(), false); \
+        settings.endArray(); \
+    } while(false)
+
+    VERIFY_TEMPORARY_TAB_EXIST("temp1");
+
+    RUN("renameTab('temp1', 'temp2')", "");
+
+    VERIFY_TEMPORARY_TAB_EXIST("temp2");
+
+    // Restart server.
+    TEST( m_test->stopServer() );
+    TEST( m_test->startServer() );
+
+    RUN("tab", "temp2\n" + QString(clipboardTabName) + "\n");
+    RUN("size()", "0\n");
 }

--- a/src/tests/tests_expire.cpp
+++ b/src/tests/tests_expire.cpp
@@ -1,0 +1,6 @@
+#include "tests.h"
+
+void Tests::expireTabs()
+{
+    // TODO: Configure not storing items and expiration.
+}

--- a/src/tests/tests_other.cpp
+++ b/src/tests/tests_other.cpp
@@ -193,13 +193,16 @@ void Tests::tabRemove()
 
 void Tests::tabIcon()
 {
-    const QString tab = testTab(1);
+    const QString tab0 = testTab(1);
+    const QString tab = testTab(2);
     const QString icon = ":/images/icon";
 
     RUN("tab" << tab << "add" << "", "");
     RUN("tabIcon" << tab, "\n");
+    RUN("tabicon" << tab0, "\n");
     RUN("tabicon" << tab << icon, "");
     RUN("tabIcon" << tab, icon + "\n");
+    RUN("tabicon" << tab0, "\n");
     RUN("tabIcon" << tab << "", "");
     RUN("tabicon" << tab, "\n");
 }


### PR DESCRIPTION
Fixes #3172

Also, enables renaming tabs with item storing disabled.

Renamed tabs will have the same properties as the old one.