### PR TITLE
Wayland: Fix clipboard access in KDE Plasma 6.5

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -38,6 +38,9 @@ env:
     libqt6svg6-dev
     libqt6svg6
 
+    libkf6guiaddons-dev
+    libkf6guiaddons
+
     libqt6waylandclient6
     qt6-wayland
     qt6-wayland-dev
@@ -60,7 +63,6 @@ env:
     qtwayland5-dev-tools
 
     libkf5notifications-dev
-    extra-cmake-modules
   # FIXME: Sending signal to client process does not cause the process
   # to exit with non-zero code with GitHub Actions. Why?
   COPYQ_TESTS_SKIP_SIGNAL: '1'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 project(copyq)
 
 if (APPLE)

--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -85,6 +85,7 @@ To build with Qt 6:
       extra-cmake-modules \
       gcc-c++ \
       git \
+      kf6-kguiaddons-devel \
       kf6-knotifications-devel \
       kf6-kstatusnotifieritem-devel \
       libSM-devel \

--- a/src/notifications.cmake
+++ b/src/notifications.cmake
@@ -15,9 +15,7 @@ if (WITH_NATIVE_NOTIFICATIONS)
         list(APPEND copyq_LIBRARIES KF5::Notifications)
     endif()
 
-    list(APPEND copyq_SOURCES
-        gui/notificationnative/notificationnative.cpp
-        gui/notificationnative/notificationdaemonnative.cpp)
+    list(APPEND copyq_SOURCES gui/notificationnative/notificationnative.cpp)
 
     list(APPEND copyq_DEFINITIONS WITH_NATIVE_NOTIFICATIONS)
 endif()

--- a/src/platform/x11/x11platform.cmake
+++ b/src/platform/x11/x11platform.cmake
@@ -47,8 +47,20 @@ endif()
 
 # Wayland clipboard
 find_package(ECM REQUIRED NO_MODULE)
-set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/platform/x11/systemclipboard)
-add_subdirectory(platform/x11/systemclipboard)
-set_target_properties(systemclipboard PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast")
-list(APPEND copyq_LIBRARIES systemclipboard)
+list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+if (WITH_QT6 AND ECM_VERSION VERSION_GREATER "6.2.0")
+    message(STATUS "Using clipboard support from KGuiAddons.")
+    find_package(KF6GuiAddons REQUIRED)
+    list(APPEND copyq_DEFINITIONS HAS_KGUIADDONS)
+    list(APPEND copyq_LIBRARIES KF6::GuiAddons)
+else()
+    message(WARNING
+        "Using built-in clipboard support."
+        " Requires Qt 6 and 'kf6-guiaddons', 'libkf6guiaddons' or similar"
+        " for better Wayland clipboard integration.")
+    set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/platform/x11/systemclipboard)
+    add_subdirectory(platform/x11/systemclipboard)
+    set_target_properties(systemclipboard PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast")
+    list(APPEND copyq_LIBRARIES systemclipboard)
+endif()


### PR DESCRIPTION
Uses KGuiAddons library if available, which (in newer versions) uses the "ext-data-control-v1" protocol instead of the obsolete "wlr-data-control-unstable-v1".

Fixes #3228