### PR TITLE
Fix rounded item corners showing wrong background color

### DIFF
--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -591,8 +591,16 @@ void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 {
     const bool isSelected = option.state & QStyle::State_Selected;
 
-    // Render background (selected, alternate, ...).
+    // Draw the list widget background clipped to the item rect so that
+    // rounded corners reveal the correct background (including gradients).
+    painter->save();
+    painter->setClipRect(option.rect);
+    QStyleOption bgOpt;
+    bgOpt.initFrom(m_view);
+    bgOpt.rect = m_view->viewport()->rect();
     QStyle *style = m_view->style();
+    style->drawPrimitive(QStyle::PE_Widget, &bgOpt, painter, m_view);
+    painter->restore();
     style->drawControl(QStyle::CE_ItemViewItem, &option, painter, m_view);
 
     // Colorize item.


### PR DESCRIPTION
Draw the list widget styled background at full size, clipped to the item rect, before drawing the styled item. This ensures border-radius corners reveal the actual widget background instead of the item background color, even when the background uses a gradient.

Assisted-by: Claude (Anthropic)