### PR TITLE
Add per-sub-process RSS memory to stats() output

### DIFF
--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1791,7 +1791,7 @@ unlike in GUI, where row numbers start from 1 by default.
       ``MODEL path: rows=N, dataSize=B (human)`` for item models,
       ``DATA_DIR path: size=B (human)`` for the item data directory,
       ``TABS: total=N, loaded=N`` for tab load state,
-      ``ACTION description`` for each running action,
+      ``ACTION description | pid=P rss=B (human), ...`` for each running action with per-sub-process memory,
       ``COMMANDS: automatic=N, display=N, menu=N, tray_menu=N, script=N`` for command counts,
       ``PLUGIN id: enabled/disabled`` for each loaded plugin,
       ``LOG_FILES: count=N, size=B (human)`` for log file total size,

--- a/src/common/action.cpp
+++ b/src/common/action.cpp
@@ -184,16 +184,17 @@ Action::~Action()
 
 QString Action::commandLine() const
 {
-    QString text;
-    for ( const auto &line : m_cmds ) {
-        for ( const auto &args : line ) {
-            if ( !text.isEmpty() )
-                text.append(QChar('|'));
-            text.append(args.join(" "));
+    QStringList groups;
+    for (const auto &line : m_cmds) {
+        QStringList cmds;
+        for (const auto &args : line) {
+            auto cmd = args.join(QLatin1Char(' '));
+            cmd.replace(QLatin1String("copyq eval --"), QLatin1String("copyq:"));
+            cmds.append(cmd);
         }
-        text.append('\n');
+        groups.append(cmds.join(QLatin1String(" | ")));
     }
-    return text.trimmed();
+    return groups.join(QLatin1String("; "));
 }
 
 void Action::setCommand(const QString &command, const QStringList &arguments)
@@ -315,6 +316,19 @@ bool Action::waitForFinished(int msecs)
 bool Action::isRunning() const
 {
     return !m_processes.empty() && m_processes.back()->state() != QProcess::NotRunning;
+}
+
+QList<qint64> Action::processIds() const
+{
+    QList<qint64> pids;
+    for (const auto *proc : m_processes) {
+        if (proc->state() != QProcess::NotRunning) {
+            const auto pid = proc->processId();
+            if (pid != 0)
+                pids.append(pid);
+        }
+    }
+    return pids;
 }
 
 void Action::setData(const QVariantMap &data)

--- a/src/common/action.h
+++ b/src/common/action.h
@@ -60,6 +60,8 @@ public:
 
     bool isRunning() const;
 
+    QList<qint64> processIds() const;
+
     /** Set human-readable name for action. */
     void setName(const QString &actionName) { m_name = actionName; }
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -524,3 +524,14 @@ QString cloneText(const QMimeData &data)
     const auto text = dataToText( data.data(mimeText), mimeText );
     return text.isEmpty() ? data.text() : text;
 }
+
+QString formatDataSize(qint64 bytes)
+{
+    if (bytes < 1024)
+        return QStringLiteral("%1 B").arg(bytes);
+    if (bytes < 1024 * 1024)
+        return QStringLiteral("%1 KiB").arg(bytes / 1024.0, 0, 'f', 1);
+    if (bytes < 1024 * 1024 * 1024)
+        return QStringLiteral("%1 MiB").arg(bytes / (1024.0 * 1024.0), 0, 'f', 1);
+    return QStringLiteral("%1 GiB").arg(bytes / (1024.0 * 1024.0 * 1024.0), 0, 'f', 1);
+}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -82,3 +82,5 @@ bool canDropToTab(const QDropEvent &event);
  * Accept any proposed drop action, preferably "move" if items data available.
  */
 void acceptDrag(QDropEvent *event);
+
+QString formatDataSize(qint64 bytes);

--- a/src/gui/actionhandler.cpp
+++ b/src/gui/actionhandler.cpp
@@ -11,6 +11,7 @@
 #include "common/log.h"
 #include "common/mimetypes.h"
 #include "common/textdata.h"
+#include "platform/platformnativeinterface.h"
 #include "gui/actionhandlerdialog.h"
 #include "gui/icons.h"
 #include "gui/notification.h"
@@ -40,11 +41,24 @@ QStringList ActionHandler::copyqStats() const
 {
     QStringList lines;
     for (auto it = m_actions.constBegin(); it != m_actions.constEnd(); ++it) {
-        if (m_internalActions.contains(it.key()))
-            continue;
-        QString desc = actionDescription(*it.value());
-        desc.replace('\n', " | ");
-        lines.append(QStringLiteral("ACTION ") + desc);
+        constexpr int maxDescriptionLength = 150;
+        QString desc = actionDescription(*it.value()).simplified();
+        desc.replace(QLatin1Char('\''), QLatin1Char('"'));
+        if (desc.size() > maxDescriptionLength)
+            desc = desc.left(maxDescriptionLength) + QStringLiteral("...");
+
+        const QList<qint64> pids = it.value()->processIds();
+        QStringList pidParts;
+        for (const qint64 pid : pids) {
+            const qint64 rss = platformNativeInterface()->processResidentMemoryBytes(pid);
+            if (rss >= 0) {
+                pidParts.append(QStringLiteral("pid=%1 rss=%2 (%3)")
+                    .arg(pid).arg(rss).arg(formatDataSize(rss)));
+            } else {
+                pidParts.append(QStringLiteral("pid=%1").arg(pid));
+            }
+        }
+        lines.append( QStringLiteral("ACTION '%1' | %2").arg(desc, pidParts.join(QStringLiteral(", "))) );
     }
     return lines;
 }
@@ -186,10 +200,9 @@ void ActionHandler::showActionErrors(Action *action, const QString &message, ush
 
     const int maxWidthPoints =
             AppConfig().option<Config::notification_maximum_width>();
-    const QString command = action->commandLine()
-            .replace(QLatin1String("copyq eval --"), QLatin1String("copyq:"));
+    const QString command = action->commandLine();
     const QString name = action->name().isEmpty()
-            ? QString(command).replace('\n', QLatin1String(" "))
+            ? command.simplified()
             : action->name();
     const QString format = tr("Command %1").arg(quoteString("%1"));
     const QString title = elideText(name, QFont(), format, pointsToPixels(maxWidthPoints));

--- a/src/platform/dummy/dummyplatform.h
+++ b/src/platform/dummy/dummyplatform.h
@@ -48,5 +48,5 @@ public:
 
     QString themePrefix() override { return QString(); }
 
-    qint64 processResidentMemoryBytes() override { return -1; }
+    qint64 processResidentMemoryBytes(qint64) override { return -1; }
 };

--- a/src/platform/mac/macplatform.h
+++ b/src/platform/mac/macplatform.h
@@ -45,5 +45,5 @@ public:
 
     QString themePrefix() override;
 
-    qint64 processResidentMemoryBytes() override;
+    qint64 processResidentMemoryBytes(qint64 pid) override;
 };

