### PR TITLE
Keep original selection order in scripts

### DIFF
--- a/src/gui/selectiondata.cpp
+++ b/src/gui/selectiondata.cpp
@@ -19,7 +19,6 @@ void addSelectionData(
     selected.reserve(selectedIndexes.size());
     for (const auto &index : selectedIndexes)
         selected.append(index);
-    std::sort(selected.begin(), selected.end());
     addSelectionData(result, selected);
 }
 

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2187,7 +2187,6 @@ QString ScriptableProxy::testSelected()
         if ( !browser->isIndexHidden(index) )
             selectedRows.append(index.row());
     }
-    std::sort( selectedRows.begin(), selectedRows.end() );
 
     for (int row : selectedRows)
         result.append(QString::number(row));

--- a/src/tests/tests_classes.cpp
+++ b/src/tests/tests_classes.cpp
@@ -345,7 +345,7 @@ void Tests::classItemSelectionGetCurrent()
     RUN("keys" << "CTRL+F1", "");
     WAIT_ON_OUTPUT(args << "read(0)", "ItemSelection(tab=\"" + tab1 + "\", rows=[0])");
     RUN("keys" << "END" << "SHIFT+UP" << "CTRL+F1", "");
-    WAIT_ON_OUTPUT(args << "read(0)", "ItemSelection(tab=\"" + tab1 + "\", rows=[2,3])");
+    WAIT_ON_OUTPUT(args << "read(0)", "ItemSelection(tab=\"" + tab1 + "\", rows=[3,2])");
 }
 
 void Tests::classItemSelectionByteArray()

--- a/src/tests/tests_items.cpp
+++ b/src/tests/tests_items.cpp
@@ -84,7 +84,7 @@ void Tests::selectItems()
     RUN("testSelected", tab + " 2 2\n");
 
     RUN("keys" << "SHIFT+UP", "");
-    RUN("testSelected", tab + " 1 1 2\n");
+    RUN("testSelected", tab + " 1 2 1\n");
 
     RUN("keys" << "CTRL+A", "");
     RUN("testSelected", tab + " 1 0 1 2\n");
@@ -266,7 +266,7 @@ void Tests::selectAndCopyOrder()
     RUN("setCurrentTab" << tab, "");
 
     RUN("keys" << "END" << "SHIFT+UP" << "SHIFT+UP" << "SHIFT+UP", "");
-    RUN(args << "testSelected", tab + " 0 0 1 2 3\n");
+    RUN(args << "testSelected", tab + " 0 3 2 1 0\n");
 
     RUN("keys" << keyNameFor(QKeySequence::Copy), "");
     WAIT_ON_OUTPUT("clipboard", "D\nC\nB\nA");

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -766,11 +766,14 @@ void Tests::commandSelectItems()
     RUN("selectItems" << "0" << "2", "true\n");
     RUN("testSelected", QString(clipboardTabName) + " 2 0 2\n");
 
+    RUN("selectItems" << "2" << "0", "true\n");
+    RUN("testSelected", QString(clipboardTabName) + " 0 2 0\n");
+
     const auto tab = testTab(1);
     const auto args = Args("tab") << tab;
     RUN(args << "add" << "C" << "B" << "A", "");
     RUN(args << "selectItems" << "1" << "2", "true\n");
-    RUN("testSelected", QString(clipboardTabName) + " 2 0 2\n");
+    RUN("testSelected", QString(clipboardTabName) + " 0 2 0\n");
     RUN("setCurrentTab" << tab, "");
     RUN("testSelected", tab + " 2 1 2\n");
 }


### PR DESCRIPTION
`ItemSelection()` and `selectItems()` will avoid changing selected items order.

Old behavior:

    > copyq 'selectItems(1,0); print(ItemSelection().current().rows())'
    0,1

New behavior:

    > copyq 'selectItems(1,0); print(ItemSelection().current().rows())'
    1,0

Fixes #3271