### PR TITLE
Fix blank items appearing in search results

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1266,6 +1266,7 @@ void ClipboardBrowser::filterItems(const ItemFilterPtr &filter)
     }
 
     d.updateAllRows();
+    preloadCurrentPage();
 }
 
 void ClipboardBrowser::filterBatch(int filterId, const QPersistentModelIndex &lastIndex)
@@ -1301,6 +1302,9 @@ void ClipboardBrowser::filterBatch(int filterId, const QPersistentModelIndex &la
             break;
         }
     }
+
+    d.updateAllRows();
+    preloadCurrentPage();
 
     const int percentCompleted = (row * 100) / length();
     emit filterProgressChanged(percentCompleted);


### PR DESCRIPTION
Ensure item widgets are created for visible rows immediately after filtering, rather than relying on deferred layout triggers. This closes the gap where rows were unhidden but their content widgets had not yet been created, resulting in blank rectangles.

Assisted-by: Claude (Anthropic)