### PR TITLE
Avoid restarting monitor while app is exiting

### DIFF
--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -255,7 +255,7 @@ void ClipboardServer::stopMonitoring()
 
 void ClipboardServer::startMonitoring()
 {
-    if (m_monitor || m_ignoreNewConnections || !m_wnd->isMonitoringEnabled())
+    if (m_monitor || m_exitting || m_ignoreNewConnections || !m_wnd->isMonitoringEnabled())
         return;
 
     COPYQ_LOG("Starting monitor");


### PR DESCRIPTION
This can happen if the app (the main server process) and the monitor process receive a request to exit from a session manager.

Fixes #3317