### PR TITLE
docs: document secret clipboard handling and restructure encryption docs

### DIFF
--- a/docs/backup.rst
+++ b/docs/backup.rst
@@ -66,9 +66,11 @@ configuration and commands within the application.
 
 .. warning::
 
-    Tabs are exported **without any encryption** by default (you would need
-    CopyQ 14.0.0 and above) and if a tab is synchronized with directory on disk
-    the files themselves will not be exported.
+    Exported data is **not encrypted by default**. When exporting from the GUI,
+    CopyQ prompts for an optional export password — if provided, tab data in the
+    export file is encrypted with that password. The ``exportData`` script
+    command does not support this and always exports unencrypted. If a tab is
+    synchronized with a directory on disk, the files themselves are not exported.
 
 To export the data click "Export..." in "File" menu, select what to
 export, confirm with OK button and select target file to save.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -448,18 +448,19 @@ Alternatively, run the following command::
 Why does encryption ask for password so often?
 ----------------------------------------------
 
-CopyQ 14.0.0 and above has a built-in encryption support, which requires
-password only at start (and when changing encryption password). Even that can
-be avoided if "Use external key store" option is enabled and the system
-supports it (Windows Credential Store, macOS Keychain, GNOME Keyring, KWallet).
+With built-in encryption (the recommended approach), CopyQ asks for the
+password at startup and when changing the encryption password. If **Require
+password after an interval** is enabled (in the "History" configuration tab),
+the password is also requested periodically. The startup prompt can be avoided
+by enabling the **Use external key store** option, which stores the password in
+the platform key store (Windows Credential Store, macOS Keychain, GNOME Keyring,
+or KWallet) — but the periodic prompt, if enabled, still applies.
 
-In older versions, there is an Encryption plugin which uses ``gpg2`` utility to
-decrypt tabs and items. The password usually needs to be entered once every few
-minutes.
-
-If the password prompt is showing up too often, either increase tab unloading
-interval ("Unload tab after an interval" option in "History" tab in
-Preferences), or change ``gpg`` configuration (see `#946
+If you are using the legacy **Encryption plugin** (which relies on ``gpg2``),
+the password usually needs to be re-entered once every few minutes. To reduce
+prompts, either increase the tab unloading interval ("Unload tab after an
+interval" option in "History" tab in Preferences) or change ``gpg``
+configuration (see `#946
 <https://github.com/hluk/CopyQ/issues/946#issuecomment-389538964>`__).
 
 How to fix "copyq: command not found" errors?

--- a/docs/password-protection.rst
+++ b/docs/password-protection.rst
@@ -3,19 +3,58 @@
 Password Protection
 ===================
 
-This page describes how to encrypt and protect selected tabs and single
-items with a password.
+This page describes how to encrypt clipboard data stored by CopyQ. The
+recommended approach is the built-in encryption available since version 14.0.0.
+A legacy plugin using GnuPG is also documented below for older versions or
+per-item encryption needs.
+
+Built-in Encryption
+-------------------
+
+CopyQ can encrypt all stored tab data with a user-set password. No external
+software is required.
+
+To enable it, open **Preferences** and check the **Encrypt Tabs** option.
+You will be prompted to set a password. The password is needed when CopyQ
+starts and when changing the encryption password. If **Require password after
+an interval** is enabled (in the "History" configuration tab), the password is
+also requested periodically.
+
+To avoid entering the password at startup, enable **Use external key store**.
+This delegates password storage to a platform key store (note that this does
+not bypass the periodic prompt when password expiry is enabled):
+
+- **Windows** — Credential Store
+- **macOS** — Keychain
+- **Linux** — GNOME Keyring or KWallet
+
+Unlike the legacy Encryption plugin, built-in encryption automatically covers
+all tabs loaded by the application — there is no per-tab or per-item setup.
 
 .. note::
 
-   CopyQ 14.0.0 and above will support encrypting all data using a custom
-   Password. This can be enabled with "Encrypt Tabs" option in Preferences. As
-   An alternative, available in older versions, the below describes using
-   Encryption plugin to encrypt specific tabs or single items (this requires a
-   GnuPG utility to be installed).
+   Built-in encryption protects data at rest but does **not** encrypt exported
+   data. The ``exportTab`` and ``exportData`` script commands always write
+   unencrypted files. When exporting from the GUI (**File — Export**), CopyQ
+   prompts for an optional export password — if provided, tab data in the
+   export file is encrypted with that password. See :ref:`backup` for details.
+
+Encryption Plugin (Legacy)
+--------------------------
+
+.. deprecated:: 14.0.0
+   The Encryption plugin is obsolete. Use the built-in encryption described
+   above instead. The plugin remains available for users who need per-item
+   encryption or are running CopyQ versions older than 14.0.0.
+
+.. warning::
+
+   The plugin depends on GnuPG (``gpg2``), which introduces external key
+   management complexity and version-compatibility issues. The password must
+   be re-entered every few minutes.
 
 Installation
-------------
+~~~~~~~~~~~~
 
 To enable this feature you need to have "Encryption" item plugin.
 
@@ -35,7 +74,7 @@ Configuration dialog) may prompt you to install
    distributions.
 
 Generate Keys and Set Password
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To be able to encrypt tabs and items you first need to generate private
 and public key files.
