### PR TITLE
ci: split build and test into separate jobs

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -83,7 +83,7 @@ env:
 
 jobs:
   build:
-    name: ${{matrix.buildname}}
+    name: Build ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     strategy:
       # Avoid canceling all jobs on transient failures.
@@ -97,6 +97,7 @@ jobs:
             with_qt6: false
             with_native_notifications: true
             cmake_preset: Debug
+            artifact_name: qt5
 
           - os: ubuntu-latest
             buildname: Qt 6
@@ -114,6 +115,7 @@ jobs:
               -ftest-coverage
               -fprofile-abs-path
               -fprofile-update=atomic
+            artifact_name: qt6
 
           - os: ubuntu-latest
             buildname: Qt 6 Clang
@@ -122,6 +124,7 @@ jobs:
             with_qt6: true
             with_native_notifications: false
             cmake_preset: Debug
+            artifact_name: qt6-clang
 
     steps:
       - name: Checkout source code
@@ -167,6 +170,86 @@ jobs:
             '-DWITH_QT6=${{matrix.with_qt6}}',
             '-DWITH_NATIVE_NOTIFICATIONS=${{matrix.with_native_notifications}}'
             ]
+
+      - name: Create build tarball
+        working-directory: ${{ runner.workspace }}
+        run: tar cf build-artifact.tar build install
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        with:
+          name: build-${{ matrix.artifact_name }}
+          path: ${{ runner.workspace }}/build-artifact.tar
+          compression-level: 0
+          retention-days: 1
+
+  test:
+    name: Test ${{matrix.buildname}}
+    needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      # Avoid canceling all jobs on transient failures.
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            buildname: Qt 5
+            compiler_package: g++
+            with_qt6: false
+            test_wayland: false
+            test_gnome: false
+            coverage: false
+            cmake_preset: Debug
+            artifact_name: qt5
+
+          - os: ubuntu-latest
+            buildname: Qt 6
+            compiler_package: g++
+            with_qt6: true
+            test_wayland: true
+            test_gnome: true
+            coverage: true
+            cmake_preset: Debug
+            artifact_name: qt6
+
+          - os: ubuntu-latest
+            buildname: Qt 6 Clang
+            compiler_package: clang
+            with_qt6: true
+            test_wayland: false
+            test_gnome: false
+            coverage: false
+            cmake_preset: Debug
+            artifact_name: qt6-clang
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1
+        with:
+          version: 1.0
+          packages: >-
+            ${{ matrix.compiler_package }}
+            ${{ env.common_packages }}
+            ${{ matrix.with_qt6 && env.qt6_packages || env.qt5_packages }}
+            ${{ matrix.coverage && 'lcov' || '' }}
+            ${{ matrix.coverage && 'kwin-wayland kwin-wayland-backend-virtual libwayland-server0 procps' || '' }}
+            ${{ matrix.test_gnome && 'gnome-shell gnome-shell-common glib2.0-bin' || '' }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: build-${{ matrix.artifact_name }}
+          path: ${{ runner.workspace }}
+
+      - name: Extract build artifacts
+        working-directory: ${{ runner.workspace }}
+        run: tar xf build-artifact.tar
 
       - name: Create gnupg directory for tests
         run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,11 +34,13 @@ jobs:
             buildname: macOS 13
             bundle_suffix: '-macos-13'
             cmake_preset: macOS-13
+            artifact_name: macos-13
 
           - os: macos-14
             buildname: macOS 12 M1
             bundle_suffix: '-macos-12-m1'
             cmake_preset: macOS-12-m1
+            artifact_name: macos-12-m1
 
     steps:
       - name: Checkout source code
@@ -97,9 +99,6 @@ jobs:
           configurePreset: '${{ matrix.cmake_preset }}'
           buildPreset: '${{ matrix.cmake_preset }}'
 
-      - name: Create gnupg directory for tests
-        run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
-
       - name: Get version string
         id: version
         run: |
@@ -120,6 +119,69 @@ jobs:
           name: 'CopyQ-${{ steps.version.outputs.version }}${{ matrix.bundle_suffix }}.dmg'
           path: '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/CopyQ-${{ steps.version.outputs.version }}${{ matrix.bundle_suffix }}.dmg'
 
+      - name: Save version for test job
+        run: echo '${{ steps.version.outputs.version }}' > '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/build-version.txt'
+
+      - name: Upload test binaries
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
+        with:
+          name: test-binaries-${{ matrix.artifact_name }}
+          path: |
+            ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/copyq-tests
+            ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/build-version.txt
+          compression-level: 0
+          retention-days: 1
+
+
+  test:
+    name: Test ${{matrix.buildname}}
+    needs: build
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            buildname: macOS 13
+            bundle_suffix: '-macos-13'
+            cmake_preset: macOS-13
+            artifact_name: macos-13
+
+          - os: macos-14
+            buildname: macOS 12 M1
+            bundle_suffix: '-macos-12-m1'
+            cmake_preset: macOS-12-m1
+            artifact_name: macos-12-m1
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Download test binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: test-binaries-${{ matrix.artifact_name }}
+          path: ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+
+      - name: Read version
+        id: version
+        run: echo "version=$(cat '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/build-version.txt')" >> "$GITHUB_OUTPUT"
+
+      - name: Download macOS bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: 'CopyQ-${{ steps.version.outputs.version }}${{ matrix.bundle_suffix }}.dmg'
+          path: ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+
+      - name: Create gnupg directory for tests
+        run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
+
+      - name: Make test binary executable
+        run: chmod +x '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/copyq-tests'
+
       - name: Test
         working-directory: '${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}'
         run: '${{github.workspace}}/utils/github/test-macos.sh'
@@ -135,7 +197,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -160,6 +160,30 @@ jobs:
           submodules: false
           fetch-depth: 1
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          modules: qtimageformats qt5compat
+          cache: true
+          set-env: true
+
+      - name: Set up dependency paths
+        run: |
+          DEPS_PREFIX=$GITHUB_WORKSPACE/deps/install
+          echo "DEPS_PREFIX=$DEPS_PREFIX" >> "$GITHUB_ENV"
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ github.workspace }}/deps/install
+          key: >-
+            macos-deps-kf${{ env.KF_VERSION }}.${{ env.KF_PATCH
+            }}-qca${{ env.QCA_VERSION
+            }}-qtkeychain${{ env.QTKEYCHAIN_VERSION
+            }}-${{ runner.arch
+            }}-${{ hashFiles('utils/patches/**') }}
+
       - name: Download test binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,8 @@ jobs:
   build:
     name: Windows
     runs-on: windows-2025
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     defaults:
       run:
         shell: bash
