### PR TITLE
Add nord themes

### DIFF
--- a/shared/themes/nord.ini
+++ b/shared/themes/nord.ini
@@ -1,0 +1,127 @@
+[General]
+css_template_items=items
+css_template_main_window=main_window
+css_template_menu=menu
+css_template_notification=notification
+
+style_main_window=true
+show_number=true
+show_scrollbars=false
+font_antialiasing=true
+use_system_icons=false
+
+icon_size=8
+item_spacing=0
+num_margin=2
+
+font="Sans,11,-1,5,50,0,0,0,0,0"
+find_font="Sans,11,-1,5,50,0,0,0,0,0"
+num_font="Sans,8,-1,5,50,0,0,0,0,0"
+edit_font="Sans,11,-1,5,50,0,0,0,0,0"
+notes_font="Sans,11,-1,5,50,0,0,0,0,0"
+notification_font="Sans,11,-1,5,50,0,0,0,0,0"
+
+bg=#2e3440
+fg=#eceff4
+alt_bg=#3b4252
+sel_bg=#5e81ac
+sel_fg=#eceff4
+find_bg=#ebcb8b
+find_fg=#2e3440
+edit_bg=#3b4252
+edit_fg=#eceff4
+notes_bg=#4c566a
+notes_fg=#eceff4
+num_fg=#ebcb8b
+num_sel_fg=#eceff4
+notification_bg=#3b4252
+notification_fg=#eceff4
+
+css=
+
+menu_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;padding: 0.15em
+    ;border-radius: 5%"
+menu_bar_disabled_css=
+menu_bar_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${fg}"
+menu_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;border: 1px solid ${sel_bg}"
+
+tool_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tool_button_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;font-weight: normal
+    ;border: 0
+    ;border-radius: 5%"
+tool_button_pressed_css="
+    ;background: ${num_fg}"
+tool_button_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${sel_fg}"
+
+search_bar="
+    ;background: ${find_bg}
+    ;color: ${bg}
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${find_bg}"
+search_bar_focused="
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${sel_bg}"
+
+tab_bar_css="
+    ;background: ${bg}"
+tab_bar_item_counter="
+    ;color: #d08770
+    ;font-size: 6pt"
+tab_bar_scroll_buttons_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tab_bar_sel_item_counter="
+    ;color: #d08770"
+tab_bar_tab_unselected_css="
+    ;background: ${bg}
+    ;color: ${num_fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${bg}"
+tab_bar_tab_selected_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${num_fg}
+    ;border-radius: 5%"
+
+tab_tree_css="
+    ;background: ${bg}
+    ;color: ${num_fg}"
+tab_tree_item_counter="
+    ;color: #d08770
+    ;font-size: 6pt"
+tab_tree_sel_item_counter="
+    ;color: #d08770"
+tab_tree_sel_item_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;text-decoration: underline"
+
+item_css="
+    ;padding: 0.3em 0.5em 0.5em 0.5em"
+alt_item_css=
+sel_item_css=
+cur_item_css="
+    ;border: 1px solid ${sel_bg}"
+hover_item_css="
+    ;background: #4c566a"
+notes_css=

--- a/shared/themes/nord_light.ini
+++ b/shared/themes/nord_light.ini
@@ -1,0 +1,127 @@
+[General]
+css_template_items=items
+css_template_main_window=main_window
+css_template_menu=menu
+css_template_notification=notification
+
+style_main_window=true
+show_number=true
+show_scrollbars=false
+font_antialiasing=true
+use_system_icons=false
+
+icon_size=8
+item_spacing=0
+num_margin=2
+
+font="Sans,11,-1,5,50,0,0,0,0,0"
+find_font="Sans,11,-1,5,50,0,0,0,0,0"
+num_font="Sans,8,-1,5,50,0,0,0,0,0"
+edit_font="Sans,11,-1,5,50,0,0,0,0,0"
+notes_font="Sans,11,-1,5,50,0,0,0,0,0"
+notification_font="Sans,11,-1,5,50,0,0,0,0,0"
+
+bg=#eceff4
+fg=#2e3440
+alt_bg=#e5e9f0
+sel_bg=#88c0d0
+sel_fg=#2e3440
+find_bg=#ebcb8b
+find_fg=#2e3440
+edit_bg=#d8dee9
+edit_fg=#2e3440
+notes_bg=#d8dee9
+notes_fg=#2e3440
+num_fg=#88c0d0
+num_sel_fg=#2e3440
+notification_bg=#e5e9f0
+notification_fg=#2e3440
+
+css=
+
+menu_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;padding: 0.15em
+    ;border-radius: 5%"
+menu_bar_disabled_css=
+menu_bar_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${fg}"
+menu_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;border: 1px solid ${sel_bg}"
+
+tool_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tool_button_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;font-weight: normal
+    ;border: 0
+    ;border-radius: 5%"
+tool_button_pressed_css="
+    ;background: ${num_fg}"
+tool_button_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${sel_fg}"
+
+search_bar="
+    ;background: ${find_bg}
+    ;color: ${fg}
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${find_bg}"
+search_bar_focused="
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${sel_bg}"
+
+tab_bar_css="
+    ;background: ${bg}"
+tab_bar_item_counter="
+    ;color: #d08770
+    ;font-size: 6pt"
+tab_bar_scroll_buttons_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tab_bar_sel_item_counter="
+    ;color: #d08770"
+tab_bar_tab_unselected_css="
+    ;background: ${bg}
+    ;color: ${num_fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${bg}"
+tab_bar_tab_selected_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${num_fg}
+    ;border-radius: 5%"
+
+tab_tree_css="
+    ;background: ${bg}
+    ;color: ${num_fg}"
+tab_tree_item_counter="
+    ;color: #d08770
+    ;font-size: 6pt"
+tab_tree_sel_item_counter="
+    ;color: #d08770"
+tab_tree_sel_item_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;text-decoration: underline"
+
+item_css="
+    ;padding: 0.3em 0.5em 0.5em 0.5em"
+alt_item_css=
+sel_item_css=
+cur_item_css="
+    ;border: 1px solid ${sel_bg}"
+hover_item_css="
+    ;background: #d8dee9"
+notes_css=


### PR DESCRIPTION
Hello, if you are open to accepting these themes based on https://www.nordtheme.com/ palette, here they are. I'm not a frontend/css guy at all, so css code probably might be improved since it was created manually after inspecting the source code and existing themes (no AI).   

* dark

<img width="1006" height="895" alt="image" src="https://github.com/user-attachments/assets/80fc6e71-63d0-4a72-9945-ef7444689003" />


* light

<img width="1006" height="895" alt="image" src="https://github.com/user-attachments/assets/3bbd4755-cf19-47ea-b575-1fe670ff32a7" />

P.S. I wanted to make it roundish to fit GNOME aesthetics but alas I could not solve white corners bug https://github.com/hluk/CopyQ/discussions/3292 so it is squarish for now.