### PR TITLE
Fix macOS provider termination timeouts, remove Windows clipboard polling

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -121,7 +121,6 @@ App::App(QCoreApplication *application,
     : m_app(application)
     , m_exitCode(0)
     , m_started(false)
-    , m_closed(false)
 {
     registerDataFileConverter();
 
@@ -168,11 +167,11 @@ void App::exit(int exitCode)
         ::exit(exitCode);
 
     m_exitCode = exitCode;
-    m_closed = true;
+    m_app->setProperty("CopyQ_quitting", true);
     QCoreApplication::exit(exitCode);
 }
 
 bool App::wasClosed() const
 {
-    return m_closed;
+    return m_app->property("CopyQ_quitting").toBool();
 }

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -46,5 +46,4 @@ private:
     QCoreApplication *m_app;
     int m_exitCode;
     bool m_started;
-    bool m_closed;
 };

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -120,6 +120,10 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     , m_ignoreKeysTimer()
     , m_sharedData(std::make_shared<ClipboardBrowserShared>())
 {
+    // Server-spawned subprocesses connect back to an already-running server.
+    // Skip the connection retry delay so they fail fast during shutdown.
+    qputenv("COPYQ_WAIT_FOR_SERVER_MS", "0");
+
     m_server = new Server(clipboardServerName(sessionName), this);
 
     if ( m_server->isListening() ) {

--- a/src/common/clientsocket.cpp
+++ b/src/common/clientsocket.cpp
@@ -7,6 +7,7 @@
 #include "common/sleeptimer.h"
 
 #include <QDataStream>
+#include <QVariant>
 
 #define SOCKET_LOG(text) \
     COPYQ_LOG_VERBOSE( QString("Socket %1: %2").arg(m_socketId).arg(text) )
@@ -111,20 +112,22 @@ ClientSocket::ClientSocket(const QString &serverName, QObject *parent)
 {
     m_socket->connectToServer(serverName);
 
-    // Try to connect again in case the server just started.
+    // Retry connecting in case the server just started.
+    // Server-spawned subprocesses set COPYQ_WAIT_FOR_SERVER_MS=0 to skip this.
     if ( m_socket->state() == QLocalSocket::UnconnectedState ) {
-        COPYQ_LOG("Waiting for server to start");
-
         bool ok;
-        int waitMs = qEnvironmentVariableIntValue("COPYQ_WAIT_FOR_SERVER_MS", &ok);
-        if (!ok)
-            waitMs = 1000;
-
-        SleepTimer t(waitMs);
-        do {
-            m_socket->connectToServer(serverName);
-        } while ( m_socket->state() == QLocalSocket::UnconnectedState && t.sleep() );
+        const int waitMs = qEnvironmentVariableIntValue("COPYQ_WAIT_FOR_SERVER_MS", &ok);
+        if (!ok || waitMs > 0) {
+            COPYQ_LOG("Waiting for server to start");
+            SleepTimer t(ok ? waitMs : 1000);
+            do {
+                m_socket->connectToServer(serverName);
+            } while ( m_socket->state() == QLocalSocket::UnconnectedState
+                      && !QCoreApplication::instance()->property("CopyQ_quitting").toBool()
+                      && t.sleep() );
+        }
     }
+
 }
 
 ClientSocket::ClientSocket(QLocalSocket *socket, QObject *parent)
@@ -143,7 +146,7 @@ ClientSocket::~ClientSocket()
 
 bool ClientSocket::start()
 {
-    if ( !m_socket || !m_socket->waitForConnected(4000) )
+    if ( !m_socket || m_socket->state() != QLocalSocket::ConnectedState )
     {
         emit connectionFailed(id());
         return false;

--- a/src/common/clipboarddataguard.cpp
+++ b/src/common/clipboarddataguard.cpp
@@ -154,6 +154,12 @@ bool ClipboardDataGuard::isExpired() {
     if (!m_data)
         return true;
 
+    if (qApp && qApp->property("CopyQ_quitting").toBool()) {
+        m_data = nullptr;
+        log( QByteArrayLiteral("Aborting clipboard cloning: Application quitting"), LogWarning );
+        return true;
+    }
+
     if (m_clipboardSequenceNumber && *m_clipboardSequenceNumber != m_clipboardSequenceNumberOriginal) {
         m_data = nullptr;
         log( QByteArrayLiteral("Aborting clipboard cloning: Clipboard changed again"), LogWarning );

--- a/src/gui/clipboardspy.cpp
+++ b/src/gui/clipboardspy.cpp
@@ -57,7 +57,7 @@ bool ClipboardSpy::setClipboardData(const QVariantMap &data)
             : ClipboardModeFlag::Selection;
         m_connection = m_clipboard->createConnection(QStringList(mimeOwner), mode);
         connect(m_connection.get(), &ClipboardConnection::changed,
-                this, &ClipboardSpy::emitChangeIfChanged);
+                this, &ClipboardSpy::emitChangeIfChanged, Qt::QueuedConnection);
     }
 
     m_clipboard->setData(m_mode, data);
@@ -75,11 +75,15 @@ QByteArray ClipboardSpy::currentOwnerData() const
 void ClipboardSpy::stop()
 {
     m_stopped = true;
+    m_connection.reset();
     emit stopped();
 }
 
 void ClipboardSpy::emitChangeIfChanged()
 {
+    if (m_stopped)
+        return;
+
     const auto newOwner = currentOwnerData();
     if (m_oldOwnerData != newOwner) {
         emit changed();

--- a/src/platform/mac/macclipboard.mm
+++ b/src/platform/mac/macclipboard.mm
@@ -23,14 +23,32 @@
 #include <Cocoa/Cocoa.h>
 #include <Carbon/Carbon.h>
 
+namespace {
+
+int clipboardMonitorIntervalMs()
+{
+    bool ok = false;
+    const int ms = qEnvironmentVariableIntValue("COPYQ_CLIPBOARD_MONITOR_INTERVAL_MS", &ok);
+    return (ok && ms > 0) ? ms : 500;
+}
+
+int clipboardMonitorToleranceMs()
+{
+    bool ok = false;
+    const int ms = qEnvironmentVariableIntValue("COPYQ_CLIPBOARD_MONITOR_TOLERANCE_MS", &ok);
+    return (ok && ms >= 0) ? ms : 5000;
+}
+
+} // namespace
+
 void MacClipboard::startMonitoringBackend(const QStringList &formats, ClipboardModeMask modes)
 {
     NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
     m_prevChangeCount = [pasteboard changeCount];
 
     m_timer = new MacTimer(this);
-    m_timer->setInterval(250);
-    m_timer->setTolerance(500);
+    m_timer->setInterval(clipboardMonitorIntervalMs());
+    m_timer->setTolerance(clipboardMonitorToleranceMs());
     connect(m_timer, &MacTimer::timeout, this, &MacClipboard::clipboardTimeout);
     m_timer->start();
 
@@ -95,5 +113,8 @@ void MacClipboard::onChanged(int mode)
 }
 
 void MacClipboard::clipboardTimeout() {
+    m_timer->stop();
     onChanged(QClipboard::Clipboard);
+    if (m_timer)
+        m_timer->start();
 }

--- a/src/platform/mac/mactimer.h
+++ b/src/platform/mac/mactimer.h
@@ -3,14 +3,11 @@
 #pragma once
 
 
+#include "cfref.h"
+
 #include <QObject>
 
-#ifdef __OBJC__
-@class NSTimer;
-#else
-using NSTimer = void;
-#endif
-
+#include <CoreFoundation/CoreFoundation.h>
 /**
  * Class similar to a QTimer but allows setting a tolerance, which
  * makes timers more battery-friendly on OSX.
@@ -28,9 +25,8 @@ public:
     inline void setSingleShot(bool singleShot);
 
     /**
-     * Set the tolerance for the timer. See NSTimer::setTolerance.
-     *
-     * Tolerance is ignored on OS X < 10.9.
+     * Set the tolerance for the timer.
+     * See CFRunLoopTimerSetTolerance.
      */
     void setTolerance(int msec);
     int tolerance() const { return m_tolerance; }
@@ -52,5 +48,5 @@ private:
     int m_tolerance;
     bool m_singleShot;
 
-    NSTimer *m_nsTimer;
+    CFRef<CFRunLoopTimerRef> m_cfTimer;
 };

--- a/src/platform/mac/mactimer.mm
+++ b/src/platform/mac/mactimer.mm
@@ -2,15 +2,13 @@
 
 #include "mactimer.h"
 
-#include <Cocoa/Cocoa.h>
 #include <QPointer>
 
 MacTimer::MacTimer(QObject *parent) :
     QObject(parent),
     m_interval(0),
     m_tolerance(0),
-    m_singleShot(false),
-    m_nsTimer(0)
+    m_singleShot(false)
 {
 }
 
@@ -21,15 +19,15 @@ MacTimer::~MacTimer()
 
 void MacTimer::stop()
 {
-    if (m_nsTimer) {
-        CFRunLoopTimerInvalidate((CFRunLoopTimerRef) m_nsTimer);
+    if (m_cfTimer) {
+        CFRunLoopTimerInvalidate(m_cfTimer);
+        m_cfTimer = nullptr;
     }
-    m_nsTimer = 0;
 }
 
 void MacTimer::restart()
 {
-    if (m_nsTimer) {
+    if (m_cfTimer) {
         stop();
         start();
     }
@@ -65,7 +63,7 @@ void MacTimer::start() {
     // Use QPointer to make it auto-null, and use a 'weak reference' in the
     // block
     QPointer<MacTimer> weakThis(this);
-    double intervalSeconds = (float)m_interval / 1000.0;
+    double intervalSeconds = (double)m_interval / 1000.0;
 
     // Create a timer which kicks into a block
     CFRunLoopTimerRef timer = CFRunLoopTimerCreateWithHandler(NULL,
@@ -79,12 +77,15 @@ void MacTimer::start() {
         }
     );
 
-    // Set the tolerance using an NSTimer as there is no CF way of doing so
-    if ([m_nsTimer respondsToSelector:@selector(setTolerance:)]) {
-        double toleranceSeconds = (double)m_tolerance / 1000.0;
-        [m_nsTimer setTolerance:toleranceSeconds];
-    }
+    if (!timer)
+        return;
 
-    // add timer to the hidden run loop
+    // Set tolerance so macOS can coalesce timer firings for power efficiency.
+    double toleranceSeconds = (double)m_tolerance / 1000.0;
+    CFRunLoopTimerSetTolerance(timer, toleranceSeconds);
+
+    // Add timer to the current run loop. The run loop retains its own
+    // reference; CFRef adopts the Create-rule +1 for stop()/invalidate.
     CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer, kCFRunLoopDefaultMode);
+    m_cfTimer = timer;
 }

--- a/src/platform/win/winplatformclipboard.cpp
+++ b/src/platform/win/winplatformclipboard.cpp
@@ -4,7 +4,6 @@
 
 #include <QClipboard>
 #include <QMimeData>
-#include <QTimer>
 
 namespace {
 
@@ -20,27 +19,9 @@ void WinPlatformClipboard::startMonitoringBackend(const QStringList &formats, Cl
     Q_UNUSED(modes)
     m_lastClipboardSequenceNumber = GetClipboardSequenceNumber();
 
-    /* Clipboard needs to be checked in intervals since
-     * the QClipboard::changed() signal is not emitted in some cases on Windows.
-     */
-    m_timer = new QTimer(this);
-    m_timer->setInterval(500);
-    connect( m_timer, &QTimer::timeout, this, [this](){
-        onClipboardChanged(QClipboard::Clipboard);
-    });
-    m_timer->start();
-
+    // Clipboard changes are detected via QClipboard::changed signal
+    // (Qt 6 uses AddClipboardFormatListener / WM_CLIPBOARDUPDATE).
     DummyClipboard::startMonitoringBackend(formats, modes);
-}
-
-void WinPlatformClipboard::stopMonitoringBackend()
-{
-    if (m_timer) {
-        m_timer->stop();
-        m_timer->deleteLater();
-        m_timer = nullptr;
-    }
-    DummyClipboard::stopMonitoringBackend();
 }
 
 bool WinPlatformClipboard::isHidden(const QMimeData &data) const

--- a/src/platform/win/winplatformclipboard.h
+++ b/src/platform/win/winplatformclipboard.h
@@ -2,12 +2,9 @@
 
 #pragma once
 
-
 #include "platform/dummy/dummyclipboard.h"
 
 #include <qt_windows.h>
-
-class QTimer;
 
 class WinPlatformClipboard final : public DummyClipboard
 {
@@ -16,7 +13,6 @@ public:
 
 protected:
     void startMonitoringBackend(const QStringList &, ClipboardModeMask) override;
-    void stopMonitoringBackend() override;
     void onChanged(int) override;
     const long int *clipboardSequenceNumber(ClipboardMode) const override {
         return &m_lastClipboardSequenceNumber;
@@ -24,5 +20,4 @@ protected:
 
 private:
     long int m_lastClipboardSequenceNumber = 0;
-    QTimer *m_timer = nullptr;
 };

--- a/src/tests/tests_common.cpp
+++ b/src/tests/tests_common.cpp
@@ -41,6 +41,7 @@ bool testStderr(
         plain("Cannot connect to server! Start CopyQ server first."),
         plain("Aborting clipboard cloning"),
         plain("Failed to provide clipboard"),
+        plain("Failed to provide selection"),
         regex("Warning <.*>: ELAPSED .* ms accessing"),
         regex("ERROR <.*>: Connection lost!"),
 
@@ -74,16 +75,15 @@ bool testStderr(
         plain("QWinEventNotifier: no event dispatcher, application shutting down? Cannot deliver event."),
         plain("setGeometry: Unable to set geometry"),
         plain("Failed to raise: "),
+        plain("[qt.qpa.mime] Retrying to obtain clipboard."),
+        plain("[qt.qpa.mime] Unable to obtain clipboard."),
+        plain("[default] QSystemTrayIcon::setVisible: No Icon set"),
 
         plain("[kf.notifications] Received a response for an unknown notification."),
         // KStatusNotifierItem
         plain("[kf.windowsystem] Could not find any platform plugin"),
 
         regex("QTemporaryDir: Unable to remove .* most likely due to the presence of read-only files."),
-
-        // Windows Qt 5.15.2
-        plain("[qt.qpa.mime] Retrying to obtain clipboard."),
-        plain("[default] QSystemTrayIcon::setVisible: No Icon set"),
 
         // macOS
         plain("Failed to get QCocoaScreen for NSObject(0x0)"),


### PR DESCRIPTION
Provider processes ("copyq --clipboard-access provideClipboard") could hang
past the 6s termination window because pasteboard IPC blocked the event loop,
preventing CommandStop from being processed.

## Changes

- Fix MacTimer to properly store and manage CFRunLoopTimerRef using CFRef
  RAII wrapper, fixing timer leaks and non-functional stop()
- Prevent re-entrant timer callbacks during slow pasteboard access by
  stopping the timer before processing and restarting after
- Tear down clipboard monitoring immediately on stop instead of waiting
  for deferred cleanup
- Use queued connections for clipboard change signals so stop events
  get a chance to be processed first
- Abort in-progress clipboard cloning when the application is quitting
- Make macOS clipboard polling interval (500ms) and tolerance (5s)
  configurable via `COPYQ_CLIPBOARD_MONITOR_INTERVAL_MS` and
  `COPYQ_CLIPBOARD_MONITOR_TOLERANCE_MS` environment variables
- Remove Windows clipboard polling timer; Qt 6 uses
  `AddClipboardFormatListener` / `WM_CLIPBOARDUPDATE` internally, so
  `QClipboard::changed` is fully event-driven and the 500ms timer
  was unnecessary wakeups
- Set `COPYQ_WAIT_FOR_SERVER_MS=0` in `ClipboardServer` so server-spawned
  subprocesses skip the connection retry delay and fail fast on shutdown
- Remove blocking `waitForConnected(4000)` from `ClientSocket::start`;
  the constructor already handles connection retries, and the 4s blocking
  wait was the main cause of delayed provideClipboard termination
- Check `CopyQ_quitting` property in `ClientSocket`'s connection retry loop
  to bail out immediately when the application is shutting down, instead
  of in `SleepTimer::sleep` where it broke server `waitForClientsToFinish`