### PR TITLE
Fix tray menu not showing on Wayland when triggered via shortcut

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,14 +21,14 @@ env:
     extra-cmake-modules
     libwayland-dev
 
+    libegl-dev
+
     gnupg2
 
     xvfb
     openbox
     xdotool
   qt6_packages: >-
-    libegl-dev
-
     qt6-base-private-dev
     qt6-base-dev
     qt6-base-dev-tools
@@ -77,6 +77,10 @@ env:
     libqca-qt5-2-plugins
 
     qtkeychain-qt5-dev
+
+  QCA_VERSION: '2.3.10'
+  QTKEYCHAIN_VERSION: '0.15.0'
+
   # FIXME: Sending signal to client process does not cause the process
   # to exit with non-zero code with GitHub Actions. Why?
   COPYQ_TESTS_SKIP_SIGNAL: '1'
@@ -103,6 +107,7 @@ jobs:
             compiler: g++
             compiler_package: g++
             with_qt6: true
+            custom_qt: '6.10.2'
             with_native_notifications: false
             test_wayland: true
             test_gnome: true
@@ -146,10 +151,46 @@ jobs:
           packages: >-
             ${{ matrix.compiler_package }}
             ${{ env.common_packages }}
-            ${{ matrix.with_qt6 && env.qt6_packages || env.qt5_packages }}
+            ${{ !matrix.custom_qt && (matrix.with_qt6 && env.qt6_packages || env.qt5_packages) || '' }}
             ${{ matrix.coverage && 'lcov' || '' }}
-            ${{ matrix.coverage && 'kwin-wayland kwin-wayland-backend-virtual libwayland-server0 procps' || '' }}
+            ${{ matrix.test_wayland && 'kwin-wayland kwin-wayland-backend-virtual libwayland-server0' || '' }}
+            ${{ matrix.custom_qt && 'libssl-dev libsecret-1-dev pkg-config' || '' }}
+            ${{ matrix.coverage && 'procps' || '' }}
             ${{ matrix.test_gnome && 'gnome-shell gnome-shell-common glib2.0-bin' || '' }}
+
+      - name: Install Qt
+        if: matrix.custom_qt
+        uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4
+        with:
+          version: ${{ matrix.custom_qt }}
+          modules: qt5compat
+
+
+      - name: Build QCA and QtKeychain
+        if: matrix.custom_qt
+        run: |
+          set -e
+          git clone --depth 1 --branch v${{ env.QCA_VERSION }} https://github.com/KDE/qca.git /tmp/qca
+          cmake -G Ninja -S /tmp/qca -B /tmp/qca-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DBUILD_WITH_QT6=ON \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_PLUGINS=ossl
+          cmake --build /tmp/qca-build --parallel
+          sudo cmake --install /tmp/qca-build
+
+          git clone --depth 1 --branch ${{ env.QTKEYCHAIN_VERSION }} https://github.com/frankosterfeld/qtkeychain.git /tmp/qtkeychain
+          cmake -G Ninja -S /tmp/qtkeychain -B /tmp/qtkeychain-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DBUILD_WITH_QT6=ON \
+            -DBUILD_TRANSLATIONS=OFF
+          cmake --build /tmp/qtkeychain-build --parallel
+          sudo cmake --install /tmp/qtkeychain-build
+
+          echo "LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 
       - name: Download miniaudio
         uses: ./.github/actions/download-miniaudio
@@ -165,7 +206,7 @@ jobs:
             '-DCMAKE_CXX_FLAGS=${{matrix.compiler_flags}}',
             '-DCMAKE_C_FLAGS=${{matrix.compiler_flags}}',
             '-DWITH_QT6=${{matrix.with_qt6}}',
-            '-DWITH_NATIVE_NOTIFICATIONS=${{matrix.with_native_notifications}}'
+            '-DWITH_NATIVE_NOTIFICATIONS=${{matrix.with_native_notifications}}',
             ]
 
       - name: Create gnupg directory for tests

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2229,6 +2229,17 @@ bool MainWindow::toggleMenu(TrayMenu *menu, QPoint pos)
 #endif
     raiseWindow(menu);
 
+    // On Wayland the menu is a frameless toplevel (not a popup), so
+    // raiseWindow's activation guard ("app already active") is not
+    // sufficient — the compositor won't move focus from another toplevel
+    // (e.g. an open dialog) to the newly mapped menu window without an
+    // explicit activation request after the raise.
+    if (!menu->windowFlags().testFlag(Qt::Popup)) {
+        menu->activateWindow();
+        QApplication::setActiveWindow(menu);
+        menu->setFocus();
+    }
+
     return true;
 }
 

--- a/src/gui/traymenu.cpp
+++ b/src/gui/traymenu.cpp
@@ -17,8 +17,13 @@
 #include <QModelIndex>
 #include <QPixmap>
 #include <QRegularExpression>
