### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -196,7 +196,7 @@ jobs:
         uses: ./.github/actions/download-miniaudio
 
       - name: Build with CMake
-        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10
         with:
           configurePreset: '${{ matrix.cmake_preset }}'
           buildPreset: '${{ matrix.cmake_preset }}'
@@ -259,7 +259,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
         with:
           files: ${{runner.workspace}}/build/copyq/${{ matrix.cmake_preset }}/coverage.info
           fail_ci_if_error: true

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/deps/install
           key: >-
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/download-miniaudio
 
       - name: Build with CMake
-        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10
         with:
           configurePreset: '${{ matrix.cmake_preset }}'
           buildPreset: '${{ matrix.cmake_preset }}'
@@ -144,7 +144,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
       - name: Upload to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           draft: true
           files: 'CopyQ-*/*.dmg'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Cache KDE dependencies
         id: cache-deps
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ github.workspace }}/deps/install
           key: >-
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/download-miniaudio
 
       - name: Build with CMake
-        uses: lukka/run-cmake@af1be47fd7c933593f687731bc6fdbee024d3ff4 # v10
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10
         env:
           VCPKG_ROOT: ''
         with:
@@ -165,13 +165,13 @@ jobs:
             "%GITHUB_WORKSPACE%\shared\copyq.iss"
 
       - name: Upload portable zip
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: copyq-${{ steps.version.outputs.version }}.zip
           path: copyq-${{ steps.version.outputs.version }}.zip
 
       - name: Upload installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: copyq-${{ steps.version.outputs.version }}-setup.exe
           path: copyq-${{ steps.version.outputs.version }}-setup.exe
@@ -188,7 +188,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
       - name: Upload to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           draft: true
           files: |


### PR DESCRIPTION
- actions/cache from 4.3.0 to 5.0.4
- actions/upload-artifact from 4.6.2 to 7.0.0
- codecov/codecov-action from 5.5.2 to 6.0.0
- lukka/run-cmake from 10.8 to 10.9
- softprops/action-gh-release from 2.5.0 to 2.6.1