### PR TITLE
when Qt6 is used make sure cmake variables are there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(CMAKE_AUTOMOC ON)
 
 OPTION(WITH_QT6 "Enable Qt 6" ON)
 if (WITH_QT6)
+    find_package(QT REQUIRED COMPONENTS Core NAMES Qt6)
     set(QT_DEFAULT_MAJOR_VERSION 6)
     find_package(Qt6Widgets 6.1.0 REQUIRED)
     set(copyq_qt Qt6)


### PR DESCRIPTION
When using `WITH_QT6` use
`find_package(QT REQUIRED COMPONENTS Core NAMES Qt6)` to make sure the QT related cmake variables are there. There is a use of the variable `QT_VERSION` further down the line while checking for Qt::GuiPrivate in the `src/platform/x11/x11platform.cmake` file.

This change makes that check work properly so we can build with Qt6 >= 6.10.