### PR TITLE
Add native audio playback via miniaudio

### DIFF
--- a/.github/actions/download-miniaudio/action.yml
+++ b/.github/actions/download-miniaudio/action.yml
@@ -1,0 +1,36 @@
+name: Download miniaudio
+description: Downloads and verifies miniaudio.h from a pinned commit (cached)
+
+runs:
+  using: composite
+  steps:
+    - name: Set miniaudio version
+      shell: bash
+      run: |
+        # 0.11.25
+        echo 'MINIAUDIO_COMMIT=9634bedb5b5a2ca38c1ee7108a9358a4e233f14d' >> "$GITHUB_ENV"
+        echo 'MINIAUDIO_SHA256=ac7af4de748b7e26b777f37e01cee313a308a7296a3eb080e2906b320cc55c89' >> "$GITHUB_ENV"
+
+    - name: Cache miniaudio header
+      id: cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: src/miniaudio.h
+        key: miniaudio-${{ env.MINIAUDIO_COMMIT }}
+
+    - name: Download and verify miniaudio
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -sSLo src/miniaudio.h --fail-with-body --retry 3 \
+          "https://raw.githubusercontent.com/mackron/miniaudio/$MINIAUDIO_COMMIT/miniaudio.h"
+
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256cmd='sha256sum -c'
+        elif command -v shasum >/dev/null 2>&1; then
+          sha256cmd='shasum -a 256 -c'
+        else
+          echo '::error::No SHA-256 utility found'; exit 1
+        fi
+
+        echo "$MINIAUDIO_SHA256  src/miniaudio.h" | $sha256cmd

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -151,6 +151,9 @@ jobs:
             ${{ matrix.coverage && 'kwin-wayland kwin-wayland-backend-virtual libwayland-server0 procps' || '' }}
             ${{ matrix.test_gnome && 'gnome-shell gnome-shell-common glib2.0-bin' || '' }}
 
+      - name: Download miniaudio
+        uses: ./.github/actions/download-miniaudio
+
       - name: Build with CMake
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -88,6 +88,9 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: '${{ github.workspace }}/utils/github/build-macos-deps.sh'
 
+      - name: Download miniaudio
+        uses: ./.github/actions/download-miniaudio
+
       - name: Build with CMake
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,6 +23,8 @@ env:
   QTKEYCHAIN_VERSION: '0.15.0'
   COPYQ_TESTS_SKIP_DRAG_AND_DROP: '1'
   COPYQ_TESTS_NO_SYMLINKS: '1'
+  # There is no audio device on the CI system
+  COPYQ_TESTS_SKIP_AUDIO: '1'
 
 jobs:
   build:
@@ -87,6 +89,9 @@ jobs:
       - name: Build KDE dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: utils/github/build-windows-deps.sh
+
+      - name: Download miniaudio
+        uses: ./.github/actions/download-miniaudio
 
       - name: Build with CMake
         uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,8 @@ Run a script - requires server to be running:
     # the above command is equivalent to
     build/copyq 'source("script.js")'
 
-Scripting API documentation is in @docs/scripting-api.rst.
+Scripting API documentation is in @docs/scripting-api.rst. After changing it,
+run @utils/script_docs_to_cpp.py to update the completion popup in the GUI.
 
 Useful scripts (omit the `tab(...)` call to use the default tab):
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ OPTION(WITH_PLUGINS "Compile plugins" ON)
 OPTION(WITH_QCA_ENCRYPTION "Enable QCA-based tab encryption" ON)
 OPTION(WITH_KEYCHAIN "Enable system keyring integration using QtKeychain" ON)
 OPTION(WITH_GNOME_CLIPBOARD_EXTENSION "Install GNOME extension, required for clipboard monitoring" ON)
+OPTION(WITH_AUDIO "Build with audio playback support (miniaudio)" ON)
 
 add_definitions( -DQT_USE_STRINGBUILDER  )
 

--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -26,6 +26,10 @@ The build requires:
 - `CMake <https://cmake.org/download/>`__
 - `Qt <https://download.qt.io/archive/qt/>`__
 
+Optional:
+
+- `miniaudio <https://miniaud.io/>`__ -- for built-in audio playback (``playSound``)
+
 Debian / Ubuntu
 ^^^^^^^^^^^^^^^
 On **Debian** and derivatives you can install all build dependencies with:
