### PR TITLE
Show tray icon before encryption password prompt

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -3102,6 +3102,13 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
         saveTabs();
     }
 
+    // Show the tray icon early so it is visible while the encryption
+    // password dialog blocks (see https://github.com/hluk/CopyQ/issues/3502).
+    if (m_options.nativeTrayMenu != appConfig->option<Config::native_tray_menu>())
+        m_options.nativeTrayMenu = appConfig->option<Config::native_tray_menu>();
+    setTrayEnabled( !appConfig->option<Config::disable_tray>() );
+    updateIcon();
+
     promptForEncryptionPasswordIfNeeded(appConfig);
     reencryptTabsIfNeeded(appConfig);
 
@@ -3183,12 +3190,7 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
     m_trayMenu->setStyleSheet(menuStyleSheet);
     m_menu->setStyleSheet(menuStyleSheet);
 
-    if (m_options.nativeTrayMenu != appConfig->option<Config::native_tray_menu>())
-        m_options.nativeTrayMenu = appConfig->option<Config::native_tray_menu>();
-    setTrayEnabled( !appConfig->option<Config::disable_tray>() );
     updateTrayMenuItems();
-
-    updateIcon();
 
     menuBar()->setNativeMenuBar( appConfig->option<Config::native_menu_bar>() );
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -3104,8 +3104,7 @@ void MainWindow::loadSettings(QSettings &settings, AppConfig *appConfig)
 
     // Show the tray icon early so it is visible while the encryption
     // password dialog blocks (see https://github.com/hluk/CopyQ/issues/3502).
-    if (m_options.nativeTrayMenu != appConfig->option<Config::native_tray_menu>())
-        m_options.nativeTrayMenu = appConfig->option<Config::native_tray_menu>();
+    m_options.nativeTrayMenu = appConfig->option<Config::native_tray_menu>();
     setTrayEnabled( !appConfig->option<Config::disable_tray>() );
     updateIcon();
 
@@ -4094,7 +4093,9 @@ void MainWindow::findNextOrPrevious()
 
 void MainWindow::enterBrowseMode()
 {
-    getPlaceholder()->setFocus();
+    auto placeholder = getPlaceholder();
+    if (placeholder)
+        placeholder->setFocus();
     ui->searchBar->hide();
 
     auto c = browserOrNull();


### PR DESCRIPTION
Initialize the tray icon before the encryption password dialog blocks, so the icon is visible while the dialog is open.

In Flatpak, this also registers the SNI on D-Bus before a user Ctrl+C on the client process can tear down the D-Bus proxy.

Fixes: https://github.com/hluk/CopyQ/issues/3502
Assisted-by: Claude (Anthropic)