### PR TITLE
Fix the JS comment syntax in a doc example

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -2105,24 +2105,24 @@ Types
 
        let req = NetworkRequest();
 
-       # allow redirects
+       // allow redirects
        req.maxRedirects = 5;
 
-       # set request headers
+       // set request headers
        req.headers = {
           'User-Agent': req.headers['User-Agent'],
           'Accept': 'application/json',
        };
 
-       # create JSON data
+       // create JSON data
        const data = JSON.stringify({text: 'Hello, **world**!'});
 
-       # send POST request
+       // send POST request
        const reply = req.request(
            'POST', 'https://api.github.com/markdown', data)
 
-       # the request is synchronous and may not be finished
-       # until a property is called (like reply.data or reply.status)
+       // the request is synchronous and may not be finished
+       // until a property is called (like reply.data or reply.status)
        if (!reply.finished) { serverLog('Processing...'); }
        print(reply.data);
 


### PR DESCRIPTION
This resolves a warning emitted during doc builds [[recent example](https://app.readthedocs.org/projects/copyq/builds/31148357/#303436602--18)]:

```
WARNING: Lexing literal_block "let req = NetworkRequest();\n\n# allow redirects\n..."
as "js" resulted in an error at token: '#'. Retrying in relaxed mode.
```

Note that there are two additional doc warnings associated with INI syntax. I didn't see an obvious way to resolve those warnings.

Thanks for all of your work on CopyQ!