@@ -37,6 +41,7 @@ On **Debian** and derivatives you can install all build dependencies with:
       cmake \
       extra-cmake-modules \
       git \
+      libminiaudio-dev \
       libqt6svg6-dev \
       libqt6waylandclient6 \
       libwayland-dev \
@@ -87,6 +92,7 @@ On **Fedora** and derivatives you can install all build dependencies with:
       libSM-devel \
       libXfixes-devel \
       libXtst-devel \
+      miniaudio-devel \
       qca-qt6-devel \
       qca-qt6-ossl \
       qt6-qtbase-devel \
@@ -97,6 +103,21 @@ On **Fedora** and derivatives you can install all build dependencies with:
       qt6-qtwayland-devel \
       qtkeychain-qt6-devel \
       wayland-devel
+
+miniaudio (manual download)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your distribution does not package miniaudio, you can download the single
+header file directly into the source tree:
+
+::
+
+    curl -sSLo src/miniaudio.h \
+      https://raw.githubusercontent.com/mackron/miniaudio/0.11.25/miniaudio.h
+
+CMake will find it automatically.  Alternatively, place ``miniaudio.h`` anywhere
+and point CMake to it with ``-DMINIAUDIO_INCLUDE_DIR=/path/to/dir``.
+
 
 Build and Install
 -----------------
@@ -109,6 +130,7 @@ Build the source code with CMake and make or using an IDE of your choice (see ne
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local .
     # Add -DWITH_QCA_ENCRYPTION=OFF for systems without `QCA` packages
     # Add -DWITH_NATIVE_NOTIFICATIONS=OFF for systems without `KF6` packages
+    # Add -DWITH_AUDIO=OFF to disable audio support (or if miniaudio is unavailable)
     make
     make install
 

--- a/docs/command-examples.rst
+++ b/docs/command-examples.rst
@@ -51,6 +51,37 @@ Play Sound when Copying to Clipboard
 The following commands will play an audio file whenever something is
 copied to the clipboard.
 
+Built-in (Cross-Platform)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The built-in audio capabilities are available since version 14.0.0 and supports
+WAV, MP3 and FLAC formats on all platforms.
+
+.. code-block:: ini
+
+    [Command]
+    Name=Play Sound on Copy
+    Command="
+         copyq:
+         playSound('/path/to/notification.wav')"
+    Automatic=true
+    Icon=\xf028
+
+To play at a lower volume:
+
+.. code-block:: ini
+
+    [Command]
+    Name=Play Sound on Copy (Quiet)
+    Command="
+         copyq:
+         playSound({file: '/path/to/notification.wav', volume: 25})"
+    Automatic=true
+    Icon=\xf028
+
+Alternatively, if audio is not available in the app itself, you can use
+external utilities to play audio file mentioned below.
+
 Windows
 ^^^^^^^
 

--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1092,6 +1092,41 @@ unlike in GUI, where row numbers start from 1 by default.
 
    Returns object for the finished command or ``undefined`` on failure.
 
+.. js:function:: playSound(fileOrObject)
+
+   Plays audio file.
+
+   The argument can be a file path string or an object with ``file`` and
+   optional ``volume`` properties.
+
+   Supports WAV, MP3 and FLAC formats. The function starts playback and
+   returns immediately.
+
+   An exception is thrown if the file doesn't exist or cannot be played.
+
+   Requires the application to be built with audio capabilities. You can verify
+   this with ``info('has-audio')``.
+
+   :param fileOrObject: Path to the audio file, or an object
+       ``{file: 'path', volume: 50}``.
+   :type fileOrObject: string or object
+
+   The ``volume`` property is a percentage (default ``100``). Values above
+   ``100`` amplify the sound; the maximum is ``200``.
+
+   Example --- play a notification sound:
+
+   .. code-block:: js
+
+       playSound('/path/to/notification.wav')
+
+   Example --- play at 50% volume:
+
+   .. code-block:: js
+
+       playSound({file: '/path/to/notification.wav', volume: 50})
+
+
 .. js:function:: String currentWindowTitle()
 
    Returns window title of currently focused window.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,9 @@ set(copyq_RESOURCES copyq.qrc)
 
 # Qt include paths and definitions
 include(notifications.cmake)
+if (WITH_AUDIO)
+    include(audio.cmake)
+endif()
 include(platform/platform.cmake)
 
 set_source_files_properties(
@@ -81,6 +84,7 @@ if (NOT APPLE)
         ${copyq_RESOURCES_RCC}
         ${copyq_QM}
         $<TARGET_OBJECTS:copyq-common>
+        ${MINIAUDIO_OBJECTS}
     )
 else()
     FIND_LIBRARY(CARBON_LIBRARY Carbon REQUIRED)
@@ -118,6 +122,7 @@ else()
         ${copyq_RESOURCES_RCC}
         ${copyq_QM}
         $<TARGET_OBJECTS:copyq-common>
+        ${MINIAUDIO_OBJECTS}
         "${CMAKE_CURRENT_SOURCE_DIR}/images/icon.icns"
     )
 endif()