@@ -58,7 +97,7 @@ section).
 Click "OK" button to confirm Configuration dialog.
 
 Protect Tabs
-------------
+~~~~~~~~~~~~
 
 Now you can create the tabs you want to encrypt (Ctrl+T to create new
 tab).
@@ -77,7 +116,7 @@ click on "Reload" button in tab to enter password again.
 .. image:: images/encryption-reload.png
 
 Protect Single Items
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 To protect items in unprotected tab you can add menu and tool bar
 actions with keyboard shortcut.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -27,6 +27,101 @@ The data from all tabs are stored in the configuration directory unencrypted
 
 CopyQ does not collect any other data and does not send anything over network.
 
+.. _secret-clipboard:
+
+Secret Clipboard Data
+=====================
+
+Password managers, web browsers in private or incognito mode, remote desktop
+software (such as RDP or Citrix), and virtualization tools (such as VMware or
+VirtualBox) often mark clipboard content as secret. CopyQ recognizes this
+and **silently ignores the clipboard change** — by default, the data is not
+stored, not shown, and not processed by automatic commands.
+
+Detection is platform-specific. The clipboard formats that indicate secrets are:
+
+- **Linux** — ``x-kde-passwordManagerHint`` set to ``secret``. Used by
+  KeePassXC, KDE Wallet, and other password managers.
+- **macOS** — Presence of ``application/x-nspasteboard-concealed-type``. Used by
+  Keychain Access, 1Password, and other macOS applications.
+- **Windows** — Any of the following formats:
+
+  - ``Clipboard Viewer Ignore``
+  - ``ExcludeClipboardContentFromMonitorProcessing``
+  - ``CanIncludeInClipboardHistory`` set to ``0``
+  - ``CanUploadToCloudClipboard`` set to ``0``
+
+  These are `documented by Microsoft
+  <https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#cloud-clipboard-and-clipboard-history-formats>`__
+  and used by Windows Credential Manager and most third-party password managers.
+
+In all cases, CopyQ adds the ``application/x-copyq-secret`` format (available in
+scripts as :js:data:`mimeSecret`) and hands the data to the
+``onSecretClipboardChanged()`` callback. The default implementation discards
+everything except the secret marker, so no sensitive content reaches CopyQ's
+history or automatic commands.
+
+To check whether the current clipboard content is considered secret, open
+**File — Show Clipboard Content** (default shortcut ``Ctrl+Shift+C``) in the
+main window. If any of the formats listed above appear in the clipboard data,
+CopyQ treats the content as secret.
+
+Overriding Secret Detection
+----------------------------
+
+If CopyQ is ignoring clipboard data that you want to capture — for example,
+content from a private browser window or a remote desktop session — you can
+override the default behavior.
+
+The safer approach is to allow secret clipboard data only from specific windows.
+The following Script command processes secrets only when the source window title
+contains "Chromium", "Chrome", or "Firefox" (adjust the pattern to match your
+browser or application):
+
+.. code-block:: ini
+
+    [Command]
+    Command="
+        const onSecretClipboardChanged_ = onSecretClipboardChanged
+        onSecretClipboardChanged = function() {
+            const title = str(data(mimeWindowTitle))
+            if (title.match(/Chromium|Chrome|Firefox/i))
+                onClipboardChanged()
+            else
+                onSecretClipboardChanged_()
+        }
+        "
+    IsScript=true
+    Name=Store Secrets from Browser
+    Icon=\xf21b
+
+This keeps passwords from password managers safely ignored while allowing
+clipboard data from private browsing windows.
+
+Alternatively, to process **all** secret clipboard data regardless of source:
+
+.. code-block:: ini
+
+    [Command]
+    Command="global.onSecretClipboardChanged = global.onClipboardChanged"
+    IsScript=true
+    Name=Store/Process All Secrets
+    Icon=\xf09c
+
+.. warning::
+
+    Processing all secrets means **passwords from password managers will be
+    stored in CopyQ's unencrypted history**. If you enable this, consider also
+    enabling encryption (see :ref:`encrypt`) to protect stored items, or use
+    selective automatic commands to filter what gets saved.
+
+.. seealso::
+
+    - :js:func:`onSecretClipboardChanged` — scripting API reference
+    - :ref:`faq-ignore-password-manager` — ignoring password manager windows by title
+    - :ref:`encrypt` — encrypting stored clipboard data
+
+
 Clipboard Content Visibility
 ============================
 


### PR DESCRIPTION
- security.rst: add Secret Clipboard Data section covering detection,
  default behavior, and override via Script commands
- password-protection.rst: lead with built-in encryption as recommended
  method; demote GnuPG plugin to legacy section; note export limitations
- faq.rst: update encryption FAQ to match
- backup.rst: clarify export encryption behavior (GUI vs script)

Assisted-by: Claude (Anthropic)