--- a/src/platform/mac/macplatform.mm
+++ b/src/platform/mac/macplatform.mm
@@ -12,6 +12,7 @@
 #include "urlpasteboardmime.h"
 #include "macclipboard.h"
 
+#include <libproc.h>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QDir>
@@ -278,13 +279,11 @@ void MacPlatform::setAutostartEnabled(bool shouldEnable)
         }
     }
 }
-
-qint64 MacPlatform::processResidentMemoryBytes()
+qint64 MacPlatform::processResidentMemoryBytes(qint64 pid)
 {
-    struct mach_task_basic_info info;
-    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
-    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
-                  (task_info_t)&info, &count) != KERN_SUCCESS)
+    struct proc_taskinfo pti;
+    const int size = proc_pidinfo(static_cast<int>(pid), PROC_PIDTASKINFO, 0, &pti, sizeof(pti));
+    if (size != sizeof(pti))
         return -1;
-    return static_cast<qint64>(info.resident_size);
+    return static_cast<qint64>(pti.pti_resident_size);
 }

--- a/src/platform/platformnativeinterface.h
+++ b/src/platform/platformnativeinterface.h
@@ -134,10 +134,10 @@ public:
     virtual QString themePrefix() = 0;
 
     /**
-     * Return the resident set size (RSS) of the current process in bytes.
-     * Returns -1 if not supported on this platform.
+     * Return the resident set size (RSS) of the given process in bytes.
+     * Returns -1 if not supported or process not accessible.
      */
-    virtual qint64 processResidentMemoryBytes() = 0;
+    virtual qint64 processResidentMemoryBytes(qint64 pid) = 0;
 
     PlatformNativeInterface(const PlatformNativeInterface &) = delete;
     PlatformNativeInterface &operator=(const PlatformNativeInterface &) = delete;

--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -384,10 +384,15 @@ void WinPlatform::setAutostartEnabled(bool enable)
     }
 }
 
