### PR TITLE
Fix building with Qt 6.10

### DIFF
--- a/src/common/server.cpp
+++ b/src/common/server.cpp
@@ -39,7 +39,7 @@ QString lockFilePath()
 
 struct Server::PrivateData {
     QLocalServer server;
-    QLockFile lockFile = lockFilePath();
+    QLockFile lockFile{lockFilePath()};
     int socketCount = 0;
     QEventLoop *loop = nullptr;
 };

--- a/src/platform/x11/systemclipboard/CMakeLists.txt
+++ b/src/platform/x11/systemclipboard/CMakeLists.txt
@@ -36,3 +36,7 @@ target_link_libraries(systemclipboard
                       ${copyq_qt}::WaylandClient
                       Wayland::Client
 )
+if (TARGET ${copyq_qt}::GuiPrivate)
+    # for native interface to get wl_seat
+    target_link_libraries(systemclipboard ${copyq_qt}::GuiPrivate)
+endif()

--- a/src/platform/x11/x11platform.cmake
+++ b/src/platform/x11/x11platform.cmake
@@ -39,6 +39,7 @@ if (WITH_X11)
     set(copyq_LIBRARIES ${copyq_LIBRARIES} ${X11_LIBRARIES} ${X11_Xfixes_LIB})
 
     if(WITH_QT6)
+        find_package(${copyq_qt} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS GuiPrivate)
         list(APPEND copyq_LIBRARIES Qt::GuiPrivate)
     else()
         list(APPEND copyq_qt_modules X11Extras)


### PR DESCRIPTION
Since Qt 6.10 private targets must be now found explicitly, see <https://doc.qt.io/qt-6/whatsnew610.html#build-system-changes>.