### PR TITLE
Fix window becoming invisible when started minimized

### DIFF
--- a/src/gui/geometry.cpp
+++ b/src/gui/geometry.cpp
@@ -109,6 +109,8 @@ QString resolutionTag(const QWidget &widget, bool openOnCurrentScreen)
     return tag;
 }
 
+} // namespace
+
 void ensureWindowOnScreen(QWidget *widget)
 {
     const QSize frame  = frameSize(widget);
@@ -147,8 +149,6 @@ void ensureWindowOnScreen(QWidget *widget)
         widget->move(x, y);
     }
 }
-
-} // namespace
 
 QVariant geometryOptionValue(const QString &optionName)
 {
@@ -197,6 +197,9 @@ void restoreWindowGeometry(QWidget *w, bool openOnCurrentScreen)
 
 void saveWindowGeometry(QWidget *w, bool openOnCurrentScreen)
 {
+    if (w->isMinimized())
+        return;
+
     const QString optionName = geometryOptionName(*w, openOnCurrentScreen);
     const QString tag = resolutionTag(*w, openOnCurrentScreen);
     QSettings geometrySettings( getGeometryConfigurationFilePath(), QSettings::IniFormat );

--- a/src/gui/geometry.h
+++ b/src/gui/geometry.h
@@ -24,4 +24,6 @@ void moveToCurrentWorkspace(QWidget *w);
 void moveWindowOnScreen(QWidget *w, QPoint pos);
 
 void setGeometryGuardBlockedUntilHidden(QWidget *w, bool blocked);
+
+void ensureWindowOnScreen(QWidget *w);
 bool isGeometryGuardBlockedUntilHidden(const QWidget *w);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -3234,6 +3234,8 @@ void MainWindow::showWindow()
     else
         showNormal();
 
+    ensureWindowOnScreen(this);
+
     auto c = browser();
     if (c) {
         if ( !c->isInternalEditorOpen() )

--- a/src/gui/windowgeometryguard.cpp
+++ b/src/gui/windowgeometryguard.cpp
@@ -114,7 +114,7 @@ bool WindowGeometryGuard::eventFilter(QObject *, QEvent *event)
 
     case QEvent::Move:
     case QEvent::Resize:
-        if ( !isWindowGeometryLocked() && m_window->isVisible() )
+        if ( !isWindowGeometryLocked() && m_window->isVisible() && !m_window->isMinimized() )
             m_timerSaveGeometry.start();
         break;
 


### PR DESCRIPTION
Skip saving window geometry while minimized to prevent persisting invalid coordinates. Validate geometry on show to recover from previously corrupted state.

Fixes: https://github.com/hluk/CopyQ/issues/3440
Assisted-by: Claude (Anthropic)