### PR TITLE
Add support for monitoring clipboard in GNOME

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -105,6 +105,7 @@ jobs:
             with_qt6: true
             with_native_notifications: false
             test_wayland: true
+            test_gnome: true
             coverage: true
             cmake_preset: Debug
             compiler_flags: >-
@@ -147,6 +148,7 @@ jobs:
             ${{ matrix.with_qt6 && env.qt6_packages || env.qt5_packages }}
             ${{ matrix.coverage && 'lcov' || '' }}
             ${{ matrix.coverage && 'kwin-wayland kwin-wayland-backend-virtual libwayland-server0 procps' || '' }}
+            ${{ matrix.test_gnome && 'gnome-shell gnome-shell-common glib2.0-bin' || '' }}
 
       - name: Build with CMake
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
@@ -164,6 +166,15 @@ jobs:
 
       - name: Create gnupg directory for tests
         run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
+
+      - name: Test on GNOME
+        working-directory: >-
+          ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        if: matrix.test_gnome
+        run: '${{github.workspace}}/utils/github/test-linux-gnome-extension.sh'
+        env:
+          COPYQ_TESTS_EXECUTABLE: >-
+            ${{runner.workspace}}/install/copyq/${{ matrix.cmake_preset }}/bin/copyq
 
       - name: Test on Wayland
         working-directory: >-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ OPTION(PEDANTIC "Enable all compiler warnings" OFF)
 OPTION(WITH_PLUGINS "Compile plugins" ON)
 OPTION(WITH_QCA_ENCRYPTION "Enable QCA-based tab encryption" ON)
 OPTION(WITH_KEYCHAIN "Enable system keyring integration using QtKeychain" ON)
+OPTION(WITH_GNOME_CLIPBOARD_EXTENSION "Install GNOME extension, required for clipboard monitoring" ON)
 
 add_definitions( -DQT_USE_STRINGBUILDER  )
 
@@ -164,6 +165,14 @@ if (UNIX AND NOT APPLE)
     install(FILES ${copyq_APPDATA}         DESTINATION ${APPDATA_INSTALL_PREFIX})
     install(FILES ${copyq_MANPAGE}         DESTINATION ${MANPAGE_INSTALL_PREFIX})
     install(FILES ${copyq_BASH_COMPLETION} DESTINATION ${BASH_COMPLETION_INSTALL_PREFIX} RENAME copyq)
+
+    if (WITH_GNOME_CLIPBOARD_EXTENSION)
+        set(copyq_GNOME_EXTENSION_DESTINATION "${DATA_INSTALL_PREFIX}/gnome-shell/extensions/copyq-clipboard@hluk.github.com")
+        install(FILES
+            shared/gnome-extension/extension.js
+            shared/gnome-extension/metadata.json
+            DESTINATION "${copyq_GNOME_EXTENSION_DESTINATION}")
+    endif()
 
     configure_file(${copyq_DESKTOP}.in ${copyq_DESKTOP})
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${copyq_DESKTOP} DESTINATION ${DESKTOP_INSTALL_PREFIX})

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -61,6 +61,15 @@ installed or updated.
     - `Issue #1030 <https://github.com/hluk/CopyQ/issues/1030>`__
     - `Issue #1245 <https://github.com/hluk/CopyQ/issues/1245>`__
 
+.. _known-issue-gnome:
+
+On GNOME, new clipboard is not stored
+-------------------------------------
+
+The app requires CopyQ Clipboard Monitor GNOME extension to be enabled so it
+can watch clipboard changes and store them. The GNOME extension can be
+installed with CopyQ 14.0.0.
+
 .. _known-issue-wayland:
 
 On Linux, global shortcuts, pasting or clipboard monitoring does not work

