### PR TITLE
Add One Dark theme

### DIFF
--- a/shared/themes/onedark.ini
+++ b/shared/themes/onedark.ini
@@ -1,0 +1,127 @@
+[General]
+css_template_items=items
+css_template_main_window=main_window
+css_template_menu=menu
+css_template_notification=notification
+
+style_main_window=true
+show_number=true
+show_scrollbars=false
+font_antialiasing=true
+use_system_icons=false
+
+icon_size=8
+item_spacing=0
+num_margin=2
+
+font="Sans,11,-1,5,50,0,0,0,0,0"
+find_font="Sans,11,-1,5,50,0,0,0,0,0"
+num_font="Sans,8,-1,5,50,0,0,0,0,0"
+edit_font="Sans,11,-1,5,50,0,0,0,0,0"
+notes_font="Sans,11,-1,5,50,0,0,0,0,0"
+notification_font="Sans,11,-1,5,50,0,0,0,0,0"
+
+bg=#282c34
+fg=#abb2bf
+alt_bg=#1e222a
+sel_bg=#61afef
+sel_fg=#282c34
+find_bg=#e5c07b
+find_fg=#282c34
+edit_bg=#1e222a
+edit_fg=#abb2bf
+notes_bg=#3e4451
+notes_fg=#abb2bf
+num_fg=#5c6370
+num_sel_fg=#abb2bf
+notification_bg=#1e222a
+notification_fg=#abb2bf
+
+css=
+
+menu_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;padding: 0.15em
+    ;border-radius: 5%"
+menu_bar_disabled_css=
+menu_bar_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${sel_fg}"
+menu_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;border: 1px solid ${sel_bg}"
+
+tool_bar_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tool_button_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;font-weight: normal
+    ;border: 0
+    ;border-radius: 5%"
+tool_button_pressed_css="
+    ;background: ${num_fg}"
+tool_button_selected_css="
+    ;background: ${sel_bg}
+    ;color: ${sel_fg}"
+
+search_bar="
+    ;background: ${find_bg}
+    ;color: ${find_fg}
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${find_bg}"
+search_bar_focused="
+    ;margin: 0.2em 0 0.1em 0
+    ;padding: 0.2em 0 0.2em 0
+    ;border: 1px solid ${sel_bg}"
+
+tab_bar_css="
+    ;background: ${bg}"
+tab_bar_item_counter="
+    ;color: #e06c75
+    ;font-size: 6pt"
+tab_bar_scroll_buttons_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;border: 0"
+tab_bar_sel_item_counter="
+    ;color: #e06c75"
+tab_bar_tab_unselected_css="
+    ;background: ${bg}
+    ;color: ${num_fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${bg}"
+tab_bar_tab_selected_css="
+    ;background: ${alt_bg}
+    ;color: ${fg}
+    ;padding: 0.2em
+    ;border: 1px solid ${sel_bg}
+    ;border-radius: 5%"
+
+tab_tree_css="
+    ;background: ${bg}
+    ;color: ${num_fg}"
+tab_tree_item_counter="
+    ;color: #e06c75
+    ;font-size: 6pt"
+tab_tree_sel_item_counter="
+    ;color: #e06c75"
+tab_tree_sel_item_css="
+    ;background: ${bg}
+    ;color: ${fg}
+    ;text-decoration: underline"
+
+item_css="
+    ;padding: 0.3em 0.5em 0.5em 0.5em"
+alt_item_css=
+sel_item_css=
+cur_item_css="
+    ;border: 1px solid ${sel_bg}"
+hover_item_css="
+    ;background: #3e4451"
+notes_css=


### PR DESCRIPTION
## Problem

CopyQ ships several built-in color themes but does not include One Dark, a
popular dark color scheme used across many editors and terminals.

## Solution

Add a new `onedark.ini` theme file based on the One Dark color palette,
following the same structure as the existing `nord.ini` theme.

## Key changes

- Add `shared/themes/onedark.ini` with full One Dark color mapping
- Styled CSS for menu bar, tool bar, search bar, tabs, and item list
- Uses the standard One Dark palette: #282c34 background, #abb2bf foreground,
  #61afef blue selection, #e5c07b yellow search highlight, #e06c75 red accents