@@ -137,6 +142,14 @@ set_target_properties(${COPYQ_EXECUTABLE_NAME} PROPERTIES LINK_FLAGS "${copyq_LI
 target_link_libraries(copyq-common ${copyq_LIBRARIES})
 target_link_libraries(${COPYQ_EXECUTABLE_NAME} ${copyq_LIBRARIES})
 target_include_directories(copyq-common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} .)
+if (WITH_AUDIO)
+    # SYSTEM suppresses warnings from the third-party header on Clang/GCC.
+    if (MSVC)
+        target_include_directories(copyq-common PRIVATE "${MINIAUDIO_INCLUDE_DIR}")
+    else()
+        target_include_directories(copyq-common SYSTEM PRIVATE "${MINIAUDIO_INCLUDE_DIR}")
+    endif()
+endif()
 target_include_directories(${COPYQ_EXECUTABLE_NAME} PRIVATE .)
 
 # Precompiled headers for faster MSVC builds.

--- a/src/audio.cmake
+++ b/src/audio.cmake
@@ -1,0 +1,37 @@
+find_path(MINIAUDIO_INCLUDE_DIR miniaudio.h
+    HINTS "${MINIAUDIO_INCLUDE_DIR}"
+    "$ENV{MINIAUDIO_INCLUDE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+if (NOT MINIAUDIO_INCLUDE_DIR OR NOT EXISTS "${MINIAUDIO_INCLUDE_DIR}/miniaudio.h")
+    message(FATAL_ERROR
+        "Header file miniaudio.h not found. To solve this do any of these:"
+        "\na) Install miniaudio development package"
+        " (miniaudio-devel on Fedora, libminiaudio-dev on Debian/Ubuntu)"
+        "\nb) Download it from https://github.com/mackron/miniaudio"
+        " and set MINIAUDIO_INCLUDE_DIR to the directory containing miniaudio.h"
+        "\nc) Set WITH_AUDIO=OFF to disable audio support")
+endif()
+message(STATUS "miniaudio found: ${MINIAUDIO_INCLUDE_DIR}")
+
+# miniaudio_impl.cpp lives in src/miniaudio/ — a separate CMake directory
+# scope where CMAKE_CXX_FLAGS is stripped of coverage flags (--coverage
+# cannot be negated by -fno-*).  See src/miniaudio/CMakeLists.txt.
+add_subdirectory(miniaudio)
+set(MINIAUDIO_OBJECTS $<TARGET_OBJECTS:miniaudio_impl>)
+
+list(APPEND copyq_DEFINITIONS WITH_AUDIO)
+
+# miniaudio needs threads and math on POSIX, dl on Linux
+find_package(Threads REQUIRED)
+if (UNIX AND NOT APPLE)
+    list(APPEND copyq_LIBRARIES Threads::Threads m ${CMAKE_DL_LIBS})
+elseif (APPLE)
+    find_library(COREAUDIO_LIB CoreAudio REQUIRED)
+    find_library(AUDIOTOOLBOX_LIB AudioToolbox REQUIRED)
+    find_library(COREFOUNDATION_LIB CoreFoundation REQUIRED)
+    list(APPEND copyq_LIBRARIES
+        ${COREAUDIO_LIB} ${AUDIOTOOLBOX_LIB} ${COREFOUNDATION_LIB})
+endif()
+# Windows: miniaudio uses WASAPI via COM, linked automatically

--- a/src/common/audioplayer.cpp
+++ b/src/common/audioplayer.cpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "audioplayer.h"
+
+#ifdef WITH_AUDIO
+
+#include <miniaudio.h>
+
+#include <QEventLoop>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QThread>
+#include <QTimer>
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace {
+
+Q_DECLARE_LOGGING_CATEGORY(logCategory)
+Q_LOGGING_CATEGORY(logCategory, "copyq.audio")
+
+// Timeout (ms) for ma_engine_init.  PulseAudio's mainloop is known to deadlock
+// during device enumeration on some Linux configurations (headless CI, broken
+// PipeWire-PulseAudio bridge, etc.).  Running init in a detached thread with
+// a timeout prevents the whole process from hanging.
+// Override with COPYQ_AUDIO_INIT_TIMEOUT_SECS for diagnostics.
+int initTimeoutMs()
+{
+    bool ok = false;
+    const int secs = qEnvironmentVariableIntValue("COPYQ_AUDIO_INIT_TIMEOUT_SECS", &ok);
+    return (ok && secs > 0 ? secs : 5) * 1000;
+}
+
+// RAII wrapper for a single ma_sound.  The ma_sound is heap-allocated and
+// never relocated — miniaudio's async playback thread holds a pointer to it,
+// so it must stay at a stable address for its entire lifetime.
+class SoundEntry {
+public:
+    SoundEntry() : m_sound(std::make_unique<ma_sound>()) {}
+
+    /// Initialise from file.  Returns the ma_result code.
+    ma_result initFromFile(
+        ma_engine *engine, const char *path, ma_uint32 flags)
+    {
+        const ma_result r = ma_sound_init_from_file(
+            engine, path, flags, nullptr, nullptr, m_sound.get());
+        m_initialized = (r == MA_SUCCESS);
+        return r;
+    }
+
+    ma_sound *get() { return m_initialized ? m_sound.get() : nullptr; }
+
+    bool atEnd() const { return m_initialized && ma_sound_at_end(m_sound.get()); }
+
+    ~SoundEntry()
+    {
+        if (m_initialized)
+            ma_sound_uninit(m_sound.get());
+    }
+
+    SoundEntry(SoundEntry &&) noexcept = default;
+    SoundEntry &operator=(SoundEntry &&) noexcept = default;
+    SoundEntry(const SoundEntry &) = delete;
+    SoundEntry &operator=(const SoundEntry &) = delete;
+
+private:
+    std::unique_ptr<ma_sound> m_sound;
+    bool m_initialized = false;
+};
+
+} // namespace
+
+struct AudioPlayer::Private {
+    std::shared_ptr<ma_engine> engine;
+    bool initialized = false;
+    std::vector<SoundEntry> entries;
+
+    /// Remove sounds that have finished playing.
+    void collectFinished()
+    {
+        entries.erase(
+            std::remove_if(entries.begin(), entries.end(),
+                [](const SoundEntry &e) { return e.atEnd(); }),
+            entries.end());
+    }
+};
+
+// Maximum volume multiplier (200%) to prevent accidental hearing damage.
+static constexpr float maxVolume = 2.0f;
+
+QString audioBackendVersion()
+{
+    return QStringLiteral("miniaudio " MA_VERSION_STRING);
+}
+
+AudioPlayer &AudioPlayer::instance()
+{
+    static AudioPlayer s;
+    return s;
+}
+
+AudioPlayer::AudioPlayer()
+    : d(std::make_unique<Private>())
+{
+    qCDebug(logCategory) << "Initializing miniaudio engine";
+
+    // Run ma_engine_init on a helper thread so we can bail out if the
+    // PulseAudio (or other) backend deadlocks during device enumeration.
+    // A nested QEventLoop keeps the UI responsive while we wait.
+    auto initResult = std::make_shared<std::atomic<ma_result>>(MA_ERROR);
+
+    // The engine is shared between AudioPlayer and the init worker thread.
+    // If init times out the worker keeps the engine alive until it finishes.
+    d->engine = std::shared_ptr<ma_engine>(new ma_engine{}, [initResult](ma_engine *e) {
+        if (initResult->load(std::memory_order_acquire) == MA_SUCCESS)
+            ma_engine_uninit(e);
+        delete e;
+    });
+
+    QEventLoop loop;
+
+    auto *worker = QThread::create([initResult, engine = d->engine]() mutable {
+        initResult->store(ma_engine_init(nullptr, engine.get()), std::memory_order_release);
+        engine.reset(); // release this thread's reference to the engine
+    });
+    QObject::connect(worker, &QThread::finished, &loop, &QEventLoop::quit);
+    worker->start();
+
+    QTimer::singleShot(initTimeoutMs(), &loop, &QEventLoop::quit);
+    loop.exec();
+
+    if (!worker->isFinished()) {
+        qCWarning(logCategory)
+            << "miniaudio engine init timed out after"
+            << initTimeoutMs() / 1000 << "seconds \u2014 audio disabled";
+        // The worker thread holds a shared_ptr to the engine, so the engine
+        // outlives the thread even if AudioPlayer is destroyed first.
+        QObject::connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+        return;
+    }
+
+    worker->deleteLater();
+
+    const ma_result result = initResult->load(std::memory_order_acquire);
+    if (result == MA_SUCCESS) {
+        qCDebug(logCategory) << "Initialized miniaudio engine successfully";
+        d->initialized = true;
+    } else {
+        qCWarning(logCategory) << "Failed to initialize miniaudio, result code:" << result;
+        d->initialized = false;
+    }
+}
+
+AudioPlayer::~AudioPlayer()
+{
+    if (d && d->initialized) {
+        d->entries.clear();
+        d->engine.reset();
+    }
+}
+
+QString AudioPlayer::play(const QString &filePath, float volume)
+{
+    if (!d->initialized)
+        return QStringLiteral("Audio engine not initialized");
+
+    if (!QFileInfo::exists(filePath))
+        return QStringLiteral("File not found: ") + filePath;
+
+    // Reclaim memory from sounds that have finished playing.
+    d->collectFinished();
+
+    SoundEntry entry;
+    const QByteArray path = filePath.toUtf8();
+    const ma_uint32 flags = MA_SOUND_FLAG_ASYNC
+                          | MA_SOUND_FLAG_NO_PITCH
+                          | MA_SOUND_FLAG_NO_SPATIALIZATION;
+    ma_result result = entry.initFromFile(d->engine.get(), path.constData(), flags);
+    if (result != MA_SUCCESS)
+        return QStringLiteral("Failed to play sound (error %1)").arg(result);
+
+    ma_sound_set_volume(entry.get(), std::clamp(volume, 0.0f, maxVolume));
+
+    result = ma_sound_start(entry.get());
+    if (result != MA_SUCCESS)
+        return QStringLiteral("Failed to start sound (error %1)").arg(result);
+
+    d->entries.push_back(std::move(entry));
+    return {};
+}
+
+
+#else // !WITH_AUDIO — stub
+
+QString audioBackendVersion()
+{
+    return QStringLiteral("none");
+}
+
+AudioPlayer &AudioPlayer::instance()
+{
+    static AudioPlayer s;
+    return s;
+}
+
+struct AudioPlayer::Private {};
+
+AudioPlayer::AudioPlayer() = default;
+AudioPlayer::~AudioPlayer() = default;
+
+QString AudioPlayer::play(const QString &, float)
+{
+    return QStringLiteral("Audio playback is not available in this build");
+}
+
+
+#endif

--- a/src/common/audioplayer.h
+++ b/src/common/audioplayer.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QString>
+#include <memory>
+
+/// Returns the audio backend name and version (e.g. "miniaudio 0.11.25"), or "none" if disabled.
+QString audioBackendVersion();
+
+class AudioPlayer {
+public:
+    static AudioPlayer &instance();
+
+    /// Start playing an audio file at the given volume (0.0 = silent, 1.0 = 100%).
+    /// Volume is clamped to [0.0, 2.0] for safety.
+    /// Returns an empty string on success or an error message on failure.
+    QString play(const QString &filePath, float volume);
+
+    ~AudioPlayer();
+
+private:
+    AudioPlayer();
+    AudioPlayer(const AudioPlayer &) = delete;
+    AudioPlayer &operator=(const AudioPlayer &) = delete;
+
+    struct Private;
+    std::unique_ptr<Private> d;
+};

--- a/src/gui/aboutdialog.cpp
+++ b/src/gui/aboutdialog.cpp
@@ -123,6 +123,11 @@ QString AboutDialog::aboutPage(const Theme &theme)
                       "Copyright (c) Fonticons, Inc.", "https://fontawesome.com")
             + helpLib("LibQxt",
                       "Copyright (c), the LibQxt project", "https://bitbucket.org/libqxt/libqxt/wiki/Home")