-qint64 WinPlatform::processResidentMemoryBytes()
+qint64 WinPlatform::processResidentMemoryBytes(qint64 pid)
 {
-    PROCESS_MEMORY_COUNTERS pmc;
-    if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, static_cast<DWORD>(pid));
+    if (!hProcess)
         return -1;
-    return static_cast<qint64>(pmc.WorkingSetSize);
+    PROCESS_MEMORY_COUNTERS pmc;
+    qint64 result = -1;
+    if (GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc)))
+        result = static_cast<qint64>(pmc.WorkingSetSize);
+    CloseHandle(hProcess);
+    return result;
 }

--- a/src/platform/win/winplatform.h
+++ b/src/platform/win/winplatform.h
@@ -47,5 +47,5 @@ public:
 
     QString themePrefix() override;
 
-    qint64 processResidentMemoryBytes() override;
+    qint64 processResidentMemoryBytes(qint64 pid) override;
 };

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -331,9 +331,9 @@ QString X11Platform::translationPrefix()
     return QString();
 }
 
-qint64 X11Platform::processResidentMemoryBytes()
+qint64 X11Platform::processResidentMemoryBytes(qint64 pid)
 {
-    QFile statm(QStringLiteral("/proc/self/statm"));
+    QFile statm(QStringLiteral("/proc/%1/statm").arg(pid));
     if (!statm.open(QIODevice::ReadOnly))
         return -1;
     const QList<QByteArray> fields = statm.readAll().split(' ');

--- a/src/platform/x11/x11platform.h
+++ b/src/platform/x11/x11platform.h
@@ -62,5 +62,5 @@ public:
 
     QString themePrefix() override { return QString(); }
 
-    qint64 processResidentMemoryBytes() override;
+    qint64 processResidentMemoryBytes(qint64 pid) override;
 };

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -81,17 +81,6 @@ const quint32 serializedFunctionCallMagicNumber = 0x58746908;
 const quint32 serializedFunctionCallVersion = 2;
 constexpr bool hasPriority = false;
 
-QString formatDataSize(qint64 bytes)
-{
-    if (bytes < 1024)
-        return QStringLiteral("%1 B").arg(bytes);
-    if (bytes < 1024 * 1024)
-        return QStringLiteral("%1 KiB").arg(bytes / 1024.0, 0, 'f', 1);
-    if (bytes < 1024 * 1024 * 1024)
-        return QStringLiteral("%1 MiB").arg(bytes / (1024.0 * 1024.0), 0, 'f', 1);
-    return QStringLiteral("%1 GiB").arg(bytes / (1024.0 * 1024.0 * 1024.0), 0, 'f', 1);
-}
-
 void registerMetaTypes() {
     static bool registered = false;
     if (registered)
@@ -2530,7 +2519,7 @@ QString ScriptableProxy::stats()
 
     // Process memory via platform interface
     {
-        const qint64 rss = platformNativeInterface()->processResidentMemoryBytes();
+        const qint64 rss = platformNativeInterface()->processResidentMemoryBytes(QCoreApplication::applicationPid());
         if (rss >= 0) {
             result += QStringLiteral("MEMORY: rss=%1 (%2)")
                 .arg(rss).arg(formatDataSize(rss));

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -10,6 +10,7 @@
 #include <QElapsedTimer>
 #include <QRegularExpression>
 #include <QTemporaryFile>
+#include <algorithm>
 
 void Tests::commandExit()
 {
@@ -1258,6 +1259,14 @@ void Tests::commandStats()
     QVERIFY2(hasTabs, stdoutActual);
     QVERIFY2(hasCommands, stdoutActual);
     QVERIFY2(hasLogFiles, stdoutActual);
+
+    // Verify monitorClipboard internal action appears with per-sub-process pid/rss
+    const auto isMonitorAction = [](const QByteArray &line) {
+        return line.startsWith("ACTION ") && line.contains("monitorClipboard");
+    };
+    const auto it = std::find_if(stats2.cbegin(), stats2.cend(), isMonitorAction);
+    QVERIFY2(it != stats2.cend(), stdoutActual);
+    QVERIFY2(it->contains("pid="), *it);
 }
 
 void Tests::statsQObjectLeak()


### PR DESCRIPTION
Report PID and resident memory for each sub-process of running actions in the stats() output. Each ACTION line now includes per-process memory info (e.g. pid=1234 rss=5678 (5.5 MiB)).

Add platform support for reading RSS of arbitrary processes by PID. Move data size formatting to shared utility code.

Assisted-by: Claude (Anthropic)