### PR TITLE
Fix ECM version constraint and document optional dependencies

### DIFF
--- a/docs/build-source-code.rst
+++ b/docs/build-source-code.rst
@@ -26,9 +26,25 @@ The build requires:
 - `CMake <https://cmake.org/download/>`__
 - `Qt <https://download.qt.io/archive/qt/>`__
 
-Optional:
+Optional (enabled by default, disable with the corresponding CMake option):
 
-- `miniaudio <https://miniaud.io/>`__ -- for built-in audio playback (``playSound``)
+- `QCA <https://invent.kde.org/libraries/qca>`__ (Qt Cryptographic
+  Architecture) -- for tab encryption (``-DWITH_QCA_ENCRYPTION=OFF`` to
+  disable)
+- `QtKeychain <https://github.com/frankosterfeld/qtkeychain>`__ -- for storing
+  encryption passwords in the system keychain (``-DWITH_KEYCHAIN=OFF`` to
+  disable)
+- `KNotifications <https://invent.kde.org/frameworks/knotifications>`__ -- for
+  native notifications on Linux/BSD (``-DWITH_NATIVE_NOTIFICATIONS=OFF`` to
+  disable)
+- `miniaudio <https://miniaud.io/>`__ -- for built-in audio playback
+  (``playSound``) (``-DWITH_AUDIO=OFF`` to disable)
+
+Conditional:
+
+- `ECM <https://invent.kde.org/frameworks/extra-cmake-modules>`__ (Extra CMake
+  Modules) -- for Wayland clipboard support (KGuiAddons) and native notifications
+  on Linux/BSD (can be disabled entirely on non-Linux platforms)
 
 Debian / Ubuntu
 ^^^^^^^^^^^^^^^

--- a/src/notifications.cmake
+++ b/src/notifications.cmake
@@ -1,9 +1,7 @@
 OPTION(WITH_NATIVE_NOTIFICATIONS "Build with native notification support" ON)
 
 if (WITH_NATIVE_NOTIFICATIONS)
-    set(KF5_MIN_VERSION "5.18.0")
-
-    find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
+    find_package(ECM REQUIRED NO_MODULE)
     list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
     if (WITH_QT6)
@@ -11,6 +9,7 @@ if (WITH_NATIVE_NOTIFICATIONS)
         find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS Notifications StatusNotifierItem)
         list(APPEND copyq_LIBRARIES KF6::Notifications KF6::StatusNotifierItem)
     else()
+        set(KF5_MIN_VERSION "5.18.0")
         find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS Notifications)
         list(APPEND copyq_LIBRARIES KF5::Notifications)
     endif()


### PR DESCRIPTION
Remove incorrect version constraint from ECM find_package call and document optional build dependencies (QCA, KNotifications, ECM, miniaudio) with their corresponding CMake disable flags.

Fixes #3518
Fixes #3525

Assisted-by: Claude (Anthropic)