### PR TITLE
Fix tray menu not appearing and crash on paste (macOS)

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2155,6 +2155,13 @@ void MainWindow::activateMenuItem(ClipboardBrowserPlaceholder *placeholder, cons
     PlatformWindowPtr lastWindow = m_windowForMenuPaste;
 
     if ( m_options.trayItemPaste && !omitPaste && canPaste() ) {
+        // Raise the target window before paste so that getCurrentWindow()
+        // returns it even when the scripted paste() path is taken.  On
+        // macOS, closing the menu transitions the app to background, so
+        // without this raise getCurrentWindow() returns the wrong window.
+        if (lastWindow)
+            lastWindow->raise();
+
         if (isScriptOverridden(ScriptOverrides::Paste)) {
             COPYQ_LOG("Pasting item with paste()");
             runScript(QStringLiteral("paste()"));
@@ -2174,7 +2181,21 @@ bool MainWindow::toggleMenu(TrayMenu *menu, QPoint pos)
     }
 
     menu->popup( toScreen(pos, menu) );
+
+#ifdef Q_OS_MACOS
+    // On macOS, menus need the full activation sequence even when Qt
+    // considers the app already active (popup() created a Qt window, so
+    // applicationState() returns ApplicationActive even though macOS may
+    // not have granted real focus yet).  Flush events between activation
+    // and raiseWindow so the activation-policy change from
+    // ForegroundBackgroundFilter is fully processed before the
+    // platform-level focus steal.
+    menu->activateWindow();
+    QApplication::setActiveWindow(menu);
+    QApplication::processEvents();
+#endif
     raiseWindow(menu);
+
     return true;
 }
 

--- a/src/gui/windowgeometryguard.cpp
+++ b/src/gui/windowgeometryguard.cpp
@@ -60,17 +60,25 @@ QScreen *currentScreen()
 void raiseWindow(QWidget *window)
 {
     window->raise();
-    if (qApp->applicationState() == Qt::ApplicationActive)
-        return;
 
-    window->activateWindow();
-    QApplication::setActiveWindow(window);
-    QTimer::singleShot(0, window, [window]{
-        const auto wid = window->winId();
-        const auto platformWindow = platformNativeInterface()->getWindow(wid);
-        if (platformWindow)
-            platformWindow->raise();
-    });
+    // When the app is already active (e.g. dialog opened from the main
+    // window), the activation calls are redundant and can interfere with
+    // focus/key dispatch on some platforms.
+    if (QApplication::applicationState() != Qt::ApplicationActive) {
+        window->activateWindow();
+        QApplication::setActiveWindow(window);
+    }
+
+    // Synchronous platform raise: the window manager must process the
+    // raise before we return, otherwise macOS (and potentially other
+    // platforms) can suppress or hide the window before the raise takes
+    // effect.  A previous version deferred this via QTimer::singleShot(0),
+    // which caused tray menus and windows triggered by global shortcuts to
+    // require multiple attempts to appear.  (See issue #3445.)
+    const auto wid = window->winId();
+    const auto platformWindow = platformNativeInterface()->getWindow(wid);
+    if (platformWindow)
+        platformWindow->raise();
 }
 
 void WindowGeometryGuard::create(QWidget *window)

--- a/src/platform/mac/cfref.h
+++ b/src/platform/mac/cfref.h
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <CoreFoundation/CoreFoundation.h>
+
+/**
+ * RAII wrapper for Core Foundation references (CFRetain/CFRelease).
+ *
+ * Automatically releases the held reference on destruction.  Eliminates
+ * the class of bugs where an early return or exception skips a CFRelease.
+ *
+ * By default the constructor **adopts** (takes ownership of) a +1 reference
+ * returned by CF *Create* / *Copy* functions — no extra retain.
+ *
+ * \code
+ *     // Adopt a +1 ref from a Create/Copy function (no extra retain):
+ *     CFRef<CGEventRef> event = CGEventCreateKeyboardEvent(src, key, YES);
+ *
+ *     // Adopt a +1 ref from a Copy function:
+ *     CFRef<CFArrayRef> items = LSSharedFileListCopySnapshot(list, &seed);
+ *
+ *     // Implicit conversion to the raw type for passing to CF APIs:
+ *     CGEventPost(kCGHIDEventTap, event);
+ *
+ *     // Release is automatic; no manual CFRelease needed.
+ * \endcode
+ */
+template <typename T>
+class CFRef {
+public:
+    CFRef() : m_ref(nullptr) {}
+
+    // Adopts a +1 reference (from Create/Copy).  Intentionally implicit so
+    // `CFRef<X> x = SomeCreate(...)` works naturally.
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    CFRef(T ref) : m_ref(ref) {}
+
+    ~CFRef()
+    {
+        if (m_ref)
+            CFRelease(m_ref);
+    }
+
+    CFRef(const CFRef &other) : m_ref(other.m_ref)
+    {
+        if (m_ref)
+            CFRetain(m_ref);
+    }
+
+    CFRef &operator=(const CFRef &other)
+    {
+        if (m_ref != other.m_ref) {
+            if (m_ref)
+                CFRelease(m_ref);
+            m_ref = other.m_ref;
+            if (m_ref)
+                CFRetain(m_ref);
+        }
+        return *this;
+    }
+
+    CFRef &operator=(T ref)
+    {
+        if (m_ref != ref) {
+            if (m_ref)
+                CFRelease(m_ref);
+            m_ref = ref;
+        }
+        return *this;
+    }
+
+    T get() const { return m_ref; }
+    operator T() const { return m_ref; }
+    explicit operator bool() const { return m_ref != nullptr; }
+
+private:
+    T m_ref;
+};

--- a/src/platform/mac/copyqpasteboardmime.mm
+++ b/src/platform/mac/copyqpasteboardmime.mm
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "copyqpasteboardmime.h"
+#include "cfref.h"
 
 #include "common/log.h"
 #include "common/mimetypes.h"
@@ -45,12 +46,10 @@ namespace {
 
     QString convertUtiOrMime(const QString &in, CFStringRef (*convert)(CFStringRef)) {
         NSString *inString = in.toNSString();
-        CFStringRef outRef = convert((__bridge CFStringRef)inString);
+        CFRef<CFStringRef> outRef = convert((__bridge CFStringRef)inString);
         QString out;
-        if (outRef) {
-            out = QString::fromNSString((__bridge NSString *)outRef);
-            CFRelease(outRef);
-        }
+        if (outRef)
+            out = QString::fromNSString((__bridge NSString *)outRef.get());
         return out;
     }
 

--- a/src/platform/mac/macplatform.mm
+++ b/src/platform/mac/macplatform.mm
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "macplatform.h"
+#include "cfref.h"
 
 #include "app/applicationexceptionhandler.h"
 #include "common/log.h"
@@ -50,11 +51,11 @@ namespace {
     bool isApplicationInItemList(LSSharedFileListRef list) {
         bool flag = false;
         UInt32 seed;
-        CFArrayRef items = LSSharedFileListCopySnapshot(list, &seed);
+        CFRef<CFArrayRef> items = LSSharedFileListCopySnapshot(list, &seed);
         if (items) {
             CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
             if (url) {
-                for (id item in(__bridge NSArray *) items) {
+                for (id item in(__bridge NSArray *) items.get()) {
                     LSSharedFileListItemRef itemRef = (__bridge LSSharedFileListItemRef)item;
                     if (LSSharedFileListItemResolve(itemRef, 0, &url, NULL) == noErr) {
                         if ([[(__bridge NSURL *) url path] hasPrefix:[[NSBundle mainBundle] bundlePath]]) {
@@ -64,14 +65,13 @@ namespace {
                     }
                 }
             }
-            CFRelease(items);
         }
         return flag;
     }
 
     void addToLoginItems()
     {
-        LSSharedFileListRef list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
+        CFRef<LSSharedFileListRef> list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
         if (list) {
             if (!isApplicationInItemList(list)) {
                 CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
@@ -80,14 +80,12 @@ namespace {
                     NSDictionary *properties = [NSDictionary
                         dictionaryWithObject: [NSNumber numberWithBool:NO]
                         forKey: @"com.apple.loginitem.HideOnLaunch"];
-                    LSSharedFileListItemRef item = LSSharedFileListInsertItemURL(list, kLSSharedFileListItemLast, NULL, NULL, url, (__bridge CFDictionaryRef)properties, NULL);
-                    if (item)
-                        CFRelease(item);
+                    CFRef<LSSharedFileListItemRef> item = LSSharedFileListInsertItemURL(list, kLSSharedFileListItemLast, NULL, NULL, url, (__bridge CFDictionaryRef)properties, NULL);
+                    (void)item;  // released automatically
                 } else {
                     ::log("Unable to find url for bundle, can't auto-load app", LogWarning);
                 }
             }
-            CFRelease(list);
         } else {
             ::log("Unable to access shared file list, can't auto-load app", LogWarning);
         }
@@ -95,21 +93,20 @@ namespace {
 
     void removeFromLoginItems()
     {
-        LSSharedFileListRef list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
+        CFRef<LSSharedFileListRef> list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
         if (list) {
             if (isApplicationInItemList(list)) {
                 CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
                 if (url) {
                     UInt32 seed;
-                    CFArrayRef items = LSSharedFileListCopySnapshot(list, &seed);
+                    CFRef<CFArrayRef> items = LSSharedFileListCopySnapshot(list, &seed);
                     if (items) {
-                        for (id item in(__bridge NSArray *) items) {
+                        for (id item in(__bridge NSArray *) items.get()) {
                             LSSharedFileListItemRef itemRef = (__bridge LSSharedFileListItemRef)item;
                             if (LSSharedFileListItemResolve(itemRef, 0, &url, NULL) == noErr)
                                 if ([[(__bridge NSURL *) url path] hasPrefix:[[NSBundle mainBundle] bundlePath]])
                                     LSSharedFileListItemRemove(list, itemRef);
                         }
-                        CFRelease(items);
                     } else {
                         ::log("No items in list of auto-loaded apps, can't stop auto-load of app", LogWarning);
                     }
@@ -117,7 +114,6 @@ namespace {
                     ::log("Unable to find url for bundle, can't stop auto-load of app", LogWarning);
                 }
             }
-            CFRelease(list);
         } else {
             ::log("Unable to access shared file list, can't stop auto-load of app", LogWarning);
         }
@@ -264,10 +260,9 @@ bool MacPlatform::isAutostartEnabled()
     // the App Store.
     // http://rhult.github.io/articles/sandboxed-launch-on-login/
     bool isInList = false;
-    LSSharedFileListRef list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
+    CFRef<LSSharedFileListRef> list = LSSharedFileListCreate(kCFAllocatorDefault, kLSSharedFileListSessionLoginItems, NULL);
     if (list) {
         isInList = isApplicationInItemList(list);
-        CFRelease(list);
     }
     return isInList;
 }

--- a/src/platform/mac/macplatformwindow.h
+++ b/src/platform/mac/macplatformwindow.h
@@ -2,19 +2,15 @@
 
 #pragma once
 
+#include "objcstrong.h"
 
 #include "platform/platformwindow.h"
 
 // For WId
 #include <QWidget>
 
-#ifdef __OBJC__
 @class NSWindow;
 @class NSRunningApplication;
-#else
-using NSWindow = void;
-using NSRunningApplication = void;
-#endif
 
 class MacPlatformWindow final : public PlatformWindow
 {
@@ -40,7 +36,7 @@ private:
     // Don't allow copies
     Q_DISABLE_COPY(MacPlatformWindow)
 
-    long int m_windowNumber;
-    NSWindow *m_window;
-    NSRunningApplication *m_runningApplication;
+    long int m_windowNumber = -1;
+    ObjCStrong<NSWindow> m_window;
+    ObjCStrong<NSRunningApplication> m_runningApplication;
 };

--- a/src/platform/mac/macplatformwindow.mm
+++ b/src/platform/mac/macplatformwindow.mm
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "macplatformwindow.h"
+#include "cfref.h"
 
 #include "common/appconfig.h"
 #include "common/log.h"
@@ -52,7 +53,7 @@ namespace {
 
     NSNumber* charToKeyCode(const char c)
     {
-        TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
+        CFRef<TISInputSourceRef> currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
         CFDataRef layoutData = (CFDataRef)TISGetInputSourceProperty(
             currentKeyboard, kTISPropertyUnicodeKeyLayoutData);
 
@@ -66,13 +67,11 @@ namespace {
                 NSString* str = keyCodeToString((CGKeyCode)i, keyboardLayout);
                 if (str != nil && [str isEqualToString:keyChar]) {
                     COPYQ_LOG( QStringLiteral("KeyCode for '%1' is %2").arg(c).arg(i) );
-                    CFRelease(currentKeyboard);
                     return [NSNumber numberWithInt:i];
                 }
             }
         }
 
-        CFRelease(currentKeyboard);
         return nil;
     }
 
@@ -97,14 +96,14 @@ namespace {
                    .arg(modifier)
                    .arg(key) );
 
-        CGEventSourceRef sourceRef = CGEventSourceCreate(
+        CFRef<CGEventSourceRef> sourceRef = CGEventSourceCreate(
             kCGEventSourceStateCombinedSessionState);
 
-        CGEventRef commandDown = CGEventCreateKeyboardEvent(sourceRef, modifier, YES);
-        CGEventRef VDown = CGEventCreateKeyboardEvent(sourceRef, key, YES);
+        CFRef<CGEventRef> commandDown = CGEventCreateKeyboardEvent(sourceRef, modifier, YES);
+        CFRef<CGEventRef> VDown = CGEventCreateKeyboardEvent(sourceRef, key, YES);
 
-        CGEventRef VUp = CGEventCreateKeyboardEvent(sourceRef, key, NO);
-        CGEventRef commandUp = CGEventCreateKeyboardEvent(sourceRef, modifier, NO);
+        CFRef<CGEventRef> VUp = CGEventCreateKeyboardEvent(sourceRef, key, NO);
+        CFRef<CGEventRef> commandUp = CGEventCreateKeyboardEvent(sourceRef, modifier, NO);
 
         // 0x000008 is a hack to fix pasting in Emacs?
         // https://github.com/TermiT/Flycut/pull/18
@@ -115,12 +114,6 @@ namespace {
         CGEventPost(kCGHIDEventTap, VDown);
         CGEventPost(kCGHIDEventTap, VUp);
         CGEventPost(kCGHIDEventTap, commandUp);
-
-        CFRelease(commandDown);
-        CFRelease(VDown);
-        CFRelease(VUp);
-        CFRelease(commandUp);
-        CFRelease(sourceRef);
     }
 
     /**
@@ -153,17 +146,15 @@ namespace {
     pid_t getPidForWid(WId find_wid) {
         // Build a set of "normal" windows. This is necessary as "NSWindowList" gets things like the
         // menubar (which can be "owned" by various apps).
-        NSArray *array = (__bridge NSArray*) CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
-        for (NSDictionary* dict in array) {
+        CFRef<CFArrayRef> windowList = CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+        for (NSDictionary* dict in (__bridge NSArray*)windowList.get()) {
             long int pid = [(NSNumber*)[dict objectForKey:@"kCGWindowOwnerPID"] longValue];
             unsigned long int wid = (unsigned long) [(NSNumber*)[dict objectForKey:@"kCGWindowNumber"] longValue];
 
             if (wid == find_wid) {
-                CFRelease(array);
                 return pid;
             }
         }
-        CFRelease(array);
 
         return 0;
     }
@@ -173,8 +164,8 @@ namespace {
         // Build a set of "normal" windows. This is necessary as "NSWindowList" gets things like the
         // menubar (which can be "owned" by various apps).
         QSet<long int> widsForProcess;
-        NSArray *array = (__bridge NSArray*) CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
-        for (NSDictionary* dict in array) {
+        CFRef<CFArrayRef> windowList = CGWindowListCopyWindowInfo(kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+        for (NSDictionary* dict in (__bridge NSArray*)windowList.get()) {
             long int pid = [(NSNumber*)[dict objectForKey:@"kCGWindowOwnerPID"] longValue];
             long int wid = [(NSNumber*)[dict objectForKey:@"kCGWindowNumber"] longValue];
             long int layer = [(NSNumber*)[dict objectForKey:@"kCGWindowLayer"] longValue];
@@ -183,7 +174,6 @@ namespace {
                 widsForProcess.insert(wid);
             }
         }
-        CFRelease(array);
 
         // Now look through the windows in NSWindowList (which are ordered from front to back)
         // the first window in this list which is also in widsForProcess is our frontmost "normal" window
@@ -205,30 +195,23 @@ namespace {
             return title;
         }
 
-        uint32_t windowid[1] = {static_cast<uint32_t>(wid)};
-        CFArrayRef windowArray = CFArrayCreate ( NULL, (const void **)windowid, 1 ,NULL);
-        NSArray *array = (__bridge NSArray*) CGWindowListCreateDescriptionFromArray(windowArray);
+        const void *windowid = reinterpret_cast<const void *>(static_cast<uintptr_t>(wid));
+        CFRef<CFArrayRef> windowArray = CFArrayCreate( NULL, &windowid, 1, NULL );
+        CFRef<CFArrayRef> descArray = CGWindowListCreateDescriptionFromArray(windowArray);
 
         // Should only be one
-        for (NSDictionary* dict in array) {
+        for (NSDictionary* dict in (__bridge NSArray*)descArray.get()) {
             title = QString::fromNSString([dict objectForKey:@"kCGWindowName"]);
         }
-
-        CFRelease(array);
-        CFRelease(windowArray);
 
         return title;
     }
 } // namespace
 
-MacPlatformWindow::MacPlatformWindow(NSRunningApplication *runningApp):
-    m_windowNumber(-1)
-    , m_window(0)
-    , m_runningApplication(0)
+MacPlatformWindow::MacPlatformWindow(NSRunningApplication *runningApp)
 {
     if (runningApp) {
         m_runningApplication = runningApp;
-        [runningApp retain];
         m_windowNumber = getTopWindow(runningApp.processIdentifier);
         COPYQ_LOG_VERBOSE("Created platform window for non-copyq");
     } else {
@@ -236,10 +219,7 @@ MacPlatformWindow::MacPlatformWindow(NSRunningApplication *runningApp):
     }
 }
 
-MacPlatformWindow::MacPlatformWindow(WId wid):
-    m_windowNumber(-1)
-    , m_window(0)
-    , m_runningApplication(0)
+MacPlatformWindow::MacPlatformWindow(WId wid)
 {
     // Try using wid as an actual window ID
     pid_t pid = getPidForWid(wid);
@@ -252,8 +232,6 @@ MacPlatformWindow::MacPlatformWindow(WId wid):
         // If given a view, its ours
         m_runningApplication = [NSRunningApplication currentApplication];
         m_window = [view window];
-        [m_runningApplication retain];
-        [m_window retain];
         m_windowNumber = [m_window windowNumber];
         COPYQ_LOG_VERBOSE("Created platform window for copyq");
     } else {
@@ -261,18 +239,9 @@ MacPlatformWindow::MacPlatformWindow(WId wid):
     }
 }
 
-MacPlatformWindow::MacPlatformWindow():
-    m_windowNumber(-1)
-    , m_window(0)
-    , m_runningApplication(0)
-{
-}
+MacPlatformWindow::MacPlatformWindow() = default;
 
-MacPlatformWindow::~MacPlatformWindow() {
-    // Releasing '0' or 'nil' is fine
-    [m_runningApplication release];
-    [m_window release];
-}
+MacPlatformWindow::~MacPlatformWindow() = default;
 
 QString MacPlatformWindow::getTitle()
 {

--- a/src/platform/mac/objcstrong.h
+++ b/src/platform/mac/objcstrong.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#ifdef __OBJC__
+#   import <Foundation/NSObject.h>
+#endif
+
+/**
+ * RAII strong-reference holder for Objective-C objects (manual retain/release).
+ *
+ * Retains the object on construction/assignment and releases it on
+ * destruction, exactly like a \c __strong property under ARC.  Using this
+ * wrapper instead of raw pointers eliminates the class of bugs where a
+ * constructor forgets to retain an autoreleased object while the destructor
+ * unconditionally releases it.
+ *
+ * Safe to use with \c nil: retaining and releasing \c nil are no-ops.
+ *
+ * \code
+ *     ObjCStrong<NSWindow> m_window;       // starts nil
+ *     m_window = [NSApp windowWithWindowNumber: wid];  // retains
+ *     m_window = nil;                      // releases old, holds nil
+ *     // destructor releases automatically
+ * \endcode
+ */
+template <typename T>
+class ObjCStrong {
+public:
+    ObjCStrong() : m_ptr(nil) {}
+
+    // Intentionally implicit: allows `m_member = [SomeClass ...]` naturally.
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    ObjCStrong(T *ptr) : m_ptr([ptr retain]) {}
+
+    ~ObjCStrong() { [m_ptr release]; }
+
+    ObjCStrong(const ObjCStrong &other) : m_ptr([other.m_ptr retain]) {}
+
+    ObjCStrong &operator=(const ObjCStrong &other)
+    {
+        if (m_ptr != other.m_ptr) {
+            [m_ptr release];
+            m_ptr = [other.m_ptr retain];
+        }
+        return *this;
+    }
+
+    ObjCStrong &operator=(T *ptr)
+    {
+        if (m_ptr != ptr) {
+            [m_ptr release];
+            m_ptr = [ptr retain];
+        }
+        return *this;
+    }
+
+    T *get() const { return m_ptr; }
+    operator T *() const { return m_ptr; }
+    T *operator->() const { return m_ptr; }
+    explicit operator bool() const { return m_ptr != nil; }
+
+private:
+    T *m_ptr;
+};

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -52,6 +52,7 @@ private slots:
     void commandVisible();
     void commandToggle();
     void commandShowHide();
+    void commandShowHideRapid();
     void commandShowAt();
     void commandFocused();
 
@@ -219,6 +220,7 @@ private slots:
     void traySearch();
     void trayPaste();
     void trayShowHideAction();
+    void trayMenuToggleRapid();
 
     void pasteNext();
 

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -149,6 +149,21 @@ void Tests::commandShowHide()
     WAIT_ON_OUTPUT("visible", "true\n");
 }
 
+
+void Tests::commandShowHideRapid()
+{
+    // Verify the main window can be hidden and reshown reliably in
+    // rapid succession.  Regression test for #3445: deferred platform
+    // raise in raiseWindow() could prevent the window from appearing.
+    for (int i = 0; i < 3; ++i) {
+        RUN("visible", "true\n");
+        RUN("hide", "");
+        WAIT_ON_OUTPUT("visible", "false\n");
+
+        RUN("show", "");
+        WAIT_ON_OUTPUT("visible", "true\n");
+    }
+}
 void Tests::commandShowAt()
 {
     RUN("visible", "true\n");
@@ -737,7 +752,7 @@ void Tests::commandEditItem()
     KEYS("END" << ":LINE 1" << "F2");
     const auto expected = QByteArrayLiteral("TESTLINE 1");
 #ifdef Q_OS_WIN
-    const auto expectedClipboard = QByteArrayLiteral("<!--StartFragment-->TESTLINE 1<!--EndFragment-->", mimeHtml);
+    const auto expectedClipboard = QByteArrayLiteral("<!--StartFragment-->TESTLINE 1<!--EndFragment-->");
 #else
     const auto expectedClipboard = expected;
 #endif

--- a/src/tests/tests_tray.cpp
+++ b/src/tests/tests_tray.cpp
@@ -192,3 +192,22 @@ void Tests::configTrayTabIsCurrent()
     RUN("menu", "");
     ACTIVATE_MENU_ITEM(trayMenuId, clipboardBrowserId, "B");
 }
+
+void Tests::trayMenuToggleRapid()
+{
+    RUN("add" << "X" << "Y" << "Z", "");
+
+    // Verify the menu can be opened, closed, and reopened reliably.
+    // Regression test for #3445: on macOS, the first shortcut press
+    // failed to show the menu due to deferred focus-stealing.
+    for (int i = 0; i < 3; ++i) {
+        KEYS(clipboardBrowserId);
+        RUN("menu", "");
+        KEYS(trayMenuId << "ESCAPE");
+    }
+
+    // Final open + activate to confirm the menu is functional.
+    KEYS(clipboardBrowserId);
+    RUN("menu", "");
+    ACTIVATE_MENU_ITEM(trayMenuId, clipboardBrowserId, "Z");
+}


### PR DESCRIPTION
On macOS, tray menus triggered by global shortcuts often required
multiple presses to appear, and pasting from the menu could crash
the app.  Three issues contributed:

1. **raiseWindow() deferred the platform raise** via a timer, allowing
   macOS to suppress the window before the raise took effect.  It also
   skipped activation when Qt already considered the app active.
   Fix: always activate and raise synchronously; the extra event flush
   that menus need is done in toggleMenu() under `Q_OS_MACOS`.

2. **Scripted paste() targets the wrong window.** When a paste override
   runs in a subprocess, it re-discovers the target window — but by then
   macOS has backgrounded the app, so the wrong window is found.
   Fix: raise the target window before invoking the paste script.

3. **Missing retain on autoreleased Objective-C objects** in the
   `MacPlatformWindow(WId)` constructor caused over-release crashes.
   Fix: introduce `ObjCStrong<T>` and `CFRef<T>` RAII wrappers that
   handle retain/release and CFRelease automatically, replacing all
   manual calls in the macOS platform code.

Adds `trayMenuToggleRapid` and `commandShowHideRapid` tests.

Fixes #3445