### PR TITLE
Add codecov.yml to stabilize coverage status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.05%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
Add a small project coverage threshold (0.05%) to absorb non-deterministic run-to-run fluctuations that cause the codecov/project check to fail on otherwise healthy PRs. Also set an 80% patch target for new/changed lines.

Assisted-by: Claude (Anthropic)