### PR TITLE
Use abbreviated unit for spinbox suffix

### DIFF
--- a/src/ui/configtabhistory.ui
+++ b/src/ui/configtabhistory.ui
@@ -119,7 +119,7 @@
 Set to 0 not to unload tabs.</string>
             </property>
             <property name="suffix">
-             <string> minutes</string>
+             <string notr="true"> min</string>
             </property>
             <property name="maximum">
              <number>480</number>
@@ -161,7 +161,7 @@ Set to 0 not to unload tabs.</string>
 Set to 0 to disable globally.</string>
             </property>
             <property name="suffix">
-             <string> seconds</string>
+             <string notr="true"> s</string>
             </property>
             <property name="maximum">
              <number>999999</number>

--- a/src/ui/tabpropertieswidget.ui
+++ b/src/ui/tabpropertieswidget.ui
@@ -108,7 +108,7 @@ Set to 0 to use global setting.</string>
          <string>global</string>
         </property>
         <property name="suffix">
-         <string> seconds</string>
+         <string notr="true"> s</string>
         </property>
         <property name="maximum">
          <number>999999</number>

--- a/translations/copyq_cs.ts
+++ b/translations/copyq_cs.ts
@@ -1311,11 +1311,6 @@ Set to 0 not to unload tabs.</source>
 Nastav na 0 pro zachování záložek v paměti.</translation>
     </message>
     <message>
-        <location filename="../src/ui/configtabhistory.ui" line="122"/>
-        <source> minutes</source>
-        <translation> minut</translation>
-    </message>
-    <message>
         <location filename="../src/ui/configtabhistory.ui" line="147"/>
         <source>Require password after an interval:</source>
         <translation>Vyžadovat heslo po uplynutí intervalu:</translation>
@@ -1328,11 +1323,6 @@ Set to 0 to disable globally.</source>
         <translation>Časový limit v sekundách pro opětovné vyžádání hesla u šifrovaných záložek.
 
 Nastav na 0 pro globální vypnutí.</translation>
-    </message>
-    <message>
-        <location filename="../src/ui/configtabhistory.ui" line="164"/>
-        <source> seconds</source>
-        <translation> sekund</translation>
     </message>
     <message>
         <location filename="../src/ui/configtabhistory.ui" line="189"/>
@@ -4138,11 +4128,6 @@ Nastav na 0 pro použití globálního nastavení.</translation>
         <location filename="../src/ui/tabpropertieswidget.ui" line="108"/>
         <source>global</source>
         <translation>globální</translation>
-    </message>
-    <message>
-        <location filename="../src/ui/tabpropertieswidget.ui" line="111"/>
-        <source> seconds</source>
-        <translation> sekund</translation>
     </message>
     <message>
         <source>&amp;Store Items</source>

--- a/utils/lupdate.sh
+++ b/utils/lupdate.sh
@@ -5,4 +5,4 @@ lupdate_args=(
     -ts
     ${1:-translations/*.ts}
 )
-exec "${LUPDATE:-lupdate-qt5}" "${lupdate_args[@]}"
+exec "${LUPDATE:-lupdate-qt6}" "${lupdate_args[@]}"


### PR DESCRIPTION
The abbreviated units "min" and "s" are SI-standard and language-neutral
(no translation needed, no plural forms).

Assisted-by: Claude (Anthropic)