--- a/shared/gnome-extension/extension.js
+++ b/shared/gnome-extension/extension.js
@@ -1,0 +1,344 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const SERVICE_NAME = 'com.github.hluk.copyq.GnomeClipboard';
+const OBJECT_PATH = '/com/github/hluk/copyq/GnomeClipboard';
+const INTERFACE_NAME = 'com.github.hluk.CopyQ.GnomeClipboard1';
+const CLIENT_OBJECT_PATH = '/com/github/hluk/copyq/GnomeClipboardClient';
+const CLIENT_INTERFACE_NAME = 'com.github.hluk.CopyQ.GnomeClipboardClient1';
+const CLIPBOARD_TYPE_CLIPBOARD = 0;
+const CLIPBOARD_TYPE_PRIMARY = 1;
+const CLIPBOARD_TYPE_BOTH = 2;
+const DEBUG = GLib.getenv('COPYQ_GNOME_EXTENSION_DEBUG') === '1';
+
+const INTERFACE_XML = `<node>
+  <interface name="${INTERFACE_NAME}">
+    <method name="RegisterClipboardClient">
+      <arg type="i" name="clipboardTypes" direction="in"/>
+    </method>
+    <method name="UnregisterClipboardClient"/>
+    <method name="SetClipboardData">
+      <arg type="i" name="clipboardType" direction="in"/>
+      <arg type="s" name="format" direction="in"/>
+      <arg type="v" name="value" direction="in"/>
+    </method>
+    <method name="GetClipboardData">
+      <arg type="i" name="clipboardType" direction="in"/>
+      <arg type="as" name="formats" direction="in"/>
+      <arg type="a{sv}" name="data" direction="out"/>
+    </method>
+    <method name="GetClipboardFormats">
+      <arg type="i" name="clipboardType" direction="in"/>
+      <arg type="as" name="formats" direction="out"/>
+    </method>
+  </interface>
+</node>`;
+
+function debug(message) {
+    if (DEBUG)
+        log(`[copyq-clipboard] ${message}`);
+}
+
+function stringToBytes(text) {
+    return new TextEncoder().encode(text);
+}
+
+function toBytes(value) {
+    if (value instanceof GLib.Variant) {
+        if (value.is_of_type(new GLib.VariantType('ay')))
+            return value.deepUnpack();
+        return toBytes(value.deepUnpack());
+    }
+    if (value instanceof GLib.Bytes)
+        return value.toArray();
+    if (value instanceof Uint8Array)
+        return value;
+    if (Array.isArray(value))
+        return Uint8Array.from(value);
+    if (typeof value === 'string')
+        return stringToBytes(value);
+    return null;
+}
+
+function toDataVariant(value) {
+    const bytes = toBytes(value);
+    return bytes ? new GLib.Variant('ay', bytes) : null;
+}
+
+function metaSelectionTypeFromClipboardType(clipboardType) {
+    const enumType = Meta.SelectionType ?? {};
+    const primary = enumType.PRIMARY ?? enumType.SELECTION_PRIMARY ?? 0;
+    const clipboard = enumType.CLIPBOARD ?? enumType.SELECTION_CLIPBOARD ?? 1;
+    return clipboardType === CLIPBOARD_TYPE_PRIMARY ? primary : clipboard;
+}
+
+function supportsClipboardType(clipboardTypes, clipboardType) {
+    const types = Number(clipboardTypes);
+    const type = Number(clipboardType);
+    return types === CLIPBOARD_TYPE_BOTH || types === type;
+}
+
+export default class CopyqClipboardExtension extends Extension {
+    enable() {
+        this._clients = new Map();
+        this._providedDataByType = {
+            [CLIPBOARD_TYPE_CLIPBOARD]: {},
+            [CLIPBOARD_TYPE_PRIMARY]: {},
+        };
+
+        this._setupListener();
+
+        this._dbusConnection = Gio.DBus.session;
+        this._dbusNodeInfo = Gio.DBusNodeInfo.new_for_xml(INTERFACE_XML);
+        this._dbusRegistrationId = this._dbusConnection.register_object(
+            OBJECT_PATH,
+            this._dbusNodeInfo.interfaces[0],
+            this._handleMethodCall.bind(this),
+            null,
+            null
+        );
+        this._dbusNameOwnerId = Gio.bus_own_name_on_connection(
+            this._dbusConnection,
+            SERVICE_NAME,
+            Gio.BusNameOwnerFlags.REPLACE,
+            null,
+            null
+        );
+    }
+
+    disable() {
+        if (this._selectionOwnerChangedId && this.selection) {
+            this.selection.disconnect(this._selectionOwnerChangedId);
+            this._selectionOwnerChangedId = 0;
+        }
+
+        if (this._dbusRegistrationId) {
+            this._dbusConnection.unregister_object(this._dbusRegistrationId);
+            this._dbusRegistrationId = 0;
+        }
+        if (this._dbusNameOwnerId) {
+            Gio.bus_unown_name(this._dbusNameOwnerId);
+            this._dbusNameOwnerId = 0;
+        }
+
+        this._clients?.clear();
+        this._clients = null;
+        this._providedDataByType = null;
+        this.selection = null;
+        this._dbusConnection = null;
+        this._dbusNodeInfo = null;
+    }
+
+    _setupListener() {
+        try {
+            const metaDisplay = Shell.Global.get().get_display();
+            const selection = metaDisplay?.get_selection?.();
+            if (!selection) {
+                debug('Failed to set up owner-changed listener: selection unavailable');
+                return;
+            }
+            debug('Setting up Shell selection owner-changed listener');
+            this._setupSelectionTracking(selection);
+        } catch (error) {
+            debug(`Failed to set up owner-changed listener: ${error}`);
+        }
+    }
+
+    _setupSelectionTracking(selection) {
+        this.selection = selection;
+        this._selectionOwnerChangedId = selection.connect('owner-changed',
+            (_selection, selectionType, _selectionSource) => {
+                this._onSelectionChange(selectionType);
+            });
+    }
+
+    _clipboardTypeFromSelectionType(selectionType) {
+        const enumType = Meta.SelectionType ?? {};
+        const primary = enumType.PRIMARY ?? enumType.SELECTION_PRIMARY ?? 0;
+        const clipboard = enumType.CLIPBOARD ?? enumType.SELECTION_CLIPBOARD ?? 1;
+        const value = Number(selectionType);
+        const text = String(selectionType).toLowerCase();
+        if (value === primary || text.includes('primary'))
+            return CLIPBOARD_TYPE_PRIMARY;
+        if (value === clipboard || text.includes('clipboard'))
+            return CLIPBOARD_TYPE_CLIPBOARD;
+        return CLIPBOARD_TYPE_CLIPBOARD;
+    }
+
+    _onSelectionChange(selectionType) {
+        const clipboardType = this._clipboardTypeFromSelectionType(selectionType);
+        debug(`Selection owner changed: selectionType=${selectionType}, clipboardType=${clipboardType}`);
+        this._notifyClients(clipboardType);
+    }
+
+    _handleMethodCall(_connection, sender, _objectPath, _interfaceName, methodName, parameters, invocation) {
+        if (methodName === 'RegisterClipboardClient') {
+            const [clipboardTypes] = parameters.deepUnpack();
+            const types = Number(clipboardTypes);
+            this._clients.set(sender, types);
+            debug(`Registered client ${sender} with clipboardTypes=${types}`);
+            invocation.return_value(null);
+            return;
+        }
+
+        if (methodName === 'UnregisterClipboardClient') {
+            this._clients.delete(sender);
+            debug(`Unregistered client ${sender}`);
+            invocation.return_value(null);
+            return;
+        }
+
+        if (methodName === 'SetClipboardData') {
+            const [clipboardType, format, value] = parameters.deepUnpack();
+            const type = Number(clipboardType);
+            const normalizedValue = toDataVariant(value);
+            if (!normalizedValue) {
+                debug(`SetClipboardData ignored for clipboardType=${type}, format=${format}: unsupported value`);
+                invocation.return_value(null);
+                return;
+            }
+            this._providedDataByType[type][format] = normalizedValue;
+            this._setClipboardData(type, format, normalizedValue);
+            debug(`SetClipboardData called for clipboardType=${type}, format=${format}`);
+            invocation.return_value(null);
+            return;
+        }
+
+        if (methodName === 'GetClipboardData') {
+            const [clipboardType, formats] = parameters.deepUnpack();
+            const requestedFormats = new Set(Array.isArray(formats) ? formats : []);
+            this._readClipboardData(clipboardType, requestedFormats, dataMap => {
+                invocation.return_value(new GLib.Variant('(a{sv})', [dataMap]));
+            });
+            return;
+        }
+
+        if (methodName === 'GetClipboardFormats') {
+            const [clipboardType] = parameters.deepUnpack();
+            const formats = this._getClipboardFormats(clipboardType);
+            invocation.return_value(new GLib.Variant('(as)', [formats]));
+        }
+    }
+
+    _notifyClients(clipboardType) {
+        if (!this._clients || this._clients.size === 0)
+            return;
+        debug(`Notifying clients for clipboardType=${clipboardType}, clients=${this._clients.size}`);
+
+        for (const [sender, clipboardTypes] of this._clients.entries()) {
+            if (!supportsClipboardType(clipboardTypes, clipboardType))
+                continue;
+            this._dbusConnection.call(
+                sender,
+                CLIENT_OBJECT_PATH,
+                CLIENT_INTERFACE_NAME,
+                'ClipboardChanged',
+                new GLib.Variant('(i)', [clipboardType]),
+                null,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                1000,
+                null,
+                (_conn, result) => {
+                    try {
+                        _conn.call_finish(result);
+                    } catch (error) {
+                        log(`[copyq-clipboard] Broadcast failed for ${sender}: ${error}`);
+                        this._clients.delete(sender);
+                    }
+                }
+            );
+        }
+    }
+
+    _readClipboardData(clipboardType, requestedFormats, onDone) {
+        if (!this.selection) {
+            const fallback = this._providedDataByType[clipboardType] ?? {};
+            onDone({...fallback});
+            return;
+        }
+
+        const selectionType = metaSelectionTypeFromClipboardType(clipboardType);
+        const advertisedFormats = this.selection.get_mimetypes(selectionType) ?? [];
+        const formats = requestedFormats && requestedFormats.size > 0
+            ? [...requestedFormats]
+            : advertisedFormats;
+
+        if (formats.length === 0) {
+            onDone({});
+            return;
+        }
+
+        const data = {};
+        let pending = formats.length;
+        const complete = () => {
+            pending--;
+            if (pending !== 0)
+                return;
+            for (const format of formats) {
+                if (!Object.prototype.hasOwnProperty.call(data, format)
+                        && Object.prototype.hasOwnProperty.call(this._providedDataByType[clipboardType], format))
+                {
+                    data[format] = this._providedDataByType[clipboardType][format];
+                }
+            }
+            onDone(data);
+        };
+
+        for (const format of formats) {
+            const output = Gio.MemoryOutputStream.new_resizable();
+            this.selection.transfer_async(
+                selectionType,
+                format,
+                -1,
+                output,
+                null,
+                (_selection, result) => {
+                try {
+                    this.selection.transfer_finish(result);
+                    const bytes = output.steal_as_bytes()?.toArray?.() ?? [];
+                    if (bytes.length > 0)
+                        data[format] = new GLib.Variant('ay', Uint8Array.from(bytes));
+                } catch (_error) {
+                    // Ignore unavailable format and keep fallback behavior.
+                }
+                complete();
+            });
+        }
+    }
+
+    _getClipboardFormats(clipboardType) {
+        const provided = Object.keys(this._providedDataByType[clipboardType] ?? {});
+        if (!this.selection)
+            return provided;
+
+        const selectionType = metaSelectionTypeFromClipboardType(clipboardType);
+        const selectionFormats = this.selection.get_mimetypes(selectionType) ?? [];
+        const all = new Set([...selectionFormats, ...provided]);
+        return [...all];
+    }
+
+    _setClipboardData(clipboardType, format, value) {
+        if (!this.selection)
+            this._setupListener();
+
+        if (!this.selection) {
+            debug(`Failed to set clipboard content: Meta selection unavailable for clipboardType=${clipboardType}`);
+            return;
+        }
+
+        const bytes = toBytes(value);
+        if (!bytes)
+            return;
+
+        try {
+            const source = Meta.SelectionSourceMemory.new(format, GLib.Bytes.new(bytes));
+            this.selection.set_owner(metaSelectionTypeFromClipboardType(clipboardType), source);
+            debug(`Set clipboard content using Meta selection source for clipboardType=${clipboardType} format=${format}`);
+        } catch (error) {
+            debug(`Failed to set clipboard content using Meta selection source: ${error}`);
+        }
+    }
+}

--- a/shared/gnome-extension/metadata.json
+++ b/shared/gnome-extension/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "CopyQ Clipboard Monitor",
+  "description": "Forwards GNOME clipboard changes to active CopyQ sessions.",
+  "uuid": "copyq-clipboard@hluk.github.com",
+  "shell-version": ["45", "46", "47", "48", "49"]
+}

--- a/src/app/clipboardmonitor.h
+++ b/src/app/clipboardmonitor.h
@@ -6,6 +6,7 @@
 #include "app/clipboardownermonitor.h"
 #include "common/clipboardmode.h"
 #include "common/common.h"
+#include "platform/platformclipboard.h"
 #include "platform/platformnativeinterface.h"
 
 #include <QVariantMap>
@@ -37,7 +38,9 @@ private:
     QVariantMap m_selectionData;
 
     PlatformClipboardPtr m_clipboard;
+    ClipboardConnectionPtr m_connection;
     QStringList m_formats;
