### PR TITLE
Fix missing console output on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -132,6 +132,64 @@ jobs:
           APP_VERSION: ${{ steps.version.outputs.version }}
           BUILD_DIR: ${{ runner.workspace }}/build/copyq/Windows
 
+      - name: Test console wrapper (cmd)
+        working-directory: ${{ github.workspace }}/copyq-${{ steps.version.outputs.version }}
+        shell: cmd
+        run: |
+          @echo off
+
+          rem --- Test 1: stdout capture via redirect ---
+          copyq.com version > __out.txt 2>nul
+          if %ERRORLEVEL% neq 0 (echo FAIL: exit code %ERRORLEVEL% & exit /b 1)
+          findstr /C:"CopyQ" __out.txt >nul || (echo FAIL: no CopyQ in output & type __out.txt & exit /b 1)
+          del __out.txt
+
+          rem --- Test 2: piping works ---
+          copyq.com version 2>nul | findstr /C:"CopyQ" >nul
+          if %ERRORLEVEL% neq 0 (echo FAIL: pipe did not contain CopyQ & exit /b 1)
+
+          rem --- Test 3: exit code propagation for errors ---
+          copyq.com thisCommandDoesNotExist12345 >nul 2>nul
+          if %ERRORLEVEL% equ 0 (echo FAIL: expected non-zero exit code & exit /b 1)
+
+          rem --- Test 4: terminal still functional after wrapper exits ---
+          echo AFTER_WRAPPER | findstr /C:"AFTER_WRAPPER" >nul
+          if %ERRORLEVEL% neq 0 (echo FAIL: terminal corrupted & exit /b 1)
+
+          echo All cmd console wrapper tests passed.
+
+      - name: Test console wrapper (pwsh)
+        working-directory: ${{ github.workspace }}/copyq-${{ steps.version.outputs.version }}
+        shell: pwsh
+        run: |
+          # GitHub Actions prepends $ErrorActionPreference = 'Stop' to pwsh
+          # scripts.  Native commands that emit stderr (Qt debug/warnings)
+          # generate ErrorRecords that terminate the script before 2>$null
+          # can suppress them.  Override to Continue and check manually.
+          $ErrorActionPreference = 'Continue'
+          $PSNativeCommandUseErrorActionPreference = $false
+
+          # Test 1: stdout capture
+          $version = (& .\copyq.com version) -join "`n"
+          if ($LASTEXITCODE -ne 0) { throw "FAIL Test 1: exit code $LASTEXITCODE" }
+          if (-not $version) { throw 'FAIL Test 1: copyq.com version produced no output' }
+          if ($version -notmatch 'CopyQ') { throw "FAIL Test 1: no CopyQ in: $version" }
+
+          # Test 2: piping
+          $piped = & .\copyq.com version | Select-String 'CopyQ'
+          if (-not $piped) { throw 'FAIL Test 2: piped output missing CopyQ' }
+
+          # Test 3: exit code propagation
+          & .\copyq.com thisCommandDoesNotExist12345 | Out-Null
+          if ($LASTEXITCODE -eq 0) { throw 'FAIL Test 3: expected non-zero exit code' }
+
+          # Test 4: terminal still works
+          $check = 'AFTER_WRAPPER'
+          if ($check -ne 'AFTER_WRAPPER') { throw 'FAIL Test 4: terminal corrupted' }
+
+          Write-Host 'All pwsh console wrapper tests passed.'
+          exit 0
+
       - name: Set up GPG for tests
         shell: pwsh
         run: |

--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -5,12 +5,11 @@ Tabs, items, clipboard and configuration can be changed through command
 line interface. Run command ``copyq help`` to see complete list of
 commands and their description.
 
-.. warning::
+.. note::
 
-    On Windows, you may not see any output when executing CopyQ in
-    terminal/console (PowerShell or cmd).
+    On Windows, use ``copyq`` (not ``copyq.exe``) in a terminal for
+    proper console output.  See :ref:`known-issue-windows-console-output`.
 
-    See workarounds in :ref:`known-issue-windows-console-output`.
 
 To add new item to tab with name "notes" run:
 

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -23,23 +23,20 @@ status are not restored after the application is restarted or after logging in.
 On Windows, CopyQ does not print anything on console
 ----------------------------------------------------
 
-On Windows, you may not see any output when executing CopyQ in a
-console/terminal application (PowerShell or cmd).
+Running ``copyq.exe`` directly from a terminal produces no console output
+because it is a GUI-subsystem process.
 