@@ -124,24 +126,13 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.version }}
           BUILD_DIR: ${{ runner.workspace }}/build/copyq/Windows
 
-      - name: Set up GPG for tests
-        shell: pwsh
-        run: |
-          $env:PATH = "C:\Program Files\Git\usr\bin;$env:PATH"
-          New-Item -ItemType Directory -Force "$HOME\.gnupg" | Out-Null
-          gpg --version
-
-      - name: Test
-        working-directory: ${{ github.workspace }}/copyq-${{ steps.version.outputs.version }}
-        shell: cmd
-        run: |
-          set "PATH=%CD%;C:\Program Files\Git\usr\bin"
-          .\copyq-tests.exe
-        env:
-          QT_FORCE_STDERR_LOGGING: 1
-          COPYQ_LOG_LEVEL: DEBUG
-          COPYQ_TESTS_RERUN_FAILED: 1
-          COPYQ_PLUGINS: ${{ github.workspace }}\copyq-${{ steps.version.outputs.version }}\itemtests.dll
+      - name: Upload deployed directory
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: deploy-windows
+          path: ${{ github.workspace }}/copyq-${{ steps.version.outputs.version }}
+          compression-level: 0
+          retention-days: 1
 
       - name: Create portable zip
         run: 7z a "copyq-${{ steps.version.outputs.version }}.zip" "copyq-${{ steps.version.outputs.version }}"
@@ -168,9 +159,43 @@ jobs:
           path: copyq-${{ steps.version.outputs.version }}-setup.exe
 
 
+  test:
+    name: Test Windows
+    needs: build
+    runs-on: windows-2025
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Download deployed directory
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: deploy-windows
+          path: ${{ github.workspace }}/copyq-${{ needs.build.outputs.version }}
+
+      - name: Set up GPG for tests
+        shell: pwsh
+        run: |
+          $env:PATH = "C:\Program Files\Git\usr\bin;$env:PATH"
+          New-Item -ItemType Directory -Force "$HOME\.gnupg" | Out-Null
+          gpg --version
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/copyq-${{ needs.build.outputs.version }}
+        shell: cmd
+        run: |
+          set "PATH=%CD%;C:\Program Files\Git\usr\bin"
+          .\copyq-tests.exe
+        env:
+          QT_FORCE_STDERR_LOGGING: 1
+          COPYQ_LOG_LEVEL: DEBUG
+          COPYQ_TESTS_RERUN_FAILED: 1
+          COPYQ_PLUGINS: ${{ github.workspace }}\copyq-${{ needs.build.outputs.version }}\itemtests.dll
+
+
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Split the single `build` job in each CI workflow (Linux, macOS, Windows) into separate `build` and `test` jobs. This allows re-running only the test job when tests fail, without a full rebuild.

## Changes

### All workflows
- Single `build` job split into `build` + `test` jobs
- Artifact transfer between jobs via `actions/upload-artifact` / `actions/download-artifact` v4
- Compiled binary artifacts use `compression-level: 0` and `retention-days: 1`

### Linux
- Build artifacts transferred as a tarball (preserves permissions, handles paths outside $GITHUB_WORKSPACE)
- Test job reinstalls runtime dependencies (Xvfb, openbox, X libs, etc.) via apt cache hit
- Coverage collection remains in the test job (lcov captures .gcno from build + .gcda from test)

### macOS
- DMG bundle artifact name unchanged (release job glob still works)
- Test binaries + version file uploaded separately
- Release job now requires both build and test to pass

### Windows
- Deployed directory uploaded as artifact
- Version string passed via job outputs
- Release job now requires both build and test to pass

## Tradeoff
- ~30-90 seconds slower on green runs (job startup + artifact transfer overhead)
- ~3-8 minutes faster on test-only reruns (skips full C++ compilation)