+    ClipboardModeMask m_modes;
 
     QString m_clipboardTab;
     bool m_storeClipboard;

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -129,6 +129,10 @@ bool removeLogFile(const QFileInfo &logFileInfo)
 
 QString getDefaultLogFilePath()
 {
+    const QString dir = qEnvironmentVariable("COPYQ_LOG_DIR");
+    if (!dir.isEmpty()) {
+        return dir;
+    }
     return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 }
 

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -17,6 +17,7 @@ enum LogLevel {
 constexpr int logFileSize = 512 * 1024;
 constexpr int logFileCount = 10;
 
+QString getDefaultLogFilePath();
 const QString &logFileName();
 
 QByteArray readLogFile(int maxReadSize);

--- a/src/gui/clipboarddialog.cpp
+++ b/src/gui/clipboarddialog.cpp
@@ -220,6 +220,8 @@ void ClipboardDialog::init()
     ui->listWidgetFormats->addAction(ui->actionRemove_Format);
 
     onListWidgetFormatsCurrentItemChanged(nullptr, nullptr);
+
+    ui->listWidgetFormats->setFocus(Qt::ActiveWindowFocusReason);
 }
 
 void ClipboardDialog::setData(const QVariantMap &data)

--- a/src/gui/clipboardspy.h
+++ b/src/gui/clipboardspy.h
@@ -4,6 +4,7 @@
 
 
 #include "common/clipboardmode.h"
+#include "platform/platformclipboard.h"
 #include "platform/platformnativeinterface.h"
 
 #include <QObject>
@@ -32,6 +33,7 @@ private:
 
     ClipboardMode m_mode;
     PlatformClipboardPtr m_clipboard;
+    ClipboardConnectionPtr m_connection;
     QByteArray m_oldOwnerData;
     bool m_settingClipboard = false;
 };

--- a/src/platform/dummy/dummyclipboard.cpp
+++ b/src/platform/dummy/dummyclipboard.cpp
@@ -23,10 +23,16 @@ QClipboard::Mode modeToQClipboardMode(ClipboardMode mode)
     return QClipboard::Clipboard;
 }
 
-void DummyClipboard::startMonitoring(const QStringList &)
+void DummyClipboard::startMonitoringBackend(const QStringList &, ClipboardModeMask)
 {
     connect(QGuiApplication::clipboard(), &QClipboard::changed,
             this, &DummyClipboard::onClipboardChanged);
+}
+
+void DummyClipboard::stopMonitoringBackend()
+{
+    disconnect(QGuiApplication::clipboard(), &QClipboard::changed,
+               this, &DummyClipboard::onClipboardChanged);
 }
 
 QVariantMap DummyClipboard::data(ClipboardMode mode, const QStringList &formats) const
@@ -83,7 +89,9 @@ bool DummyClipboard::isHidden(const QMimeData &data) const
 void DummyClipboard::onChanged(int mode)
 {
     if (mode == QClipboard::Clipboard)
-        emit changed(ClipboardMode::Clipboard);
+        emitConnectionChanged(ClipboardMode::Clipboard);
+    else if (mode == QClipboard::Selection)
+        emitConnectionChanged(ClipboardMode::Selection);
 }
 
 void DummyClipboard::onClipboardChanged(QClipboard::Mode mode)