-**Workarounds:**
-
-* Use different console application: Git Bash, Cygwin or similar.
-* Use Action dialog in CopyQ (``F5`` shortcut) and set "Store standard output"
-  to "text/plain" to save the output as new item in current tab.
-* Append ``| Write-Output`` to commands in PowerShell:
-
-  .. code-block:: powershell
-
-    & 'C:\Program Files\CopyQ\copyq.exe' help | Write-Output
+Use ``copyq`` (or ``copyq.com``) instead — Windows prefers ``.com`` over
+``.exe``, so typing ``copyq`` in a terminal uses the console wrapper
+automatically.  The wrapper provides proper terminal integration: the shell
+waits for the process, stdout/stderr are connected, and piping works.
 
 .. seealso::
 
     `Issue #349 <https://github.com/hluk/CopyQ/issues/349>`__
+
+    `Issue #2937 <https://github.com/hluk/CopyQ/issues/2937>`__
+
 
 .. _known-issue-macos-paste-after-install:
 

--- a/shared/copyq.iss
+++ b/shared/copyq.iss
@@ -149,6 +149,7 @@ Name: "startup"; Description: {cm:AutoStartProgram,CopyQ}; Flags: unchecked
 
 [Files]
 Source: "{#Root}\copyq.exe"; DestDir: "{app}"; Components: program; Flags: ignoreversion
+Source: "{#Root}\copyq.com"; DestDir: "{app}"; Components: program; Flags: ignoreversion
 Source: "{#Root}\snoretoast.exe"; DestDir: "{app}"; Components: program; Flags: ignoreversion skipifsourcedoesntexist
 Source: "{#Root}\AUTHORS"; DestDir: "{app}"; Components: program; Flags: ignoreversion
 Source: "{#Root}\LICENSE"; DestDir: "{app}"; Components: program; Flags: ignoreversion