+#include <QLoggingCategory>
+#include <QWindow>
 
 namespace {
+
+Q_DECLARE_LOGGING_CATEGORY(logCategory)
+Q_LOGGING_CATEGORY(logCategory, "copyq.traymenu")
 
 const char propertyTextFormat[] = "CopyQ_text_format";
 
@@ -64,6 +69,26 @@ TrayMenu::TrayMenu(QWidget *parent)
     m_customActionsSeparator = addSeparator();
     initSingleShotTimer( &m_timerUpdateActiveAction, 0, this, &TrayMenu::doUpdateActiveAction );
     setAttribute(Qt::WA_InputMethodEnabled);
+
+    // WORKAROUND: Starting with Qt 6.9 (qtbase commit 8c0dd12f), popups
+    // without a focused transient parent are rejected with an asynchronous
+    // close event instead of falling back to a toplevel.  When the tray
+    // menu is triggered via a global shortcut on Wayland, no CopyQ window
+    // has focus, so the popup is immediately closed (QTBUG-139921, #3325).
+    // Remove the Popup flag to turn the menu into a normal toplevel, and
+    // close it explicitly when an action fires (hideUpToMenuBar() is a
+    // no-op for non-popup menus).
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
+        qCDebug(logCategory) << "Wayland detected, removing Popup flag";
+        setWindowFlag(Qt::Popup, false);
+        setWindowFlag(Qt::Window, true);
+        setWindowFlag(Qt::FramelessWindowHint, true);
+        setWindowFlag(Qt::WindowStaysOnTopHint, true);
+
+        connect(this, &QMenu::triggered, this, &QMenu::close);
+    }
+#endif
 }
 
 void TrayMenu::updateTextFromData(QAction *act, const QVariantMap &data)

--- a/src/platform/x11/x11platform.cmake
+++ b/src/platform/x11/x11platform.cmake
@@ -46,14 +46,16 @@ endif()
 find_package(ECM REQUIRED NO_MODULE)
 list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 if (WITH_QT6 AND ECM_VERSION VERSION_GREATER "6.2.0")
+    find_package(KF6GuiAddons QUIET)
+endif()
+if (KF6GuiAddons_FOUND)
     message(STATUS "Using clipboard support from KGuiAddons.")
-    find_package(KF6GuiAddons REQUIRED)
     list(APPEND copyq_DEFINITIONS HAS_KGUIADDONS)
     list(APPEND copyq_LIBRARIES KF6::GuiAddons)
 else()
     message(WARNING
         "Using built-in clipboard support."
-        " Requires Qt 6 and 'kf6-kguiaddons', 'libkf6guiaddons' or similar"
+        " Install 'kf6-kguiaddons', 'libkf6guiaddons' or similar"
         " for better Wayland clipboard integration.")
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include_directories(${CMAKE_CURRENT_BINARY_DIR}/platform/x11/systemclipboard)

--- a/src/tests/tests_common.cpp
+++ b/src/tests/tests_common.cpp
@@ -64,6 +64,7 @@ bool testStderr(
         plain("The compositor sent a wl_pointer.enter"),
         plain("QObject::connect: No such signal QPlatformNativeInterface::systemTrayWindowChanged(QScreen*)"),
         plain("Could not init WaylandClipboard, falling back to QtClipboard."),
+        plain("QDBusTrayIcon encountered a D-Bus error"),
 
         // KDE Frameworks (Linux)
         plain("[kf.notifications]"),

--- a/utils/github/test-linux-gnome-extension.sh
+++ b/utils/github/test-linux-gnome-extension.sh
@@ -21,6 +21,9 @@ if [[ -z "${COPYQ_TESTS_GNOME_EXTENSION_INIT:-}" ]]; then
     env --ignore-environment \
         COPYQ_TESTS_GNOME_EXTENSION_INIT=1 \
         HOME="$tmp_dir" \
+        PATH="$PATH" \
+        ${LD_LIBRARY_PATH:+LD_LIBRARY_PATH="$LD_LIBRARY_PATH"} \
+        ${QT_PLUGIN_PATH:+QT_PLUGIN_PATH="$QT_PLUGIN_PATH"} \
         COPYQ_LOG_LEVEL="${COPYQ_LOG_LEVEL:-DEBUG}" \
         QT_LOGGING_RULES="${QT_LOGGING_RULES:-*.debug=true;qt.*.debug=false;qt.*.warning=true}" \
         COPYQ_GNOME_EXTENSION_DEBUG="${COPYQ_GNOME_EXTENSION_DEBUG:-1}" \

--- a/utils/github/test-linux-wayland.sh
+++ b/utils/github/test-linux-wayland.sh
@@ -13,6 +13,7 @@ default_wayland_tests=(
     clipboardToItem
     itemToClipboard
     avoidStoringPasswords
+    trayShowHideAction
 )
 
 kwin_wayland --virtual --socket=copyq-wayland &


### PR DESCRIPTION
On Wayland, Qt requires popup windows to have a focused transient parent.
When the tray menu is triggered via a global shortcut, no CopyQ window has
focus so the compositor rejects the popup.

Remove the Popup flag on Wayland and use frameless window hints instead,
with explicit activation after raise and focus-loss auto-dismiss. Also
handle the case where QMenu flash animation keeps isVisible() true briefly
after an action fires.

See: https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/6003
Fixes: #3325
Assisted-by: Claude (Anthropic)