--- a/src/platform/dummy/dummyclipboard.h
+++ b/src/platform/dummy/dummyclipboard.h
@@ -13,10 +13,6 @@ QClipboard::Mode modeToQClipboardMode(ClipboardMode mode);
 class DummyClipboard : public PlatformClipboard
 {
 public:
-    void startMonitoring(const QStringList &) override;
-
-    void setMonitoringEnabled(ClipboardMode, bool) override {}
-
     QVariantMap data(ClipboardMode mode, const QStringList &formats) const override;
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
@@ -31,6 +27,8 @@ public:
     void setClipboardOwner(const QString &) override {}
 
 protected:
+    void startMonitoringBackend(const QStringList &, ClipboardModeMask) override;
+    void stopMonitoringBackend() override;
     virtual const QMimeData *rawMimeData(ClipboardMode mode) const;
     virtual void onChanged(int mode);
     void onClipboardChanged(QClipboard::Mode mode);

--- a/src/platform/mac/macclipboard.h
+++ b/src/platform/mac/macclipboard.h
@@ -5,15 +5,17 @@
 
 #include "platform/dummy/dummyclipboard.h"
 
+class MacTimer;
+
 class MacClipboard final : public DummyClipboard {
 public:
-    void startMonitoring(const QStringList &) override;
-
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
 
     bool isHidden(const QMimeData &data) const override;
 
 protected:
+    void startMonitoringBackend(const QStringList &, ClipboardModeMask) override;
+    void stopMonitoringBackend() override;
     void onChanged(int mode) override;
     const long int *clipboardSequenceNumber(ClipboardMode) const override {
         return &m_prevChangeCount;
@@ -23,4 +25,5 @@ private:
     void clipboardTimeout();
 
     long int m_prevChangeCount = 0;
+    MacTimer *m_timer = nullptr;
 };

--- a/src/platform/platform.cmake
+++ b/src/platform/platform.cmake
@@ -2,6 +2,7 @@
 find_package(X11)
 
 file(GLOB copyq_SOURCES ${copyq_SOURCES}
+    platform/platformclipboard.cpp
     platform/platformclipboard.h
     )
 

--- a/src/platform/platformclipboard.cpp
+++ b/src/platform/platformclipboard.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "platformclipboard.h"
+
+#include <algorithm>
+
+ClipboardModeFlag clipboardModeFlag(ClipboardMode mode)
+{
+    return mode == ClipboardMode::Clipboard
+        ? ClipboardModeFlag::Clipboard
+        : ClipboardModeFlag::Selection;
+}
+
+ClipboardConnection::ClipboardConnection(
+        const QStringList &formats, ClipboardModeMask modes, PlatformClipboard *clipboard)
+    : m_formats(formats)
+    , m_modes(modes)
+    , m_clipboard(clipboard)
+{}
+
+ClipboardConnection::~ClipboardConnection()
+{
+    if (m_clipboard)
+        m_clipboard->unregisterConnection(this);
+}
+
+PlatformClipboard::~PlatformClipboard()
+{
+    for (auto *connection : std::as_const(m_connections))
+        connection->m_clipboard = nullptr;
+    m_connections.clear();
+}
+
+ClipboardConnectionPtr PlatformClipboard::createConnection(
+        const QStringList &formats, ClipboardModeMask modes)
+{
+    auto connection = ClipboardConnectionPtr(new ClipboardConnection(formats, modes, this));
+    registerConnection(connection.get());
+    return connection;
+}
+
+void PlatformClipboard::registerConnection(ClipboardConnection *connection)
+{
+    m_connections.append(connection);
+    setMonitoringState();
+}
+
+void PlatformClipboard::unregisterConnection(ClipboardConnection *connection)
+{
+    const auto it = std::remove(m_connections.begin(), m_connections.end(), connection);
+    if (it == m_connections.end())
+        return;
+
+    m_connections.erase(it, m_connections.end());
+    connection->m_clipboard = nullptr;
+    setMonitoringState();
+}
+
+void PlatformClipboard::setMonitoringState()
+{
+    m_monitoredFormats.clear();
+    m_monitoredModes = {};
+
+    for (const auto *connection : std::as_const(m_connections)) {
+        m_monitoredFormats.append(connection->formats());
+        m_monitoredModes |= connection->modes();
+    }
+    m_monitoredFormats.removeDuplicates();
+
+    if (m_connections.isEmpty()) {
+        if (m_isMonitoringActive) {
+            stopMonitoringBackend();
+            m_isMonitoringActive = false;
+        }
+        return;
+    }
+
+    if (!m_isMonitoringActive) {
+        startMonitoringBackend(m_monitoredFormats, m_monitoredModes);
+        m_isMonitoringActive = true;
+    } else {
+        updateMonitoringSubscription(m_monitoredFormats, m_monitoredModes);
+    }
+}
+
+void PlatformClipboard::updateMonitoringSubscription(const QStringList &, ClipboardModeMask)
+{
+}
+
+void PlatformClipboard::emitConnectionChanged(ClipboardMode mode)
+{
+    const auto flag = clipboardModeFlag(mode);
+    const auto connections = m_connections;
+    for (auto *connection : connections) {
+        if (connection->modes().testFlag(flag))
+            emit connection->changed(mode);
+    }
+}

--- a/src/platform/platformnativeinterface.h
+++ b/src/platform/platformnativeinterface.h
@@ -15,9 +15,11 @@ class QKeyEvent;
 
 class PlatformWindow;
 class PlatformClipboard;
+class ClipboardConnection;
 
 using PlatformWindowPtr = std::shared_ptr<PlatformWindow>;
 using PlatformClipboardPtr = std::shared_ptr<PlatformClipboard>;
+using ClipboardConnectionPtr = std::unique_ptr<ClipboardConnection>;
 
 /**
  * Interface for platform dependent code.

--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -36,7 +36,7 @@ void setBinaryFor(int fd)
     _setmode(fd, _O_BINARY);
 }
 
-QString portableConfigFolder()
+QString portableFolder()
 {
     const QString appDir = QCoreApplication::applicationDirPath();
     if ( !QFileInfo(appDir).isWritable() )
@@ -46,11 +46,13 @@ QString portableConfigFolder()
     if ( QFile::exists(uninstPath) )
         return {};
 
-    const QString path = appDir + QLatin1String("/config");
-    QDir dir(path);
-
-    if ( !dir.mkpath(".") || !dir.isReadable() )
+    QDir dir(appDir);
+    if ( !dir.mkpath(QStringLiteral("config"))
+      || !dir.mkpath(QStringLiteral("logs"))
+      || !dir.isReadable() )
+    {
         return {};
+    }
 
     const QString fullPath = dir.absolutePath();
     if ( !QFileInfo(fullPath).isWritable() )
@@ -173,12 +175,13 @@ void initApplication(QCoreApplication *app)
     QSettings::setDefaultFormat(QSettings::IniFormat);
 
     // Use config and log file in portable app folder.
-    const QString portableFolder = portableConfigFolder();
-    if ( !portableFolder.isEmpty() ) {
-        QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, portableFolder);
-        if ( qEnvironmentVariableIsEmpty("COPYQ_LOG_FILE") )
-            qputenv("COPYQ_LOG_FILE", portableFolder.toLocal8Bit() + "/copyq.log");
-        app->setProperty("CopyQ_item_data_path", portableFolder + QLatin1String("/items"));
+    const QString folder = portableFolder();
+    if ( !folder.isEmpty() ) {
+        const QString configFolder = folder + QLatin1String("/config");
+        QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, configFolder);
+        if ( qEnvironmentVariableIsEmpty("COPYQ_LOG_DIR") )
+            qputenv("COPYQ_LOG_DIR", folder.toLocal8Bit() + "/logs");
+        app->setProperty("CopyQ_item_data_path", configFolder + QLatin1String("/items"));
     }
 }
 

--- a/src/platform/win/winplatformclipboard.h
+++ b/src/platform/win/winplatformclipboard.h
@@ -7,14 +7,16 @@
 
 #include <qt_windows.h>
 
+class QTimer;
+
 class WinPlatformClipboard final : public DummyClipboard
 {
 public:
-    void startMonitoring(const QStringList &) override;
-
     bool isHidden(const QMimeData &data) const override;
 
 protected:
+    void startMonitoringBackend(const QStringList &, ClipboardModeMask) override;
+    void stopMonitoringBackend() override;
     void onChanged(int) override;
     const long int *clipboardSequenceNumber(ClipboardMode) const override {
         return &m_lastClipboardSequenceNumber;
@@ -22,4 +24,5 @@ protected:
 
 private:
     long int m_lastClipboardSequenceNumber = 0;
+    QTimer *m_timer = nullptr;
 };

--- a/src/platform/x11/x11platform.cmake
+++ b/src/platform/x11/x11platform.cmake
@@ -8,6 +8,7 @@ file(GLOB copyq_SOURCES ${copyq_SOURCES}
 
 add_definitions( -DHAS_MOUSE_SELECTIONS )
 add_definitions( -DCOPYQ_MOVE_TO_WORKSPACE )
+list(APPEND copyq_qt_modules DBus)
 
 OPTION(WITH_X11 "Enable X11 support (global shortcuts, getting window titles)" ON)
 if (WITH_X11)
@@ -32,8 +33,6 @@ if (WITH_X11)
         platform/x11/x11platformwindow.cpp
         ../qxt/qxtglobalshortcut_x11.cpp
         )
-    list(APPEND copyq_qt_modules DBus)
-
     set(USE_QXT TRUE)
 
     set(copyq_LIBRARIES ${copyq_LIBRARIES} ${X11_LIBRARIES} ${X11_Xfixes_LIB})

--- a/src/platform/x11/x11platformclipboard.cpp
+++ b/src/platform/x11/x11platformclipboard.cpp
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <QApplication>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusArgument>
+#include <QDBusMessage>
+#include <QDBusReply>
+#include <QDBusServiceWatcher>
+#include <QDBusVariant>
+#include <QLoggingCategory>
+#include <memory>
 
 #include "x11platformclipboard.h"
 
@@ -9,7 +18,6 @@
 #include "common/clipboarddataguard.h"
 #include "common/common.h"
 #include "common/mimetypes.h"
-#include "common/log.h"
 #include "common/timer.h"
 
 #ifdef HAS_KGUIADDONS
@@ -27,14 +35,32 @@ using KSystemClipboard = WaylandClipboard;
 #endif
 
 #include <QClipboard>
+#include <QMetaType>
 #include <QMimeData>
 #include <QPointer>
+#include <optional>
 
 namespace {
+
+Q_LOGGING_CATEGORY(logClipboard, "copyq.clipboard")
+Q_LOGGING_CATEGORY(logClipboardGnome, "copyq.clipboard.gnome")
 
 constexpr auto minCheckAgainIntervalMs = 50;
 constexpr auto maxCheckAgainIntervalMs = 500;
 constexpr auto maxRetryCount = 3;
+const auto gnomeClipboardService = QStringLiteral("com.github.hluk.copyq.GnomeClipboard");
+const auto gnomeClipboardPath = QStringLiteral("/com/github/hluk/copyq/GnomeClipboard");
+const auto gnomeClipboardInterface = QStringLiteral("com.github.hluk.CopyQ.GnomeClipboard1");
+const auto gnomeClipboardClientPath = QStringLiteral("/com/github/hluk/copyq/GnomeClipboardClient");
+const auto gnomeClipboardClientInterface = QStringLiteral("com.github.hluk.CopyQ.GnomeClipboardClient1");
+constexpr int gnomeClipboardTypeClipboard = 0;
+constexpr int gnomeClipboardTypePrimary = 1;
+constexpr int gnomeClipboardTypeBoth = 2;
+
+int gnomeClipboardType(ClipboardMode mode)
+{
+    return mode == ClipboardMode::Selection ? gnomeClipboardTypePrimary : gnomeClipboardTypeClipboard;
+}
 
 /// Return true only if selection is incomplete, i.e. mouse button or shift key is pressed.
 bool isSelectionIncomplete()
@@ -61,40 +87,451 @@ bool isSelectionIncomplete()
 #endif
 }
 
+QVariant unwrapDbusValue(QVariant value)
+{
+    if (value.canConvert<QDBusVariant>())
+        value = value.value<QDBusVariant>().variant();
+
+    if (value.userType() == QMetaType::QByteArray)
+        return value;
+
+    if (value.canConvert<QByteArray>()) {
+        const auto bytes = value.toByteArray();
+        if (!bytes.isNull())
+            return bytes;
+    }
+
+    if (value.userType() == qMetaTypeId<QDBusArgument>()) {
+        const auto argument = value.value<QDBusArgument>();
+        if (argument.currentType() == QDBusArgument::VariantType) {
+            QVariant nested;
+            argument >> nested;
+            return unwrapDbusValue(nested);
+        }
+        if (argument.currentType() == QDBusArgument::ArrayType) {
+            QByteArray bytes;
+            argument.beginArray();
+            while (!argument.atEnd()) {
+                QVariant element;
+                argument >> element;
+                bytes.append(static_cast<char>(element.toUInt()));
+            }
+            argument.endArray();
+            return bytes;
+        }
+    }
+
+    return value;
+}
+
+QVariantMap variantToMap(const QVariant &value)
+{
+    if (value.canConvert<QVariantMap>())
+        return value.toMap();
+
+    if (value.userType() == qMetaTypeId<QDBusArgument>()) {
+        const auto argument = value.value<QDBusArgument>();
+        if (argument.currentType() == QDBusArgument::MapType) {
+            QVariantMap map;
+            argument.beginMap();
+            while (!argument.atEnd()) {
+                QString key;
+                QVariant entryValue;
+                argument.beginMapEntry();
+                argument >> key >> entryValue;
+                argument.endMapEntry();
+                map.insert(key, unwrapDbusValue(entryValue));
+            }
+            argument.endMap();
+            return map;
+        }
+    }
+
+    return {};
+}
+
+QVariantMap normalizeClipboardDataMap(const QVariantMap &dataMap)
+{
+    QVariantMap data;
+    for (auto it = dataMap.constBegin(); it != dataMap.constEnd(); ++it) {
+        QVariant value = unwrapDbusValue(it.value());
+        if (value.userType() == QMetaType::QByteArray) {
+            data.insert(it.key(), value);
+        } else if (value.userType() == QMetaType::QString) {
+            data.insert(it.key(), value.toString().toUtf8());
+        }
+    }
+    return data;
+}
+
+std::optional<QPair<QString, QVariant>> preferredClipboardFormatValue(const QVariantMap &dataMap)
+{
+    static const QStringList preferredFormats = {
+        QStringLiteral("text/plain;charset=utf-8"),
+        QStringLiteral("text/plain"),
+        QStringLiteral("text/uri-list"),
+        QStringLiteral("image/png"),
+        QStringLiteral("image/bmp"),
+        QStringLiteral("image/jpeg"),
+        QStringLiteral("image/gif"),
+        QStringLiteral("image/svg+xml"),
+        QStringLiteral("text/html"),
+    };
+
+    if (dataMap.isEmpty())
+        return std::nullopt;
+
+    for (const auto &format : preferredFormats) {
+        const auto it = dataMap.constFind(format);
+        if (it != dataMap.constEnd())
+            return QPair<QString, QVariant>(format, it.value());
+    }
+
+    for (auto it = dataMap.constBegin(); it != dataMap.constEnd(); ++it) {
+        if (!it.key().startsWith(QLatin1String(COPYQ_MIME_PREFIX)))
+            return QPair<QString, QVariant>(it.key(), it.value());
+    }
+
+    const auto it = dataMap.constBegin();
+    return QPair<QString, QVariant>(it.key(), it.value());
+}
+
+QVariantMap dataMapFromMimeData(const QMimeData *mimeData)
+{
+    if (mimeData == nullptr)
+        return {};
+
+    QVariantMap data;
+    for (const auto &format : mimeData->formats())
+        data.insert(format, mimeData->data(format));
+
+    if (mimeData->hasText()) {
+        const QByteArray bytes = mimeData->text().toUtf8();
+        data.insert(mimeText, bytes);
+        data.insert(mimeTextUtf8, bytes);
+    }
+    return data;
+}
+
 } // namespace
+
+class GnomeClipboardExtensionClient final : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.github.hluk.CopyQ.GnomeClipboardClient1")
+public:
+    explicit GnomeClipboardExtensionClient(QObject *parent)
+        : QObject(parent)
+        , m_connection(QDBusConnection::sessionBus())
+        , m_serviceWatcher(
+                gnomeClipboardService, m_connection,
+                QDBusServiceWatcher::WatchForRegistration
+                | QDBusServiceWatcher::WatchForUnregistration,
+                this)
+    {
+        if (!m_connection.isConnected()) {
+            qCWarning(logClipboardGnome)
+                << "Failed to register GNOME clipboard client: DBus is not available";
+            return;
+        }
+
+        m_registeredObject = m_connection.registerObject(
+            gnomeClipboardClientPath, this, QDBusConnection::ExportScriptableSlots);
+        if (!m_registeredObject) {
+            const auto error = m_connection.lastError();
+            qCInfo(logClipboardGnome)
+                << "Failed to register GNOME clipboard client:"
+                << error.name() << "-" << error.message();
+        }
+
+        connect(&m_serviceWatcher, &QDBusServiceWatcher::serviceRegistered,
+                this, &GnomeClipboardExtensionClient::onServiceRegistered);
+        connect(&m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered,
+                this, &GnomeClipboardExtensionClient::onServiceUnregistered);
+        m_serviceWatcherReady = m_connection.interface()
+            && m_connection.interface()->isServiceRegistered(gnomeClipboardService);
+    }
+
+    bool isConnected() const
+    {
+        return m_registeredObject && m_connection.isConnected() && m_serviceWatcherReady;
+    }
+
+    bool isRegisteredWithExtension() const { return m_registeredWithExtension; }
+
+    ~GnomeClipboardExtensionClient() override
+    {
+        unregisterClient();
+        if (m_registeredObject)
+            m_connection.unregisterObject(gnomeClipboardClientPath);
+    }
+
+    void registerClipboardTypes(int clipboardTypes)
+    {
+        m_clipboardTypes = clipboardTypes;
+        if (m_serviceWatcherReady)
+            registerClient();
+    }
+
+    void unregisterClipboardTypes()
+    {
+        unregisterClient();
+    }
+
+    QStringList fetchClipboardFormats(ClipboardMode mode) const
+    {
+        if (!m_serviceWatcherReady)
+            return {};
+
+        auto message = QDBusMessage::createMethodCall(
+            gnomeClipboardService, gnomeClipboardPath, gnomeClipboardInterface,
+            QStringLiteral("GetClipboardFormats"));
+        message << gnomeClipboardType(mode);
+        const QDBusMessage reply = m_connection.call(message);
+        if (reply.type() == QDBusMessage::ErrorMessage) {
+            qCWarning(logClipboardGnome)
+                << "Failed to fetch clipboard formats from GNOME extension:"
+                << reply.errorName() << "-" << reply.errorMessage();
+            return {};
+        }
+
+        const auto arguments = reply.arguments();
+        if (arguments.isEmpty() || !arguments.first().canConvert<QStringList>()) {
+            qCWarning(logClipboardGnome)
+                << "Failed to fetch clipboard formats from GNOME extension: invalid reply";
+            return {};
+        }
+        return arguments.first().toStringList();
+    }
+
+    QVariantMap fetchClipboardData(ClipboardMode mode, const QStringList &formats) const
+    {
+        if (!m_serviceWatcherReady)
+            return {};
+
+        auto message = QDBusMessage::createMethodCall(
+            gnomeClipboardService, gnomeClipboardPath, gnomeClipboardInterface,
+            QStringLiteral("GetClipboardData"));
+        message << gnomeClipboardType(mode) << formats;
+        const QDBusMessage reply = m_connection.call(message);
+        if (reply.type() == QDBusMessage::ErrorMessage) {
+            qCWarning(logClipboardGnome)
+                << "Failed to fetch clipboard data from GNOME extension:"
+                << reply.errorName() << "-" << reply.errorMessage();
+            return {};
+        }
+
+        const auto arguments = reply.arguments();
+        if (arguments.isEmpty()) {
+            qCWarning(logClipboardGnome)
+                << "Failed to fetch clipboard data from GNOME extension: empty reply";
+            return {};
+        }
+
+        auto data = variantToMap(arguments.first());
+        for (auto it = data.begin(); it != data.end(); ++it) {
+            it.value() = unwrapDbusValue(it.value());
+        }
+        return data;
+    }
+
+    void setClipboardData(ClipboardMode mode, const QString &format, const QVariant &value)
+    {
+        if (!m_serviceWatcherReady)
+            return;
+
+        auto message = QDBusMessage::createMethodCall(
+            gnomeClipboardService, gnomeClipboardPath, gnomeClipboardInterface,
+            QStringLiteral("SetClipboardData"));
+        message << gnomeClipboardType(mode) << format << QVariant::fromValue(QDBusVariant(value));
+        QDBusReply<void> reply = m_connection.call(message);
+        if (!reply.isValid()) {
+            qCWarning(logClipboardGnome)
+                << "Failed to set clipboard data through GNOME extension:"
+                << format << reply.error().name() << "-" << reply.error().message();
+        }
+    }
+
+signals:
+    void clipboardChanged(int clipboardType);
+
+public slots:
+    Q_SCRIPTABLE void ClipboardChanged(int clipboardType)
+    {
+        emit clipboardChanged(clipboardType);
+    }
+
+private:
+    void registerClient()
+    {
+        auto message = QDBusMessage::createMethodCall(
+            gnomeClipboardService, gnomeClipboardPath, gnomeClipboardInterface,
+            QStringLiteral("RegisterClipboardClient"));
+        message << m_clipboardTypes;
+        QDBusReply<void> reply = m_connection.call(message);
+        if (!reply.isValid()) {
+            m_registeredWithExtension = false;
+            qCWarning(logClipboardGnome)
+                << "Failed to register with GNOME extension service:"
+                << reply.error().name() << "-" << reply.error().message();
+        } else {
+            m_registeredWithExtension = true;
+            qCDebug(logClipboardGnome)
+                << "Registered with GNOME extension service, clipboardTypes:"
+                << m_clipboardTypes;
+        }
+    }
+
+    void unregisterClient()
+    {
+        if (!m_registeredWithExtension)
+            return;
+
+        auto message = QDBusMessage::createMethodCall(
+            gnomeClipboardService, gnomeClipboardPath, gnomeClipboardInterface,
+            QStringLiteral("UnregisterClipboardClient"));
+        QDBusReply<void> reply = m_connection.call(message);
+        if (!reply.isValid()) {
+            qCWarning(logClipboardGnome)
+                << "Failed to unregister from GNOME extension service:"
+                << reply.error().message();
+        } else {
+            m_registeredWithExtension = false;
+        }
+    }
+
+    void onServiceRegistered(const QString &name)
+    {
+        if (name == gnomeClipboardService) {
+            m_serviceWatcherReady = true;
+            registerClient();
+        }
+    }
+
+    void onServiceUnregistered(const QString &name)
+    {
+        if (name == gnomeClipboardService) {
+            m_serviceWatcherReady = false;
+            m_registeredWithExtension = false;
+        }
+    }
+
+    QDBusConnection m_connection;
+    QDBusServiceWatcher m_serviceWatcher;
+    int m_clipboardTypes = gnomeClipboardTypeClipboard;
+    bool m_registeredObject = false;
+    bool m_registeredWithExtension = false;
+    bool m_serviceWatcherReady = false;
+};
+
+class GnomeExtensionMimeData final : public QMimeData
+{
+public:
+    explicit GnomeExtensionMimeData(const GnomeClipboardExtensionClient *client, ClipboardMode mode)
+        : m_client(client)
+        , m_mode(mode)
+    {}
+
+    QStringList formats() const override
+    {
+        return m_client ? m_client->fetchClipboardFormats(m_mode) : QStringList{};
+    }
+
+    bool hasFormat(const QString &mimeType) const override
+    {
+        if (!m_client)
+            return false;
+        const auto formats = m_client->fetchClipboardFormats(m_mode);
+        if (formats.contains(mimeType))
+            return true;
+        const auto data = m_client->fetchClipboardData(m_mode, {mimeType});
+        return data.contains(mimeType);
+    }
+
+protected:
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+    QVariant retrieveData(const QString &mimeType, QMetaType preferredType) const override
+#else
+    QVariant retrieveData(const QString &mimeType, QVariant::Type preferredType) const override
+#endif
+    {
+        Q_UNUSED(preferredType)
+        if (!m_client)
+            return {};
+
+        auto data = m_client->fetchClipboardData(m_mode, {mimeType});
+        const auto value = data.value(mimeType);
+        if (value.userType() == QMetaType::QByteArray)
+            return value;
+        if (value.userType() == QMetaType::QString)
+            return value.toString().toUtf8();
+        if (value.canConvert<QByteArray>())
+            return value.toByteArray();
+        return {};
+    }
+
+private:
+    const GnomeClipboardExtensionClient *m_client = nullptr;
+    ClipboardMode m_mode = ClipboardMode::Clipboard;
+};
 
 X11PlatformClipboard::X11PlatformClipboard()
 {
     m_clipboardData.mode = ClipboardMode::Clipboard;
     m_selectionData.mode = ClipboardMode::Selection;
 
-    // Create Wayland clipboard instance so it can start receiving new data.
     if ( !X11Info::isPlatformX11() ) {
+        // Create Wayland clipboard instance so it can start receiving new data.
         KSystemClipboard::instance();
+
+        // Try to register with CopyQ GNOME extension.
+        m_gnomeClipboardExtensionClient = std::make_unique<GnomeClipboardExtensionClient>(this);
+        connect(
+            m_gnomeClipboardExtensionClient.get(), &GnomeClipboardExtensionClient::clipboardChanged,
+            this, &X11PlatformClipboard::onGnomeClipboardChanged );
+        if (!m_gnomeClipboardExtensionClient->isConnected())
+            m_gnomeClipboardExtensionClient.reset();
     }
 }
 
-void X11PlatformClipboard::startMonitoring(const QStringList &formats)
+X11PlatformClipboard::~X11PlatformClipboard() = default;
+
+void X11PlatformClipboard::updateMonitoringSubscription(
+        const QStringList &formats, ClipboardModeMask modes)
 {
     m_clipboardData.formats = formats;
 
     // Avoid asking apps for bigger data when mouse selection changes.
     // This could make the app hang for a moment.
-    m_selectionData.formats.append(mimeText);
-    m_selectionData.formats.append(mimeTextUtf8);
+    m_selectionData.formats = QStringList{mimeText, mimeTextUtf8};
     for (auto &format : formats) {
         if (!format.startsWith(QLatin1String("image/")) && !format.startsWith(QLatin1String("text/")))
             m_selectionData.formats.append(format);
     }
 
+    m_clipboardData.enabled = modes.testFlag(ClipboardModeFlag::Clipboard);
+    m_selectionData.enabled = modes.testFlag(ClipboardModeFlag::Selection);
+
     if ( m_selectionData.enabled && !QGuiApplication::clipboard()->supportsSelection() ) {
-        log("X11 selection is not supported, disabling.");
+        qCWarning(logClipboard) << "X11 selection is not supported, disabling.";
         m_selectionData.enabled = false;
     }
+
+    if (!X11Info::isPlatformX11() && m_monitoring && isGnomeExtensionAvailable()) {
+        m_gnomeClipboardExtensionClient->registerClipboardTypes(toGnomeClipboardTypes(modes));
+    }
+}
+
+void X11PlatformClipboard::startMonitoringBackend(
+        const QStringList &formats, ClipboardModeMask modes)
+{
+    updateMonitoringSubscription(formats, modes);
 
     if ( !X11Info::isPlatformX11() ) {
         connect(KSystemClipboard::instance(), &KSystemClipboard::changed,
                 this, [this](QClipboard::Mode mode){ onClipboardChanged(mode); });
+        if (isGnomeExtensionAvailable())
+            m_gnomeClipboardExtensionClient->registerClipboardTypes(toGnomeClipboardTypes(modes));
     }
 
     // Ignore the initial clipboard content since
@@ -127,19 +564,36 @@ void X11PlatformClipboard::startMonitoring(const QStringList &formats)
 
     m_monitoring = true;
 
-    DummyClipboard::startMonitoring(formats);
+    DummyClipboard::startMonitoringBackend(formats, modes);
 }
 
-void X11PlatformClipboard::setMonitoringEnabled(ClipboardMode mode, bool enable)
+void X11PlatformClipboard::stopMonitoringBackend()
 {
-    auto &clipboardData = mode == ClipboardMode::Clipboard ? m_clipboardData : m_selectionData;
-    clipboardData.enabled = enable;
+    if (!m_monitoring)
+        return;
+
+    m_timerCheckAgain.stop();
+    m_clipboardData.timerEmitChange.stop();
+    m_selectionData.timerEmitChange.stop();
+    m_monitoring = false;
+
+    if ( !X11Info::isPlatformX11() ) {
+        disconnect(KSystemClipboard::instance(), nullptr, this, nullptr);
+        if (isGnomeExtensionAvailable())
+            m_gnomeClipboardExtensionClient->unregisterClipboardTypes();
+    }
+
+    DummyClipboard::stopMonitoringBackend();
 }
 
 QVariantMap X11PlatformClipboard::data(ClipboardMode mode, const QStringList &formats) const
 {
-    if (!m_monitoring)
+    if (!m_monitoring) {
+        if (isGnomeExtensionAvailable()) {
+            return m_gnomeClipboardExtensionClient->fetchClipboardData(mode, formats);
+        }
         return DummyClipboard::data(mode, formats);
+    }
 
     const auto &clipboardData = mode == ClipboardMode::Clipboard ? m_clipboardData : m_selectionData;
 
@@ -147,6 +601,21 @@ QVariantMap X11PlatformClipboard::data(ClipboardMode mode, const QStringList &fo
     if ( !data.contains(mimeOwner) )
         data[mimeWindowTitle] = clipboardData.owner.toUtf8();
     return data;
+}
+
+const QMimeData *X11PlatformClipboard::mimeData(ClipboardMode mode) const
+{
+    if (isGnomeExtensionAvailable()) {
+        std::unique_ptr<QMimeData> &ptr = (mode == ClipboardMode::Clipboard)
+            ? m_gnomeClipboardMimeData : m_gnomeSelectionMimeData;
+        if (!ptr) {
+            ptr = std::make_unique<GnomeExtensionMimeData>(
+                    m_gnomeClipboardExtensionClient.get(), mode);
+        }
+        return ptr.get();
+    }
+
+    return DummyClipboard::mimeData(mode);
 }
 
 void X11PlatformClipboard::setData(ClipboardMode mode, const QVariantMap &dataMap)
@@ -164,17 +633,30 @@ void X11PlatformClipboard::setData(ClipboardMode mode, const QVariantMap &dataMa
             DummyClipboard::setData(mode, dataMap);
         }
     } else {
-        DummyClipboard::setData(mode, dataMap);
         auto data = createMimeData(dataMap);
         const auto qmode = modeToQClipboardMode(mode);
-        // WORKAROUND: KGuiAddons does not handle UTF-8 text properly.
-        // This unfortunately overrides "text/plain" with
-        // "text/plain;charset=utf-8" (these can differ).
-        // See: https://invent.kde.org/frameworks/kguiaddons/-/merge_requests/184
-        if (dataMap.contains(mimeTextUtf8))
-            data->setText(dataMap.value(mimeTextUtf8).toString());
-        KSystemClipboard::instance()->setMimeData(data, qmode);
+        if (isGnomeExtensionAvailable()) {
+            setGnomeExtensionClipboardData(mode, dataMap);
+            DummyClipboard::setData(mode, dataMap);
+        } else {
+            DummyClipboard::setData(mode, dataMap);
+            // WORKAROUND: KGuiAddons does not handle UTF-8 text properly.
+            // This unfortunately overrides "text/plain" with
+            // "text/plain;charset=utf-8" (these can differ).
+            // See: https://invent.kde.org/frameworks/kguiaddons/-/merge_requests/184
+            if (dataMap.contains(mimeTextUtf8))
+                data->setText(dataMap.value(mimeTextUtf8).toString());
+            else
+                KSystemClipboard::instance()->setMimeData(data, qmode);
+        }
     }
+}
+
+void X11PlatformClipboard::setRawData(ClipboardMode mode, QMimeData *mimeData)
+{
+    if (isGnomeExtensionAvailable())
+        setGnomeExtensionClipboardData(mode, dataMapFromMimeData(mimeData));
+    DummyClipboard::setRawData(mode, mimeData);
 }
 
 const QMimeData *X11PlatformClipboard::rawMimeData(ClipboardMode mode) const
@@ -204,12 +686,12 @@ void X11PlatformClipboard::onChanged(int mode)
     if (mode == QClipboard::Selection) {
         // Omit checking selection too fast.
         if ( m_timerCheckAgain.isActive() ) {
-            COPYQ_LOG("Postponing fast selection change");
+            qCDebug(logClipboard) << "Postponing fast selection change";
             return;
         }
 
         if ( isSelectionIncomplete() ) {
-            COPYQ_LOG("Selection is incomplete");
+            qCDebug(logClipboard) << "Selection is incomplete";
             if ( !m_timerCheckAgain.isActive()
                  || minCheckAgainIntervalMs < m_timerCheckAgain.remainingTime() )
             {
@@ -276,10 +758,10 @@ void X11PlatformClipboard::updateClipboardData(X11PlatformClipboard::ClipboardDa
             m_timerCheckAgain.start(clipboardData->retry * maxCheckAgainIntervalMs);
         }
 
-        log( QString("Failed to retrieve %1 data (try %2/%3)")
-             .arg(clipboardData->mode == ClipboardMode::Clipboard ? "clipboard" : "selection")
-             .arg(clipboardData->retry)
-             .arg(maxRetryCount), LogWarning );
+        qCWarning(logClipboard)
+            << "Failed to retrieve"
+            << (clipboardData->mode == ClipboardMode::Clipboard ? "clipboard" : "selection")
+            << "data, try" << clipboardData->retry << "of" << maxRetryCount;
 
         return;
     }
@@ -326,9 +808,9 @@ void X11PlatformClipboard::updateClipboardData(X11PlatformClipboard::ClipboardDa
 
 void X11PlatformClipboard::useNewClipboardData(X11PlatformClipboard::ClipboardData *clipboardData)
 {
-    COPYQ_LOG( QStringLiteral("%1 CHANGED, owner=%2")
-            .arg(clipboardData->mode == ClipboardMode::Clipboard ? "Clipboard" : "Selection")
-            .arg(clipboardData->newOwner) );
+    qCDebug(logClipboard)
+        << (clipboardData->mode == ClipboardMode::Clipboard ? "Clipboard" : "Selection")
+        << "CHANGED, owner:" << clipboardData->newOwner;
 
     clipboardData->data = clipboardData->newData;
     clipboardData->owner = clipboardData->newOwner;
@@ -336,7 +818,7 @@ void X11PlatformClipboard::useNewClipboardData(X11PlatformClipboard::ClipboardDa
     if (clipboardData->ignoreNext)
         clipboardData->ignoreNext = false;
     else
-        emit changed(clipboardData->mode);
+        emitConnectionChanged(clipboardData->mode);
 }
 
 void X11PlatformClipboard::checkAgainLater(bool clipboardChanged, int interval)
@@ -346,3 +828,40 @@ void X11PlatformClipboard::checkAgainLater(bool clipboardChanged, int interval)
     else if (clipboardChanged)
         m_timerCheckAgain.start(maxCheckAgainIntervalMs);
 }
+
+void X11PlatformClipboard::onGnomeClipboardChanged(int clipboardType)
+{
+    if (clipboardType == gnomeClipboardTypeClipboard) {
+        qCDebug(logClipboardGnome) << "GNOME Clipboard change";
+        onChanged(QClipboard::Clipboard);
+    } else {
+        qCDebug(logClipboardGnome) << "GNOME Selection change";
+        onChanged(QClipboard::Selection);
+    }
+}
+
+bool X11PlatformClipboard::isGnomeExtensionAvailable() const
+{
+    return m_gnomeClipboardExtensionClient
+        && m_gnomeClipboardExtensionClient->isConnected();
+}
+
+void X11PlatformClipboard::setGnomeExtensionClipboardData(ClipboardMode mode, const QVariantMap &dataMap) const
+{
+    const QVariantMap normalizedDataMap = normalizeClipboardDataMap(dataMap);
+    if (const auto preferred = preferredClipboardFormatValue(normalizedDataMap))
+        m_gnomeClipboardExtensionClient->setClipboardData(mode, preferred->first, preferred->second);
+}
+
+int X11PlatformClipboard::toGnomeClipboardTypes(ClipboardModeMask modes) const
+{
+    const bool clipboard = modes.testFlag(ClipboardModeFlag::Clipboard);
+    const bool selection = modes.testFlag(ClipboardModeFlag::Selection);
+    if (clipboard && selection)
+        return gnomeClipboardTypeBoth;
+    if (selection)
+        return gnomeClipboardTypePrimary;
+    return gnomeClipboardTypeClipboard;
+}
+
+#include "x11platformclipboard.moc"

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -1482,8 +1482,7 @@ QJSValue Scriptable::info()
 {
     m_skipArguments = 1;
 
-    const QString logFile = QStringLiteral("%1-*.log*")
-        .arg(logFileName().section('-', 0, -3));
+    const QString logFile = logFileName();
     using InfoMap = QMap<QString, QString>;
     InfoMap info;
     info.insert("config", QSettings().fileName());

--- a/src/tests/tests_common.cpp
+++ b/src/tests/tests_common.cpp
@@ -54,7 +54,6 @@ bool testStderr(
         plain("QXcbClipboard: SelectionRequest too old"),
         plain("libpng warning: iCCP: known incorrect sRGB profile"),
         plain("QMime::convertToMime: unhandled mimetype: text/plain"),
-        plain("[kf.notifications] Failed to notify \"Created too many similar notifications in quick succession\""),
         plain("Failed to register with host portal"),
         plain("Deleting keychain failed"),
 
@@ -63,6 +62,11 @@ bool testStderr(
         plain("Unexpected wl_keyboard.enter event"),
         plain("The compositor sent a wl_pointer.enter"),
         plain("QObject::connect: No such signal QPlatformNativeInterface::systemTrayWindowChanged(QScreen*)"),
+        plain("Could not init WaylandClipboard, falling back to QtClipboard."),
+
+        // KDE Frameworks (Linux)
+        plain("[kf.notifications]"),
+        plain("[kf.statusnotifieritem]"),
 
         // Windows
         plain("QWindowsWindow::setGeometry: Unable to set geometry"),

--- a/src/tests/tests_common.cpp
+++ b/src/tests/tests_common.cpp
@@ -68,7 +68,7 @@ bool testStderr(
         plain("QWindowsWindow::setGeometry: Unable to set geometry"),
         plain("QWinEventNotifier: no event dispatcher, application shutting down? Cannot deliver event."),
         plain("setGeometry: Unable to set geometry"),
-        plain("QWindowsPipeWriter:"),
+        plain("Failed to raise: "),
 
         plain("[kf.notifications] Received a response for an unknown notification."),
         // KStatusNotifierItem

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -636,11 +636,17 @@ void Tests::commandCopy()
     RUN("copy" << "DATA" << "B", "true\n");
     WAIT_FOR_CLIPBOARD2("B", "DATA");
 
+    // Test copying UTF-8 text.
+    RUN("--" << "copy({[mimeText]: '\\\\u2705', [mimeTextUtf8]: '✅'})", "true\n");
+    WAIT_FOR_CLIPBOARD2("✅", mimeTextUtf8);
+
     RUN( Args() << "copy"
          << "DATA3" << "C"
          << "DATA4" << "D"
          , "true\n" );
     WAIT_FOR_CLIPBOARD2("C", "DATA3");
+
+    SKIP_ON_ENV("COPYQ_TESTS_SKIP_MULTIPLE_CLIPBOARD_FORMATS");
     WAIT_FOR_CLIPBOARD2("D", "DATA4");
 
     RUN( "copy({'DATA1': 1, 'DATA2': 2})", "true\n" );
@@ -653,17 +659,12 @@ void Tests::commandCopy()
     RUN_EXPECT_ERROR_WITH_STDERR(
         "copy([{}, {}])",
         CommandException, "Expected single item");
-
-    // Test copying UTF-8 text.
-    RUN("--" << "copy({[mimeText]: '\\\\u2705', [mimeTextUtf8]: '✅'})", "true\n");
-    WAIT_FOR_CLIPBOARD2("✅", mimeTextUtf8);
 }
 
 void Tests::commandClipboard()
 {
     TEST( m_test->setClipboard("A") );
     WAIT_FOR_CLIPBOARD("A");
-    RUN("clipboard", "A");
 
     TEST( m_test->setClipboard("B", "DATA") );
     WAIT_FOR_CLIPBOARD2("B", "DATA");
@@ -675,7 +676,10 @@ void Tests::commandHasClipboardFormat()
     TEST( m_test->setClipboard("B", "DATA") );
     WAIT_FOR_CLIPBOARD2("B", "DATA");
     WAIT_ON_OUTPUT("hasClipboardFormat('DATA')", "true\n");
-    WAIT_ON_OUTPUT("hasClipboardFormat('text/plain')", "false\n");
+    RUN("hasClipboardFormat('text/plain')", "false\n");
+
+    TEST( m_test->setClipboard("A") );
+    WAIT_ON_OUTPUT("hasClipboardFormat('text/plain')", "true\n");
 }
 
 void Tests::commandEdit()

--- a/utils/github/test-linux-gnome-extension.sh
+++ b/utils/github/test-linux-gnome-extension.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Runs GNOME extension clipboard integration test.
+set -xeuo pipefail
+
+export QT_QPA_PLATFORM=wayland
+
+# Launch in clean environment
+if [[ -z "${COPYQ_TESTS_GNOME_EXTENSION_INIT:-}" ]]; then
+    tmp_dir="$(mktemp -d)"
+    cleanup() {
+        while ! rm -rf "$tmp_dir"; do
+            sleep 0.2
+        done
+    }
+    trap cleanup EXIT TERM INT HUP
+    mkdir -p "$tmp_dir/.config" \
+        "$tmp_dir/.local/share" \
+        "$tmp_dir/.cache" \
+        "$tmp_dir/.runtime"
+    chmod 0700 "$tmp_dir/.runtime"
+    env --ignore-environment \
+        COPYQ_TESTS_GNOME_EXTENSION_INIT=1 \
+        HOME="$tmp_dir" \
+        COPYQ_LOG_LEVEL="${COPYQ_LOG_LEVEL:-DEBUG}" \
+        QT_LOGGING_RULES="${QT_LOGGING_RULES:-*.debug=true;qt.*.debug=false;qt.*.warning=true}" \
+        COPYQ_GNOME_EXTENSION_DEBUG="${COPYQ_GNOME_EXTENSION_DEBUG:-1}" \
+        COPYQ_SESSION_NAME="${COPYQ_SESSION_NAME:-__COPYQ_GNOMEEXT}" \
+        COPYQ_TESTS_EXECUTABLE="$COPYQ_TESTS_EXECUTABLE" \
+        COPYQ_TESTS_TESTS_EXECUTABLE="${COPYQ_TESTS_TESTS_EXECUTABLE:-./copyq-tests}" \
+        COPYQ_TESTS_SKIP_MULTIPLE_CLIPBOARD_FORMATS=1 \
+        XDG_CONFIG_HOME="$tmp_dir/.config" \
+        XDG_DATA_HOME="$tmp_dir/.local/share" \
+        XDG_DATA_DIRS="$tmp_dir/.local/share" \
+        XDG_CACHE_HOME="$tmp_dir/.cache" \
+        XDG_RUNTIME_DIR="$tmp_dir/.runtime" \
+        LANG="$LANG" \
+        dbus-run-session -- "$0" "$@"
+    exit
+fi
+
+if [[ ! -x "$COPYQ_TESTS_EXECUTABLE" ]]; then
+    echo "❌ FAILED: CopyQ executable not found: $COPYQ_TESTS_EXECUTABLE"
+    exit 1
+fi
+if [[ ! -x "$COPYQ_TESTS_TESTS_EXECUTABLE" ]]; then
+    echo "❌ FAILED: copyq-tests executable not found: $COPYQ_TESTS_TESTS_EXECUTABLE"
+    exit 1
+fi
+
+# Install GNOME extension before starting gnome-shell
+extension_uuid="copyq-clipboard@hluk.github.com"
+prefix_dir="$(cd "$(dirname "$COPYQ_TESTS_EXECUTABLE")/.." && pwd)"
+installed_extension_dir="${COPYQ_GNOME_EXTENSION_DIR:-$prefix_dir/share/gnome-shell/extensions/$extension_uuid}"
+if [[ ! -d "$installed_extension_dir" ]]; then
+    echo "❌ FAILED: Extension not found: $installed_extension_dir"
+    exit 1
+fi
+user_extension_dir="${HOME}/.local/share/gnome-shell/extensions/${extension_uuid}"
+mkdir -p "$(dirname "$user_extension_dir")"
+rm -rf "$user_extension_dir"
+cp -a "$installed_extension_dir" "$user_extension_dir"
+
+# Some CI images miss compiled GNOME schemas even when gnome-shell is installed.
+schema_dir=$XDG_DATA_HOME/glib-2.0/schemas
+mkdir -p "$schema_dir"
+glib-compile-schemas --targetdir="$schema_dir" /usr/share/glib-2.0/schemas
+if ! gsettings list-schemas 2>/dev/null | grep -qx 'org.gnome.shell'; then
+    echo "❌ FAILED: GNOME schema org.gnome.shell is unavailable"
+    exit 1
+fi
+
+# Avoid dependency on org.gnome.Shell.Extensions helper in minimal environments.
+gsettings set org.gnome.shell disable-user-extensions false || true
+gsettings set org.gnome.shell enabled-extensions "['${extension_uuid}']" || true
+
+cleanup() {
+    kill ${gnome_pid:-} ${tail_pid:-} ${copyq_pid:-} 2>/dev/null || true
+}
+trap cleanup EXIT TERM INT HUP
+
+gnome-shell --headless --wayland --wayland-display=copyq-wayland --no-x11 --virtual-monitor 1280x960 &
+gnome_pid=$!
+
+check_gnome_running() {
+    if ! kill -0 "$gnome_pid"; then
+        echo "❌ FAILED: gnome-shell is not running"
+        exit 1
+    fi
+}
+
+export WAYLAND_DISPLAY=copyq-wayland
+socket=$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY
+for _ in {1..20}; do
+    check_gnome_running
+    if [[ -S "$socket" ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ -S "$socket" ]]; then
+    echo "✅ PASSED: Wayland display is available"
+else
+    echo "❌ FAILED: Wayland display not available"
+    exit 1
+fi
+
+extention_service_health_check() {
+    gdbus call --session \
+        --dest org.freedesktop.DBus \
+        --object-path /org/freedesktop/DBus \
+        --method org.freedesktop.DBus.NameHasOwner \
+        com.github.hluk.copyq.GnomeClipboard | grep -q "true"
+}
+
+try=0
+while ! extention_service_health_check; do
+    check_gnome_running
+    try=$((try + 1))
+    if (( try > 20 )); then
+        echo "❌ FAILED: GNOME extension service health check failed"
+        exit 1
+    fi
+    sleep 0.5
+done
+echo "✅ PASSED: GNOME extension service is running"
+
+export COPYQ_LOG_FILE="$XDG_RUNTIME_DIR/copyq.log"
+touch "$COPYQ_LOG_FILE"
+tail -f "$COPYQ_LOG_FILE" &
+tail_pid=$!
+
+"$COPYQ_TESTS_EXECUTABLE" 2>/dev/null &
+copyq_pid=$!
+COPYQ_WAIT_FOR_SERVER_MS=5000 "$COPYQ_TESTS_EXECUTABLE" '
+    config("check_selection", true);
+    while(!isClipboardMonitorRunning()) {};
+    hide();
+'
+
+set_clipboard() {
+    clipboard_type=$1
+    text=$2
+    if [[ "$clipboard_type" == CLIPBOARD ]]; then
+        clipboard_type_id=0
+    else
+        clipboard_type_id=1
+    fi
+    gdbus call --session \
+        --dest com.github.hluk.copyq.GnomeClipboard \
+        --object-path /com/github/hluk/copyq/GnomeClipboard \
+        --method com.github.hluk.CopyQ.GnomeClipboard1.SetClipboardData \
+        "$clipboard_type_id" \
+        "text/plain;charset=utf-8" \
+        "<'$text'>"
+}
+
+test_clipboard() {
+    clipboard_type=$1
+    text=$2
+    set_clipboard "$clipboard_type" "$text"
+    script="
+        for (i=0; i<20; ++i) {
+            if (read(0) == '$text') {
+                abort();
+            }
+            sleep(100);
+        }
+        fail();
+    "
+    if "$COPYQ_TESTS_EXECUTABLE" "$script"; then
+        echo "✅ PASSED: $clipboard_type item propagated from GNOME extension"
+    else
+        echo "❌ FAILED: $clipboard_type item did not propagate from GNOME extension"
+        exit 1
+    fi
+}
+
+test_clipboard CLIPBOARD 'CLIPBOARD TEXT'
+test_clipboard PRIMARY 'PRIMARY TEXT'
+
+"$COPYQ_TESTS_EXECUTABLE" exit
+
+"$COPYQ_TESTS_TESTS_EXECUTABLE" commandHasClipboardFormat commandCopy commandClipboard


### PR DESCRIPTION
Uses a custom GNOME extension for monitoring clipboard, since apps
themselves cannot do that.

The extension cannot set multiple formats to clipboard. The most useful
known format is selected, or a random one.

Assisted-by: gpt-5.3-codex

Fixes #2342, fixes #1243