### PR TITLE
Replace deprecated qt_add_translation function

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ set(copyq_COMPILE
 add_library(copyq-common OBJECT ${copyq_COMPILE})
 
 find_package(${copyq_qt} REQUIRED COMPONENTS LinguistTools)
-if("${QT_VERSION_MAJOR}" STREQUAL "5")
+if("${QT_DEFAULT_MAJOR_VERSION}" STREQUAL "5")
     qt5_add_translation(copyq_QM ${copyq_TRANSLATIONS})
 else()
     qt_add_translations(copyq-common

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,14 +57,18 @@ set(copyq_COMPILE
     ${copyq_SOURCES}
     ${copyq_FORMS_HEADERS}
     ${copyq_VERSION_FILE}
-    )
+   )
 add_library(copyq-common OBJECT ${copyq_COMPILE})
 
 find_package(${copyq_qt} REQUIRED COMPONENTS LinguistTools)
-qt_add_translations(copyq-common
-    TS_FILES ${copyq_TRANSLATIONS}
-    QM_FILES_OUTPUT_VARIABLE copyq_QM
-)
+if("${QT_VERSION_MAJOR}" STREQUAL "5")
+    qt5_add_translation(copyq_QM ${copyq_TRANSLATIONS})
+else()
+    qt_add_translations(copyq-common
+        TS_FILES ${copyq_TRANSLATIONS}
+        QM_FILES_OUTPUT_VARIABLE copyq_QM
+    )
+endif()
 
 if (NOT copyq_version)
     message(FATAL_ERROR "Application version is unset")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,11 +13,12 @@ file(GLOB copyq_FORMS
     ui/*.ui
     )
 
+# translations
+file(GLOB copyq_TRANSLATIONS ../translations/*.ts)
+
 set(copyq_RESOURCES copyq.qrc)
 
 # Qt include paths and definitions
-set(copyq_DEFINITIONS ${${copyq_qt}Widgets_DEFINITIONS})
-
 include(notifications.cmake)
 include(platform/platform.cmake)
 
@@ -30,12 +31,6 @@ if (USE_QXT)
     list(APPEND copyq_SOURCES ../qxt/qxtglobalshortcut.cpp)
     list(APPEND copyq_DEFINITIONS QXT_STATIC COPYQ_GLOBAL_SHORTCUTS)
 endif()
-
-# translations
-file(GLOB copyq_TRANSLATIONS ../translations/*.ts)
-
-find_package(${copyq_qt}LinguistTools REQUIRED)
-qt_add_translation(copyq_QM ${copyq_TRANSLATIONS})
 
 qt_wrap_ui(copyq_FORMS_HEADERS ${copyq_FORMS})
 qt_add_resources(copyq_RESOURCES_RCC ${copyq_RESOURCES})
@@ -64,6 +59,12 @@ set(copyq_COMPILE
     ${copyq_VERSION_FILE}
     )
 add_library(copyq-common OBJECT ${copyq_COMPILE})
+
+find_package(${copyq_qt} REQUIRED COMPONENTS LinguistTools)
+qt_add_translations(copyq-common
+    TS_FILES ${copyq_TRANSLATIONS}
+    QM_FILES_OUTPUT_VARIABLE copyq_QM
+)
 
 if (NOT copyq_version)
     message(FATAL_ERROR "Application version is unset")
@@ -129,8 +130,8 @@ endforeach()
 
 set_target_properties(copyq-common PROPERTIES COMPILE_DEFINITIONS "${copyq_DEFINITIONS}")
 set_target_properties(${COPYQ_EXECUTABLE_NAME} PROPERTIES LINK_FLAGS "${copyq_LINK_FLAGS}")
-target_link_libraries(${COPYQ_EXECUTABLE_NAME} ${copyq_LIBRARIES})
 target_link_libraries(copyq-common ${copyq_LIBRARIES})
+target_link_libraries(${COPYQ_EXECUTABLE_NAME} ${copyq_LIBRARIES})
 target_include_directories(copyq-common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} .)
 target_include_directories(${COPYQ_EXECUTABLE_NAME} PRIVATE .)
 


### PR DESCRIPTION
Hello, the qt_add_translation is deprecated (as per https://doc.qt.io/qt-6/qtlinguist-cmake-qt-add-translation.html)

Also while trying to package your app, I struggled with `set(copyq_DEFINITIONS ${${copyq_qt}Widgets_DEFINITIONS})`. It seems to look for extra widgets definitions but launchpad didn't work. Looks fine without it so I'm wondering if it's still needed.

Thanks for your reply :)