+#ifdef WITH_AUDIO
+            + helpLib("miniaudio",
+                      "Copyright (c) David Reid",
+                      "https://miniaud.io/")
+#endif
             + helpLib("Solarized",
                       "Copyright (c) Ethan Schoonover", "https://ethanschoonover.com/solarized")
 

--- a/src/gui/commandcompleterdocumentation.h
+++ b/src/gui/commandcompleterdocumentation.h
@@ -122,6 +122,7 @@ void addDocumentation(AddDocumentationCallback addDocumentation)
     addDocumentation("sha512sum", "sha512sum(data) -> `ByteArray`", "Returns SHA512 checksum of data.");
     addDocumentation("open", "open(url, ...) -> bool", "Tries to open URLs in appropriate applications.");
     addDocumentation("execute", "execute(argument, ..., null, stdinData, ...) -> `FinishedCommand`", "Executes a command.");
+    addDocumentation("playSound", "playSound(fileOrObject)", "Plays audio file.");
     addDocumentation("currentWindowTitle", "String currentWindowTitle() -> string", "Returns window title of currently focused window.");
     addDocumentation("currentClipboardOwner", "String currentClipboardOwner() -> string", "Returns name of the current clipboard owner.");
     addDocumentation("dialog", "dialog(...)", "Shows messages or asks user for input.");

