### PR TITLE
Fix log label and showing correct log record order

### DIFF
--- a/plugins/itemencrypted/CMakeLists.txt
+++ b/plugins/itemencrypted/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(copyq_plugin_itemencrypted_SOURCES
     ../../src/common/command.cpp
     ../../src/common/config.cpp
-    ../../src/common/log.cpp
     ../../src/common/mimetypes.cpp
     ../../src/common/shortcuts.cpp
     ../../src/common/textdata.cpp

--- a/plugins/itemimage/CMakeLists.txt
+++ b/plugins/itemimage/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(copyq_plugin_itemimage_SOURCES
     ../../src/common/action.cpp
-    ../../src/common/log.cpp
     ../../src/common/mimetypes.cpp
     ../../src/common/temporaryfile.cpp
     ../../src/item/itemeditor.cpp

--- a/plugins/itemimage/itemimage.cpp
+++ b/plugins/itemimage/itemimage.cpp
@@ -3,7 +3,6 @@
 #include "itemimage.h"
 #include "ui_itemimagesettings.h"
 
-#include "common/contenttype.h"
 #include "common/mimetypes.h"
 #include "item/itemeditor.h"
 #include "gui/pixelratio.h"

--- a/plugins/itemsync/CMakeLists.txt
+++ b/plugins/itemsync/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(copyq_plugin_itemsync_SOURCES
     ../../src/item/itemwidgetwrapper.cpp
     ../../src/common/config.cpp
-    ../../src/common/log.cpp
     ../../src/common/mimetypes.cpp
     ../../src/gui/iconfont.cpp
     ../../src/gui/iconselectbutton.cpp

--- a/plugins/itemsync/itemsync.cpp
+++ b/plugins/itemsync/itemsync.cpp
@@ -7,7 +7,6 @@
 
 #include "common/appconfig.h"
 #include "common/contenttype.h"
-#include "common/log.h"
 #include "common/mimetypes.h"
 #include "common/regexp.h"
 #include "gui/iconselectbutton.h"
@@ -22,6 +21,7 @@
 #endif
 
 #include <QBoxLayout>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
@@ -424,9 +424,8 @@ bool ItemSyncSaver::saveItems(const QString &tabName, const QAbstractItemModel &
     QStringList savedFiles;
 
     if ( !m_watcher->isValid() ) {
-        log( tr("Failed to synchronize tab \"%1\" with directory \"%2\"!")
-             .arg(tabName, path),
-             LogError );
+        qCritical() << tr("Failed to synchronize tab \"%1\" with directory \"%2\"!")
+             .arg(tabName, path);
         return false;
     }
 

--- a/plugins/itemtags/CMakeLists.txt
+++ b/plugins/itemtags/CMakeLists.txt
@@ -3,7 +3,6 @@ set(copyq_plugin_itemtags_SOURCES
     ../../src/item/itemsaverwrapper.cpp
     ../../src/common/command.cpp
     ../../src/common/config.cpp
-    ../../src/common/log.cpp
     ../../src/common/mimetypes.cpp
     ../../src/common/textdata.cpp
     ../../src/gui/iconselectbutton.cpp

--- a/src/app/clipboardclient.cpp
+++ b/src/app/clipboardclient.cpp
@@ -44,12 +44,10 @@ QCoreApplication *createClientApplication(int &argc, char **argv, const QStringL
     if ( arguments.size() > 1 && arguments[0] == QLatin1String("--clipboard-access") ) {
         const auto app = platformNativeInterface()
                 ->createClipboardProviderApplication(argc, argv);
-        setLogLabel(arguments[1].toUtf8());
         return app;
     }
 
     const auto app = platformNativeInterface()->createClientApplication(argc, argv);
-    setLogLabel("Client");
     return app;
 }
 

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -96,7 +96,6 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     , m_shortcutActions()
     , m_ignoreKeysTimer()
 {
-    setLogLabel("Server");
     cleanUpLogFilesAfterMs(30000);
 
     m_server = new Server(clipboardServerName(), this);

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -191,8 +191,15 @@ QByteArray readLogFile(int maxReadSize)
 
         while (!f.atEnd()) {
             const QByteArray line = f.readLine();
+            // Sort only by timestamp to preserve the relative order of records
+            // with the same timestamp.
+            constexpr auto timestampSize =
+                std::char_traits<char>::length("yyyy-MM-dd hh:mm:ss.zzz");
             const auto it = std::upper_bound(
-                sortedLogLines.begin(), sortedLogLines.end(), line, std::greater<>());
+                sortedLogLines.begin(), sortedLogLines.end(), line,
+                [](const QByteArray &a, const QByteArray &b) {
+                    return a.mid(1, timestampSize) >= b.mid(1, timestampSize);
+                });
             if (it == sortedLogLines.end() && currentSize >= maxReadSize)
                 continue;
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -118,9 +118,6 @@ QString getLogFileName()
     QDir dir(path);
     dir.mkpath(QStringLiteral("."));
 
-    if (logLabel() == "Server")
-        return QStringLiteral("%1/copyq.log").arg(path);
-
     const QString dateTime = QDateTime::currentDateTime()
         .toString(QStringLiteral("yyyyMMdd"));
     return QStringLiteral("%3/copyq-%1-%2.log")

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -11,7 +11,6 @@
 #include <QVariant>
 
 #include <QStandardPaths>
-#include <functional>
 
 namespace {
 

--- a/src/common/temporaryfile.cpp
+++ b/src/common/temporaryfile.cpp
@@ -2,9 +2,8 @@
 
 #include "temporaryfile.h"
 
-#include "common/log.h"
-
 #include <QDir>
+#include <QDebug>
 #include <QTemporaryFile>
 
 bool openTemporaryFile(QTemporaryFile *file, const QString &suffix)
@@ -14,15 +13,14 @@ bool openTemporaryFile(QTemporaryFile *file, const QString &suffix)
     file->setFileTemplate(tmpPath);
 
     if ( !file->open() ) {
-        log( QString("Failed to open temporary file \"%1\" (template \"%2\")")
-             .arg(file->fileName(), tmpPath),
-             LogError );
+        qCritical() << "Failed to open temporary file"
+            << file->fileName() << "template" << tmpPath << ":" << file->errorString();
         return false;
     }
 
     if ( !file->setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner) ) {
-        log( QString("Failed set permissions to temporary file \"%1\"")
-             .arg(file->fileName()), LogError );
+        qCritical() << "Failed set permissions to temporary file"
+            << file->fileName() << ":" << file->errorString();
         return false;
     }
 

--- a/src/gui/logdialog.cpp
+++ b/src/gui/logdialog.cpp
@@ -184,7 +184,7 @@ class ThreadNameDecorator final : public Decorator
 {
 public:
     explicit ThreadNameDecorator(const QFont &font, QObject *parent)
-        : Decorator(QRegularExpression("<[A-Za-z]+-[0-9-]+>"), parent)
+        : Decorator(QRegularExpression("<[A-Za-z/]+-[0-9-]+>"), parent)
     {
         QFont boldFont = font;
         boldFont.setBold(true);
@@ -203,9 +203,9 @@ private:
 
         const auto bg =
                 text.startsWith("<Server-") ? QColor::fromRgb(255, 255, 200)
-              : text.startsWith("<monitor") ? QColor::fromRgb(220, 240, 255)
-              : text.startsWith("<provide") ? QColor::fromRgb(220, 255, 220)
-              : text.startsWith("<synchronize") ? QColor::fromRgb(220, 255, 240)
+              : text.startsWith("<cmd/monitor") ? QColor::fromRgb(220, 240, 255)
+              : text.startsWith("<cmd/provide") ? QColor::fromRgb(220, 255, 220)
+              : text.startsWith("<cmd/synchronize") ? QColor::fromRgb(220, 255, 240)
               : QColor(Qt::white);
         m_format.setBackground(bg);
 

--- a/src/gui/windowgeometryguard.cpp
+++ b/src/gui/windowgeometryguard.cpp
@@ -4,13 +4,13 @@
 
 #include "common/appconfig.h"
 #include "common/config.h"
-#include "common/log.h"
 #include "common/timer.h"
 #include "gui/screen.h"
 #include "platform/platformnativeinterface.h"
 #include "platform/platformwindow.h"
 
 #include <QApplication>
+#include <QDebug>
 #include <QEvent>
 #include <QMoveEvent>
 #include <QScreen>
@@ -92,7 +92,7 @@ bool WindowGeometryGuard::eventFilter(QObject *, QEvent *event)
             if ( !isWindowGeometryLocked() && openOnCurrentScreen() && isMousePositionSupported() ) {
                 QScreen *screen = currentScreen();
                 if (screen && window->screen() != screen) {
-                    COPYQ_LOG(QStringLiteral("Geometry: Moving to screen: %1").arg(screen->name()));
+                    qDebug() << "Geometry: Moving to screen:" << screen->name();
                     m_window->move(screen->availableGeometry().topLeft());
                 }
             }
@@ -183,11 +183,11 @@ void WindowGeometryGuard::onScreenChanged()
     if (!screen)
         return;
 
-    COPYQ_LOG(QStringLiteral("Geometry: Screen changed: %1").arg(screen->name()));
+    qDebug() << "Geometry: Screen changed:" << screen->name();
 
     const bool isMousePositionSupported = ::isMousePositionSupported();
     if ( window && isMousePositionSupported && screen != currentScreen() ) {
-        COPYQ_LOG(QStringLiteral("Geometry: Avoiding geometry-restore on incorrect screen"));
+        qDebug() << "Geometry: Avoiding geometry-restore on incorrect screen";
         return;
     }
 

--- a/src/tests/tests_slow_clipboard.cpp
+++ b/src/tests/tests_slow_clipboard.cpp
@@ -80,7 +80,7 @@ void Tests::slowClipboard()
     QMimeData *data = new SlowMimeData("X", 1500);
     clipboard->setRawData(ClipboardMode::Clipboard, data);
     waitFor(2000);
-    const auto expectedLog = R"(^.*<monitorClipboard-\d+>: Aborting clipboard cloning: Data access took too long$)";
+    const auto expectedLog = R"(^.*<cmd/monitorClipboard-\d+>: Aborting clipboard cloning: Data access took too long$)";
     QTRY_COMPARE( count(splitLines(readLogFile(maxReadLogSize)), expectedLog), 1 );
 
     TEST( m_test->setClipboard("B", "a/a") );

--- a/utils/github/test-signals.sh
+++ b/utils/github/test-signals.sh
@@ -11,9 +11,18 @@ exit_code=0
 
 ./copyq &
 copyq_pid=$!
-sleep 2
-# Run simple command to ensure server fully started.
-./copyq 'serverLog("Server started")'
+
+# Wait for server to start
+for i in {1..3}; do
+    echo "Trying to start CopyQ server ($i)"
+    if ./copyq 'serverLog("Server started")'; then
+        break
+    elif [[ $i == 5 ]]; then
+        echo "❌ FAILED: Could not start CopyQ server"
+        exit 1
+    fi
+    sleep $((i * 2))
+done
 
 sigterm=15
 expected_exit_code=$((128 + sigterm))


### PR DESCRIPTION
Sets correct log label before installing log handler.

Avoids using log function in plugins (otherwise they have empty label in logs since it uses value stored in the plugin compilation unit and not the main app).

Fixes order of log records with the same timestamp.