### PR TITLE
Windows/macOS: Re-register global shortcuts on keyboard layout change

### DIFF
--- a/qxt/qxtglobalshortcut.cpp
+++ b/qxt/qxtglobalshortcut.cpp
@@ -38,6 +38,7 @@
 namespace {
 
 int referenceCounter = 0;
+std::function<void()> layoutChangedCallback;
 
 QHash<QPair<quint32, quint32>, QxtGlobalShortcut*> shortcuts;
 
@@ -126,6 +127,12 @@ void QxtGlobalShortcutPrivate::activateShortcut(quint32 nativeKey, quint32 nativ
     QxtGlobalShortcut* shortcut = shortcuts.value(qMakePair(nativeKey, nativeMods));
     if (shortcut && shortcut->isEnabled())
         emit shortcut->activated(shortcut);
+}
+
+void QxtGlobalShortcutPrivate::onKeyboardLayoutChanged()
+{
+    if (layoutChangedCallback)
+        layoutChangedCallback();
 }
 
 /*!
@@ -305,4 +312,9 @@ void QxtGlobalShortcut::setEnabled(bool enabled)
 void QxtGlobalShortcut::setDisabled(bool disabled)
 {
     d_ptr->enabled = !disabled;
+}
+
+void QxtGlobalShortcut::setLayoutChangedCallback(LayoutChangedCallback callback)
+{
+    layoutChangedCallback = std::move(callback);
 }

--- a/qxt/qxtglobalshortcut.h
+++ b/qxt/qxtglobalshortcut.h
@@ -31,6 +31,7 @@
 
 #include <QObject>
 #include <QKeySequence>
+#include <functional>
 
 class QxtGlobalShortcutPrivate;
 
@@ -60,6 +61,9 @@ public:
     void activate();
 
     static void notifyRestartNeeded();
+
+    using LayoutChangedCallback = std::function<void()>;
+    static void setLayoutChangedCallback(LayoutChangedCallback callback);
 
 public Q_SLOTS:
     void setEnabled(bool enabled = true);

--- a/qxt/qxtglobalshortcut_mac.cpp
+++ b/qxt/qxtglobalshortcut_mac.cpp
@@ -40,6 +40,12 @@ static QMap<quint32, EventHotKeyRef> keyRefs;
 static QHash<Identifier, quint32> keyIDs;
 static quint32 hotKeySerial = 0;
 static bool qxt_mac_handler_installed = false;
+static bool qxt_mac_layout_observer_installed = false;
+
+void qxt_mac_keyboard_layout_changed(CFNotificationCenterRef, void *, CFStringRef, const void *, CFDictionaryRef)
+{
+    QxtGlobalShortcutPrivate::onKeyboardLayoutChanged();
+}
 
 OSStatus qxt_mac_handle_hot_key(EventHandlerCallRef nextHandler, EventRef event, void* data)
 {
@@ -57,6 +63,16 @@ OSStatus qxt_mac_handle_hot_key(EventHandlerCallRef nextHandler, EventRef event,
 
 void QxtGlobalShortcutPrivate::init()
 {
+    if (!qxt_mac_layout_observer_installed) {
+        qxt_mac_layout_observer_installed = true;
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDistributedCenter(),
+            nullptr,
+            qxt_mac_keyboard_layout_changed,
+            kTISNotifySelectedKeyboardInputSourceChanged,
+            nullptr,
+            CFNotificationSuspensionBehaviorDeliverImmediately);
+    }
 }
 
 void QxtGlobalShortcutPrivate::destroy()

--- a/qxt/qxtglobalshortcut_p.h
+++ b/qxt/qxtglobalshortcut_p.h
@@ -67,6 +67,7 @@ public:
         const QByteArray &eventType, void *message, NativeEventResult *result) override;
 
     static void activateShortcut(quint32 nativeKey, quint32 nativeMods);
+    static void onKeyboardLayoutChanged();
 
 private:
     void initFallback();

--- a/qxt/qxtglobalshortcut_win.cpp
+++ b/qxt/qxtglobalshortcut_win.cpp
@@ -57,11 +57,12 @@ bool QxtGlobalShortcutPrivate::nativeEventFilter(const QByteArray & eventType,
     Q_UNUSED(eventType)
     Q_UNUSED(result)
     MSG* msg = static_cast<MSG*>(message);
-    if (msg->message == WM_HOTKEY)
-    {
+    if (msg->message == WM_HOTKEY) {
         const quint32 keycode = HIWORD(msg->lParam);
         const quint32 modifiers = LOWORD(msg->lParam);
         activateShortcut(keycode, modifiers);
+    } else if (msg->message == WM_INPUTLANGCHANGE) {
+        onKeyboardLayoutChanged();
     }
     return false;
 }

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -7,6 +7,7 @@
 #include "common/clientsocket.h"
 #include "common/client_server.h"
 #include "common/commandstatus.h"
+#include "common/commandstore.h"
 #include "common/config.h"
 #include "common/log.h"
 #include "common/mimetypes.h"
@@ -233,6 +234,12 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     setClipboardMonitorRunning(false);
     startMonitoring();
 
+#ifdef COPYQ_GLOBAL_SHORTCUTS
+    QxtGlobalShortcut::setLayoutChangedCallback([this]() {
+        onKeyboardLayoutChanged();
+    });
+#endif
+
     callback(QStringLiteral("onStart"));
 }
 
@@ -240,6 +247,9 @@ ClipboardServer::~ClipboardServer()
 {
     qApp->setProperty("CopyQ_server", QVariant());
 
+#ifdef COPYQ_GLOBAL_SHORTCUTS
+    QxtGlobalShortcut::setLayoutChangedCallback(nullptr);
+#endif
     removeGlobalShortcuts();
 
     delete m_wnd;
@@ -303,13 +313,12 @@ void ClipboardServer::removeGlobalShortcuts()
     m_shortcutActions.clear();
 }
 
-void ClipboardServer::onCommandsSaved(const QVector<Command> &commands)
+void ClipboardServer::addGlobalShortcuts(const QVector<Command> &commands)
 {
-#ifdef COPYQ_GLOBAL_SHORTCUTS
-    removeGlobalShortcuts();
-
+#ifndef COPYQ_GLOBAL_SHORTCUTS
+    Q_UNUSED(commands)
+#else
     QList<QKeySequence> usedShortcuts;
-
     for (const auto &command : commands) {
         if (command.type() & CommandType::GlobalShortcut) {
             for (const auto &shortcutText : command.globalShortcuts) {
@@ -321,6 +330,23 @@ void ClipboardServer::onCommandsSaved(const QVector<Command> &commands)
             }
         }
     }
+#endif
+}
+
+void ClipboardServer::onKeyboardLayoutChanged()
+{
+#ifdef COPYQ_GLOBAL_SHORTCUTS
+    COPYQ_LOG("Keyboard layout changed, re-registering shortcuts");
+    removeGlobalShortcuts();
+    addGlobalShortcuts(loadAllCommands());
+#endif
+}
+
+void ClipboardServer::onCommandsSaved(const QVector<Command> &commands)
+{
+#ifdef COPYQ_GLOBAL_SHORTCUTS
+    removeGlobalShortcuts();
+    addGlobalShortcuts(commands);
 #endif
 
     const auto hash = monitorCommandStateHash(commands);

--- a/src/app/clipboardserver.h
+++ b/src/app/clipboardserver.h
@@ -84,6 +84,8 @@ private:
     void shortcutActivated(QxtGlobalShortcut *shortcut);
 
     void removeGlobalShortcuts();
+    void addGlobalShortcuts(const QVector<Command> &commands);
+    void onKeyboardLayoutChanged();
 
     /** Called when new commands are available. */
     void onCommandsSaved(const QVector<Command> &commands);


### PR DESCRIPTION
When the keyboard layout changes, the native keycodes for registered shortcuts may change. Re-register all shortcuts with updated native codes to keep them working.

Windows: Handle WM_INPUTLANGCHANGE message in the native event filter.

macOS: Observe kTISNotifySelectedKeyboardInputSourceChanged via the CF distributed notification center, which is the correct mechanism for detecting input source changes (polling TISCopyCurrentKeyboardInputSource does not work reliably as it requires the event loop to run).

Fixes #1323

Assisted-by: Opus 4.6 (Anthropic)