--- a/src/miniaudio/CMakeLists.txt
+++ b/src/miniaudio/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Build miniaudio implementation without coverage instrumentation.
+#
+# GCC's --coverage flag cannot be negated by -fno-profile-arcs or
+# -fno-test-coverage — it acts as an independent meta-flag.  The only way
+# to exclude a source file from coverage is to compile it in a separate
+# directory scope where CMAKE_CXX_FLAGS has been stripped of --coverage
+# (and the related -fprofile-* / -ftest-coverage flags).
+#
+# This matters because coverage instrumentation changes threading behaviour
+# inside miniaudio's PulseAudio backend enough to trigger a deadlock in
+# pa_mainloop_iterate during ma_engine_init.
+
+# Strip coverage-related flags from this scope's CMAKE_CXX_FLAGS.
+string(REPLACE "--coverage"         "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-fprofile-arcs"     "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-ftest-coverage"    "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-fprofile-abs-path" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-fprofile-update=[^ ]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+add_library(miniaudio_impl OBJECT miniaudio_impl.cpp)
+target_include_directories(miniaudio_impl SYSTEM PRIVATE "${MINIAUDIO_INCLUDE_DIR}")
+
+# Suppress all warnings — this is third-party code.
+if (MSVC)
+    target_compile_options(miniaudio_impl PRIVATE /W0)
+else()
+    target_compile_options(miniaudio_impl PRIVATE -w)
+endif()

--- a/src/miniaudio/miniaudio_impl.cpp
+++ b/src/miniaudio/miniaudio_impl.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Compile miniaudio implementation as part of CopyQ.
+// The miniaudio.h header is provided by the system (e.g. miniaudio-devel).
+#define MINIAUDIO_IMPLEMENTATION
+#include <miniaudio.h>

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -5,6 +5,7 @@
 #include "app/clipboardmonitor.h"
 #include "common/action.h"
 #include "common/appconfig.h"
+#include "common/audioplayer.h"
 #include "common/command.h"
 #include "common/commandstatus.h"
 #include "common/commandstore.h"
@@ -38,7 +39,6 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
-#include <QFileInfo>
 #include <QMap>
 #include <QMimeData>
 #include <QMetaProperty>
@@ -737,6 +737,7 @@ QJSValue Scriptable::version()
             + "\n"
             + "Arch: " + QSysInfo::buildAbi() + "\n"
             + "OS: " + QSysInfo::prettyProductName() + "\n"
+            + "Audio: " + audioBackendVersion() + "\n"
             ;
 }
 
