### PR TITLE
Update build from source docs on previous Ubuntu versions for KF6

### DIFF
--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -37,8 +37,6 @@ On **Ubuntu** you can install all build dependencies with:
       cmake \
       extra-cmake-modules \
       git \
-      libkf6guiaddons \
-      libkf6guiaddons-dev \
       libqca-qt6-2 \
       libqca-qt6-dev \
       libqca-qt6-plugins \
@@ -60,7 +58,15 @@ On **Ubuntu** you can install all build dependencies with:
       qt6-wayland-dev-tools \
       qtkeychain-qt6-dev
 
-Fedora / RHEL / Centos
+On Ubuntu 25.04 and newer, you can also install `KF6` packages:
+
+::
+
+    sudo apt install \
+      libkf6guiaddons \
+      libkf6guiaddons-dev \
+
+Fedora / RHEL / CentOS
 ^^^^^^^^^^^^^^^^^^^^^^
 On **Fedora** and derivatives you can install all build dependencies with:
 
@@ -97,6 +103,7 @@ Build the source code with CMake and make or using an IDE of your choice (see ne
 
     cd CopyQ
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .
+    # Add -DWITH_NATIVE_NOTIFICATIONS=OFF for Ubuntu systems without `KF6` packages
     make
     make install
 

--- a/src/platform/x11/x11platform.cmake
+++ b/src/platform/x11/x11platform.cmake
@@ -59,7 +59,7 @@ if (WITH_QT6 AND ECM_VERSION VERSION_GREATER "6.2.0")
 else()
     message(WARNING
         "Using built-in clipboard support."
-        " Requires Qt 6 and 'kf6-guiaddons', 'libkf6guiaddons' or similar"
+        " Requires Qt 6 and 'kf6-kguiaddons', 'libkf6guiaddons' or similar"
         " for better Wayland clipboard integration.")
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include_directories(${CMAKE_CURRENT_BINARY_DIR}/platform/x11/systemclipboard)


### PR DESCRIPTION
Hello, I stumbled upon a compilation problem, more context in #3382

This PR will set both KF6 Notifications & StatusNotifierItem optional because they are not available on Ubuntu LTS. Only Ubuntu >=25.04 (https://packages.ubuntu.com/plucky/libkf6guiaddons-dev) have it.

Compilation works fine without the flag `WITH_NATIVE_NOTIFICATIONS`, it just disable native notification support, that could only be available on recent versions.
Also `src/platform/x11/x11platform.cmake` already handle that case where built-in clipboard support could be skipped if no kguiaddons are found.

Updated build from source docs and kguiaddons typo accordingly