--- a/src/platform/win/copyq_console_wrapper.cpp
+++ b/src/platform/win/copyq_console_wrapper.cpp
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Console-subsystem wrapper for CopyQ (copyq.com).
+//
+// Windows distinguishes GUI and console applications at the PE binary level.
+// CopyQ's main binary (copyq.exe) is a GUI-subsystem application to avoid
+// spawning a console window when launched from a shortcut or at startup.
+//
+// This wrapper is a console-subsystem binary.  Windows command resolution
+// prefers .com over .exe, so typing "copyq" in a terminal runs copyq.com.
+// Because it is a console app, the shell waits for it, and stdout/stderr
+// are connected to the terminal.
+//
+// The wrapper launches copyq.exe with the same arguments and inherited
+// standard handles.  No pipes, no buffering, no I/O relay — the child
+// writes directly to the caller's console or pipe.  This avoids the
+// deadlock and argument-mangling problems that plagued CopyQ's earlier
+// QProcess-based .com wrapper (2013–2015).
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+static HANDLE s_childProcess = NULL;
+
+static BOOL WINAPI consoleCtrlHandler(DWORD event)
+{
+    (void)event;
+    // The child is a GUI-subsystem process — it does not receive console
+    // control events.  Terminate it so the wrapper can exit cleanly.
+    if (s_childProcess)
+        TerminateProcess(s_childProcess, STATUS_CONTROL_C_EXIT);
+    return TRUE;
+}
+
+// Replace the file extension in `path` (length `len`) with `newExt`.
+// Returns FALSE if no extension is found.
+static BOOL replaceExtension(wchar_t *path, DWORD len, const wchar_t *newExt)
+{
+    for (wchar_t *p = path + len - 1; p > path; --p) {
+        if (*p == L'\\' || *p == L'/')
+            break;
+        if (*p == L'.') {
+            // Overwrite from the dot onward.
+            for (++p; *newExt; ++p, ++newExt)
+                *p = *newExt;
+            *p = L'\0';
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+int main(void)
+{
+    // Resolve copyq.exe: same directory, swap .com -> .exe.
+    wchar_t exePath[MAX_PATH];
+    DWORD len = GetModuleFileNameW(NULL, exePath, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH)
+        return 1;
+
+    if (!replaceExtension(exePath, len, L"exe"))
+        return 1;
+
+    // Pass the original command line through, replacing only argv[0].
+    // Skip past the program name in the raw command line.
+    const wchar_t *cmdLine = GetCommandLineW();
+    const wchar_t *args = cmdLine;
+    if (*args == L'"') {
+        for (++args; *args && *args != L'"'; ++args) {}
+        if (*args == L'"') ++args;
+    } else {
+        while (*args && *args != L' ' && *args != L'\t') ++args;
+    }
+    // `args` now points at the space before the first argument (or end).
+
+    // Build: "C:\...\copyq.exe" <original args>
+    // Max command line on Windows is 32767 characters.
+    wchar_t newCmdLine[32768];
+    newCmdLine[0] = L'"';
+    DWORD pos = 1;
+
+    for (DWORD i = 0; exePath[i] && pos < 32766; ++i)
+        newCmdLine[pos++] = exePath[i];
+    if (pos >= 32766)
+        return 1;
+    newCmdLine[pos++] = L'"';
+
+    // Append the rest of the original command line (includes leading space).
+    for (const wchar_t *p = args; *p && pos < 32767; ++p)
+        newCmdLine[pos++] = *p;
+    newCmdLine[pos] = L'\0';
+
+    // Launch copyq.exe, inheriting our console handles directly.
+    // No pipes, no relay — the child writes to the caller's terminal.
+    STARTUPINFOW si;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&pi, sizeof(pi));
+
+    if (!CreateProcessW(
+            exePath,
+            newCmdLine,
+            NULL, NULL,
+            TRUE,             // Inherit handles
+            0,                // No special flags; GUI-subsystem exe won't spawn a console
+            NULL, NULL,
+            &si, &pi))
+    {
+        return 1;
+    }
+
+    CloseHandle(pi.hThread);
+    s_childProcess = pi.hProcess;
+
+    SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+
+    DWORD exitCode = 1;
+    GetExitCodeProcess(pi.hProcess, &exitCode);
+    CloseHandle(pi.hProcess);
+
+    return (int)exitCode;
+}

--- a/src/platform/win/winplatform.cmake
+++ b/src/platform/win/winplatform.cmake
@@ -22,3 +22,22 @@ list(APPEND copyq_COMPILE
 if (MSVC)
     set(copyq_LINK_FLAGS ${copyq_LINK_FLAGS} "/ENTRY:mainCRTStartup")
 endif()
+
+
+# Console-subsystem wrapper (copyq.com).
+# Windows prefers .com over .exe, so "copyq" in a terminal runs this
+# wrapper which launches the GUI-subsystem copyq.exe with inherited
+# console handles.  This gives proper shell integration: the shell
+# waits, stdout works, piping works, exit codes propagate.
+add_executable(copyq-console-wrapper
+    platform/win/copyq_console_wrapper.cpp
+    ${copyq_RC}
+)
+set_target_properties(copyq-console-wrapper PROPERTIES
+    OUTPUT_NAME copyq
+    SUFFIX .com
+    WIN32_EXECUTABLE FALSE
+)
+install(TARGETS copyq-console-wrapper
+    RUNTIME DESTINATION . COMPONENT Runtime
+)

--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -32,9 +32,43 @@
 
 namespace {
 
-void setBinaryFor(int fd)
+// Connect a C runtime FILE* to its inherited Win32 standard handle.
+// On native Windows, the UCRT startup (_ioinit) already bridges inherited
+// handles to fds 0/1/2.  In that case we just set binary mode.  The
+// fallback path handles environments where the CRT did not initialize
+// the stream (fd is -2): it creates a new fd via _open_osfhandle and
+// transfers the FILE* state to the pre-allocated standard stream.
+void reopenStdHandle(DWORD nStdHandle, FILE *stream, const char *mode)
 {
-    _setmode(fd, _O_BINARY);
+    HANDLE h = GetStdHandle(nStdHandle);
+    if (h == INVALID_HANDLE_VALUE || h == NULL)
+        return;
+
+    // If the CRT already initialized this stream during startup
+    // (native Windows with inherited handles), just set binary mode.
+    const int existingFd = _fileno(stream);
+    if (existingFd >= 0) {
+        _setmode(existingFd, _O_BINARY);
+        setvbuf(stream, NULL, _IONBF, 0);
+        return;
+    }
+
+    // CRT did not initialize the stream (fd is -2).  Bridge the Win32
+    // handle to a properly initialized FILE*.  This technique is used
+    // by Blender, GIMP, and other GUI-subsystem apps.
+    const int flags = _O_BINARY
+        | ((stream == stdin) ? _O_RDONLY : _O_WRONLY);
+    const int fd = _open_osfhandle(reinterpret_cast<intptr_t>(h), flags);
+    if (fd < 0)
+        return;
+
+    // The FILE struct allocated by _fdopen is intentionally leaked;
+    // its internal state is now owned by `stream`.
+    FILE *fp = _fdopen(fd, mode);
+    if (fp) {
+        *stream = *fp;
+        setvbuf(stream, NULL, _IONBF, 0);
+    }
 }
 
 QString portableFolder()
@@ -169,8 +203,13 @@ void uninstallControlHandler()
 void initApplication(QCoreApplication *app)
 {
     installControlHandler();
-    setBinaryFor(0);
-    setBinaryFor(1);
+
+    // In a GUI-subsystem binary, C runtime stdio is disconnected.
+    // Reconnect to inherited Win32 handles so QFile::open(stdout, ...)
+    // and similar calls work when launched from copyq.com or a pipe.
+    reopenStdHandle(STD_INPUT_HANDLE,  stdin,  "rb");
+    reopenStdHandle(STD_OUTPUT_HANDLE, stdout, "wb");
+    reopenStdHandle(STD_ERROR_HANDLE,  stderr, "wb");
 
     // Don't use Windows registry.
     QSettings::setDefaultFormat(QSettings::IniFormat);

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -36,6 +36,12 @@ private slots:
     void badCommand();
     void badSessionName();
 
+#ifdef Q_OS_WIN
+    void consoleWrapperVersion();
+    void consoleWrapperHelp();
+    void consoleWrapperExitCode();
+#endif
+
     void commandCatchExceptions();
 
     void commandExit();

--- a/src/tests/tests_cli.cpp
+++ b/src/tests/tests_cli.cpp
@@ -12,6 +12,13 @@
 
 #include <QRegularExpression>
 
+#ifdef Q_OS_WIN
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
+#endif
+
 void Tests::configPath()
 {
     RUN("print(info('config'))", Settings().fileName());
@@ -208,3 +215,59 @@ void Tests::commandCatchExceptions()
     RUN("try { removeTab('MISSING') } catch(e) { print(e) }",
         "Error: Tab with given name doesn't exist!");
 }
+
+#ifdef Q_OS_WIN
+
+void Tests::consoleWrapperVersion()
+{
+    const QString wrapper = QDir(QCoreApplication::applicationDirPath())
+                                .absoluteFilePath("copyq.com");
+    if (!QFile::exists(wrapper))
+        QSKIP("copyq.com not found in build directory");
+
+    QProcess p;
+    p.start(wrapper, {"version"});
+    QVERIFY(p.waitForFinished(10000));
+    QCOMPARE(p.exitCode(), 0);
+
+    const QByteArray out = p.readAllStandardOutput();
+    QVERIFY2(!out.isEmpty(), "copyq.com version produced no stdout");
+    const QString version = QString::fromUtf8(out);
+    QVERIFY(version.contains(QRegularExpression("\\bCopyQ\\b")));
+    QVERIFY(version.contains(QRegularExpression("\\bQt:\\s+\\d")));
+}
+
+void Tests::consoleWrapperHelp()
+{
+    const QString wrapper = QDir(QCoreApplication::applicationDirPath())
+                                .absoluteFilePath("copyq.com");
+    if (!QFile::exists(wrapper))
+        QSKIP("copyq.com not found in build directory");
+
+    QProcess p;
+    p.start(wrapper, {"help"});
+    QVERIFY(p.waitForFinished(10000));
+    QCOMPARE(p.exitCode(), 0);
+
+    const QByteArray out = p.readAllStandardOutput();
+    QVERIFY2(!out.isEmpty(), "copyq.com help produced no stdout");
+    const QString help = QString::fromUtf8(out);
+    QVERIFY(help.contains("show"));
+    QVERIFY(help.contains("exit"));
+}
+
+void Tests::consoleWrapperExitCode()
+{
+    const QString wrapper = QDir(QCoreApplication::applicationDirPath())
+                                .absoluteFilePath("copyq.com");
+    if (!QFile::exists(wrapper))
+        QSKIP("copyq.com not found in build directory");
+
+    QProcess p;
+    p.start(wrapper, {"thisCommandDoesNotExist12345"});
+    QVERIFY(p.waitForFinished(10000));
+    QVERIFY2(p.exitCode() != 0,
+             "Expected non-zero exit code for unknown command");
+}
+
+#endif // Q_OS_WIN


### PR DESCRIPTION
Attach to the parent console when running as a client or console app so that output from commands like --help, --version, and scripting reaches the terminal. Piped output (e.g. copyq help | more) is preserved by checking handle types before reattaching.

Remove the corresponding known issue from documentation.

Fixes: https://github.com/hluk/CopyQ/issues/2937
Fixes: https://github.com/hluk/CopyQ/issues/349
Assisted-by: Claude (Anthropic)