@@ -1291,6 +1292,38 @@ void Scriptable::popup()
     m_proxy->showMessage(messageData);
 }
 
+QJSValue Scriptable::playSound()
+{
+    m_skipArguments = 1;
+    const QJSValue value = argument(0);
+
+    QString filePath;
+    float volume = 1.0f;
+    // CLI string arguments arrive as ByteArray objects; treat those as file paths.
+    // A plain JS object (not ByteArray) is parsed as an options object.
+    if (value.isObject() && !getByteArray(value)) {
+        const QJSValue fileProp = value.property(QStringLiteral("file"));
+        if (!fileProp.isString() || fileProp.toString().isEmpty())
+            return throwError("playSound: object argument requires a 'file' string property");
+
+        filePath = fileProp.toString();
+
+        const QJSValue volProp = value.property(QStringLiteral("volume"));
+        if (!volProp.isUndefined()) {
+            if (!volProp.isNumber())
+                return throwError("playSound: 'volume' must be a number");
+            volume = static_cast<float>(volProp.toNumber()) / 100.0f;
+        }
+    } else {
+        filePath = arg(0);
+    }
+
+    if (const auto error = m_proxy->playSound(filePath, volume); !error.isEmpty())
+        return throwError(error);
+
+    return {};
+}
+
 QJSValue Scriptable::notification()
 {
     m_skipArguments = -1;
@@ -1559,6 +1592,14 @@ QJSValue Scriptable::info()
 
     info.insert("has-keychain",
 #ifdef WITH_KEYCHAIN
+                "1"
+#else
+                "0"
+#endif
+                );
+
+    info.insert("has-audio",
+#ifdef WITH_AUDIO
                 "1"
 #else
                 "0"

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -226,6 +226,7 @@ public slots:
     void action();
     void popup();
     QJSValue notification();
+    QJSValue playSound();
 
     QJSValue exportTab();
     void exporttab() { exportTab(); }

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -3,6 +3,7 @@
 #include "scriptableproxy.h"
 
 #include "common/action.h"
+#include "common/audioplayer.h"
 #include "common/appconfig.h"
 #include "common/command.h"
 #include "common/commandstatus.h"
@@ -1085,6 +1086,12 @@ void ScriptableProxy::showMessage(const MessageData &messageData)
     notification->setButtons(messageData.buttons.items);
     notification->setUrgency(messageData.urgency);
     notification->setPersistency(messageData.persistency);
+}
+
+QString ScriptableProxy::playSound(const QString &filePath, float volume)
+{
+    INVOKE(playSound, (filePath, volume));
+    return AudioPlayer::instance().play(filePath, volume);
 }
 
 QVariantMap ScriptableProxy::nextItem(const QString &tabName, int where)

--- a/src/scriptable/scriptableproxy.h
+++ b/src/scriptable/scriptableproxy.h
@@ -145,6 +145,8 @@ public slots:
 
     void showMessage(const MessageData &messageData);
 
+    QString playSound(const QString &filePath, float volume);
+
     QVariantMap nextItem(const QString &tabName, int where);
     void browserMoveToClipboard(const QString &tabName, int row);
     void browserSetCurrent(const QString &tabName, int arg1);

--- a/src/tests/tests.cmake
+++ b/src/tests/tests.cmake
@@ -4,6 +4,7 @@ file(GLOB copyq_tests_SOURCES tests/*.cpp)
 add_executable(copyq-tests
     ${copyq_tests_SOURCES}
     $<TARGET_OBJECTS:copyq-common>
+    ${MINIAUDIO_OBJECTS}
 )
 set_target_properties(copyq-tests PROPERTIES COMPILE_DEFINITIONS "${copyq_DEFINITIONS}")
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -117,6 +117,7 @@ private slots:
     void commandNotification();
     void commandNotificationUrgency();
     void commandNotificationPersistent();
+    void commandPlaySound();
 
     void commandIcon();
     void commandIconTag();

--- a/src/tests/tests_playsound.cpp
+++ b/src/tests/tests_playsound.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "test_utils.h"
+#include "tests.h"
+#include "tests_common.h"
+
+#include "common/commandstatus.h"
+
+#include <QDataStream>
+#include <QTemporaryFile>
+
+namespace {
+
+/// Build a minimal valid WAV file containing silence.
+/// PCM 8-bit mono at 100 Hz; \a durationMs in milliseconds.
+/// Produces a tiny file (~100 bytes/s) for testing playback paths.
+QByteArray makeSilentWav(int durationMs)
+{
+    const int sampleRate = 100;
+    const int bitsPerSample = 8;
+    const int numChannels = 1;
+    const int bytesPerSample = bitsPerSample / 8;
+    const int numSamples = sampleRate * durationMs / 1000;
+    const int dataSize = numSamples * numChannels * bytesPerSample;
+
+    QByteArray wav;
+    QDataStream s(&wav, QIODevice::WriteOnly);
+    s.setByteOrder(QDataStream::LittleEndian);
+
+    // RIFF header
+    s.writeRawData("RIFF", 4);
+    s << quint32(36 + dataSize); // file size - 8
+    s.writeRawData("WAVE", 4);
+
+    // fmt sub-chunk
+    s.writeRawData("fmt ", 4);
+    s << quint32(16);            // sub-chunk size (PCM)
+    s << quint16(1);             // audio format (PCM)
+    s << quint16(numChannels);
+    s << quint32(sampleRate);
+    s << quint32(sampleRate * numChannels * bytesPerSample); // byte rate
+    s << quint16(numChannels * bytesPerSample);              // block align
+    s << quint16(bitsPerSample);
+
+    // data sub-chunk — 8-bit PCM silence is 0x80 (midpoint), not 0x00
+    s.writeRawData("data", 4);
+    s << quint32(dataSize);
+    wav.append(QByteArray(dataSize, '\x80'));
+
+    return wav;
+}
+
+/// Write a silent WAV to a QTemporaryFile; returns false on I/O error.
+bool writeSilentWav(QTemporaryFile &tmp, int durationMs)
+{
+    if (!tmp.open())
+        return false;
+    const QByteArray wav = makeSilentWav(durationMs);
+    if (tmp.write(wav) != wav.size())
+        return false;
+    if (!tmp.flush())
+        return false;
+    tmp.close();
+    return true;
+}
+
+} // namespace
+
+void Tests::commandPlaySound()
+{
+    // Object argument with missing file property
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound({})",
+        CommandException, "ScriptError: playSound: object argument requires a 'file' string property");
+
+    // Object argument with non-string file property
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound({file: 123})",
+        CommandException, "ScriptError: playSound: object argument requires a 'file' string property");
+
+    // Object argument with non-number volume
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound({file: '/no/such/file.wav', volume: 'loud'})",
+        CommandException, "ScriptError: playSound: 'volume' must be a number");
+
+#ifndef WITH_AUDIO
+    SKIP("Audio playback not compiled in (WITH_AUDIO is off)");
+#endif
+
+    SKIP_ON_ENV("COPYQ_TESTS_SKIP_AUDIO");
+
+    // Missing argument — empty path reaches the server which reports file-not-found
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound", CommandException, "ScriptError: File not found:");
+
+    // File does not exist (string argument)
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound" << "/no/such/file.wav", CommandException, "ScriptError: File not found:");
+
+    // Object argument with nonexistent file
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "playSound({file: '/no/such/file.wav', volume: 50})",
+        CommandException, "ScriptError: File not found:");
+
+    // Existing file: playSound delegates to the server which starts
+    // playback asynchronously.
+    {
+        QTemporaryFile tmp;
+        QVERIFY(writeSilentWav(tmp, 500));
+
+        // String argument (default volume)
+        RUN("playSound" << tmp.fileName(), "");
+
+        // Object argument with explicit volume
+        RUN("eval" << QStringLiteral("playSound({file: '%1', volume: 50})").arg(tmp.fileName()), "");
+
+        // Object argument without volume (default 100%)
+        RUN("eval" << QStringLiteral("playSound({file: '%1'})").arg(tmp.fileName()), "");
+    }
+}


### PR DESCRIPTION
Add playSound(file) scripting function for playing audio files (WAV, MP3,
FLAC) using the miniaudio library. This enables users to trigger audio
notifications from scripts and automatic commands without heavyweight
Qt Multimedia dependencies.

Implementation:
- CMake integration with compile-time optional WITH_NATIVE_AUDIO flag
- miniaudio compiled from system-provided header (miniaudio-devel package)
- AudioPlayer singleton wrapping ma_engine with async fire-and-forget playback
- Stub implementation when built without audio support returns descriptive error
- Script function registered via Qt meta-object auto-discovery
- CLI help, autocomplete documentation, and RST API docs
- miniaudio credited in About dialog
- CI workflows download miniaudio header for all platforms

Closes #1328

Assisted-by: Claude (Anthropic)
