### PR TITLE
docs: Add macOS CLI symlink instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,6 +24,21 @@ following commands (for details, see `issue #2652
     xattr -d com.apple.quarantine /Applications/CopyQ.app
     codesign --force --deep --sign - /Applications/CopyQ.app
 
+On **macOS**, after Homebrew installation, the ``copyq`` CLI command is not
+available by default. To enable CLI access, create a symlink manually:
+
+.. code-block:: bash
+
+    sudo ln -sf /Applications/CopyQ.app/Contents/MacOS/CopyQ /usr/local/bin/copyq
+
+After this, you can use the CLI:
+
+.. code-block:: bash
+
+    copyq --version
+    copyq clipboard
+    copyq size
+
 On Debian unstable, **Debian 11+**, **Ubuntu 22.04+** and later derivatives can
 install stable version from official repositories:
 


### PR DESCRIPTION
## Summary

Adds documentation for enabling CLI access on macOS after Homebrew installation.

## Problem

After installing CopyQ via `brew install --cask copyq`, the `copyq` CLI command is not available in PATH. This is because Homebrew casks only install the `.app` bundle and don't create CLI symlinks automatically (unlike Homebrew formulae).

## Solution

Added clear instructions in `docs/installation.rst` showing users how to manually create the symlink:

```bash
sudo ln -sf /Applications/CopyQ.app/Contents/MacOS/CopyQ /usr/local/bin/copyq
```

Also included example CLI usage commands to verify the setup works.

## Related

- Fixes #3407
- Related to #2652 (macOS installation issues)

## Testing

- Verified instructions work on macOS 15.1.1 (Sequoia) with Apple Silicon
- Tested with CopyQ v13.0.0 installed via Homebrew

## Checklist

- [x] Documentation updated
- [x] Tested on macOS
- [x] Related issue referenced