### PR TITLE
Simplify exception handling to use engine error state

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int evaluate(
         functionArguments.append(argument);
 
     const auto result = function.call(functionArguments);
-    const bool hasUncaughtException = result.isError() || scriptable.hasUncaughtException();
+    const bool hasUncaughtException = result.isError() || engine.hasError();
 
     const auto output = scriptable.serializeScriptValue(result);
     if ( !output.isEmpty() ) {

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -123,23 +123,20 @@ QString argumentError()
     return Scriptable::tr("Invalid number of arguments!");
 }
 
-QString exceptionBacktrace(const QJSValue &exception, const QStringList &stack = {})
+QString exceptionBacktrace(const QStringList &stack)
 {
-    const auto backtraceValue = exception.property("stack");
-    auto backtrace = backtraceValue.isUndefined() ? QStringList() : backtraceValue.toString().split("\n");
-    for (int i = backtrace.size() - 1; i >= 0; --i) {
-        if ( backtrace[i] == QLatin1String("@:1") )
-            backtrace.removeAt(i);
-    }
-    for (const auto &frame : stack)
-        backtrace.append(frame);
-
-    if ( backtrace.isEmpty() )
+    if ( stack.isEmpty() )
         return {};
 
     return QStringLiteral("\n\n--- backtrace ---\n%1\n--- end backtrace ---")
-        .arg(backtrace.join(QLatin1String("\n")));
+        .arg(stack.join(QLatin1String("\n")));
 
+}
+
+QString exceptionBacktrace(const QJSValue &exception)
+{
+    const auto backtraceValue = exception.property("stack");
+    return backtraceValue.isUndefined() ? QString() : exceptionBacktrace(backtraceValue.toString().split("\n"));
 }
 
 QJSValue evaluateStrict(QJSEngine *engine, const QString &script)
@@ -314,21 +311,6 @@ Scriptable::Scriptable(
 
     QJSValue globalObject = m_engine->globalObject();
     globalObject.setProperty(QStringLiteral("global"), globalObject);
-
-    m_safeCall = evaluateStrict(m_engine, QStringLiteral(
-        "(function() {"
-            "try {return {result: this.apply(global, arguments)};}"
-            "catch(e) {throw {exception: e};}"
-        "})"));
-
-    m_safeEval = evaluateStrict(m_engine, QStringLiteral(
-        "(function(){"
-            "const _eval = eval;"
-            "return function(script) {"
-                "try {return {result: _eval(script)};}"
-                "catch(e) {throw {exception: e};}"
-            "}"
-        "})()"));
 
     m_createFn = evaluateStrict(m_engine, QStringLiteral(
         "(function(from, name) {"
@@ -527,19 +509,10 @@ QJSValue Scriptable::throwImportError(const QString &filePath)
     return throwError( tr("Failed to import file \"%1\"").arg(filePath) );
 }
 
-QJSValue Scriptable::unwrapResultOrException(const QJSValue &resultOrException)
-{
-    if (resultOrException.hasOwnProperty(QStringLiteral("result")))
-        return resultOrException.property(QStringLiteral("result"));
-
-    auto exc = resultOrException.property(QStringLiteral("exception"));
-    logUncaughtException(exc);
-    m_engine->throwError(exc);
-    return exc;
-}
-
 void Scriptable::clearExceptions()
 {
+    m_lastLoggedException = {};
+
     if (m_engine->hasError())
         m_engine->catchError();
 
@@ -579,14 +552,15 @@ QJSValue Scriptable::call(const QString &label, QJSValue *fn, const QJSValueList
     if ( m_engine->hasError() )
         return {};
 
-    m_stack.prepend(label);
-    COPYQ_LOG_VERBOSE( QStringLiteral("Stack push: %1").arg(m_stack.join('|')) );
+    QJSValue globalObject = engine()->globalObject();
+    globalObject.setProperty(QStringLiteral("_copyqFn"), *fn);
+    globalObject.setProperty(QStringLiteral("_copyqArgs"), toScriptValue(arguments, m_engine));
 
-    const auto v = m_safeCall.callWithInstance(*fn, arguments);
-    const auto result = unwrapResultOrException(v);
+    const auto result = evalAndCatch(QStringLiteral("_copyqFn(..._copyqArgs)"), label);
 
-    m_stack.pop_front();
-    COPYQ_LOG_VERBOSE( QStringLiteral("Stack pop: %1").arg(m_stack.join('|')) );
+    globalObject.deleteProperty(QStringLiteral("_copyqFn"));
+    globalObject.deleteProperty(QStringLiteral("_copyqArgs"));
+
     return result;
 }
 
@@ -2742,7 +2716,7 @@ void Scriptable::logUncaughtException(const QJSValue &exc)
             .remove(QRegularExpression("^Error: "))
             .trimmed();
 
-    const QString backtraceText = exceptionBacktrace(exc, m_stack);
+    const QString backtraceText = exceptionBacktrace(m_stack);
     const auto exceptionText = QStringLiteral("ScriptError: %3%4").arg(exceptionName, backtraceText);
 
     // Show exception popups only if the script was launched from application.
@@ -2997,14 +2971,32 @@ QJSValue Scriptable::eval(const QString &script, const QString &label)
     if (m_engine->hasError())
         return QJSValue();
 
-    m_stack.prepend(QStringLiteral("eval:") + label);
+    return evalAndCatch(script, label);
+}
+
+QJSValue Scriptable::evalAndCatch(const QString &script, const QString &label)
+{
+    m_stack.prepend(label);
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack push: %1").arg(m_stack.join('|')) );
 
-    const auto v = m_safeEval.call({QJSValue(script)});
-    const auto result = unwrapResultOrException(v);
+    QStringList exceptionStackTrace;
+    // Workarounds for QJSEngine::evaluate:
+    // - fileName argument is set to empty string, otherwise QJSEngine::evaluate leaks memory
+    // - exceptionStackTrace is only used to indicate that an exception was
+    //   thrown, since it cannot be clear from the result nor from
+    //   QJSEngine::hasError()
+    const auto result = m_engine->evaluate(script, QString(), 1, &exceptionStackTrace);
+    if (!exceptionStackTrace.isEmpty()) {
+        if (!m_lastLoggedException.equals(result)) {
+            m_lastLoggedException = result;
+            logUncaughtException(result);
+        }
+        m_engine->throwError(result);
+    }
 
     m_stack.pop_front();
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack pop: %1").arg(m_stack.join('|')) );
+
     return result;
 }
 

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -130,7 +130,6 @@ QString exceptionBacktrace(const QStringList &stack)
 
     return QStringLiteral("\n\n--- backtrace ---\n%1\n--- end backtrace ---")
         .arg(stack.join(QLatin1String("\n")));
-
 }
 
 QString exceptionBacktrace(const QJSValue &exception)
@@ -293,6 +292,12 @@ bool isOverridden(const QJSValue &globalObject, const QString &property)
     return globalObject.property(property).property(QStringLiteral("_copyq")).toString() != property;
 }
 
+bool isSimpleIdentifier(QStringView s)
+{
+    return !s.isEmpty() && s[0].isLetter()
+        && std::all_of(s.cbegin() + 1, s.cend(), [](QChar c) { return c.isLetterOrNumber(); });
+}
+
 } // namespace
 
 Scriptable::Scriptable(
@@ -311,6 +316,13 @@ Scriptable::Scriptable(
 
     QJSValue globalObject = m_engine->globalObject();
     globalObject.setProperty(QStringLiteral("global"), globalObject);
+
+
+    m_safeCall = evaluateStrict(m_engine, QStringLiteral(
+        "(function() {"
+            "try {return {result: this.apply(global, arguments)};}"
+            "catch(e) {throw {exception: e};}"
+        "})"));
 
     m_createFn = evaluateStrict(m_engine, QStringLiteral(
         "(function(from, name) {"
@@ -509,6 +521,17 @@ QJSValue Scriptable::throwImportError(const QString &filePath)
     return throwError( tr("Failed to import file \"%1\"").arg(filePath) );
 }
 
+QJSValue Scriptable::unwrapResultOrException(const QJSValue &resultOrException)
+{
+    if (resultOrException.hasOwnProperty(QStringLiteral("result")))
+        return resultOrException.property(QStringLiteral("result"));
+
+    auto exc = resultOrException.property(QStringLiteral("exception"));
+    logUncaughtException(exc);
+    m_engine->throwError(exc);
+    return exc;
+}
+
 void Scriptable::clearExceptions()
 {
     m_lastLoggedException = {};
@@ -552,15 +575,14 @@ QJSValue Scriptable::call(const QString &label, QJSValue *fn, const QJSValueList
     if ( m_engine->hasError() )
         return {};
 
-    QJSValue globalObject = engine()->globalObject();
-    globalObject.setProperty(QStringLiteral("_copyqFn"), *fn);
-    globalObject.setProperty(QStringLiteral("_copyqArgs"), toScriptValue(arguments, m_engine));
+    m_stack.prepend(label);
+    COPYQ_LOG_VERBOSE( QStringLiteral("Stack push: %1").arg(m_stack.join('|')) );
 
-    const auto result = evalAndCatch(QStringLiteral("_copyqFn(..._copyqArgs)"), label);
+    const auto v = m_safeCall.callWithInstance(*fn, arguments);
+    const auto result = unwrapResultOrException(v);
 
-    globalObject.deleteProperty(QStringLiteral("_copyqFn"));
-    globalObject.deleteProperty(QStringLiteral("_copyqArgs"));
-
+    m_stack.pop_front();
+    COPYQ_LOG_VERBOSE( QStringLiteral("Stack pop: %1").arg(m_stack.join('|')) );
     return result;
 }
 
@@ -2694,10 +2716,8 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
         }
     }
 
-    if ( result.isCallable() && canContinue() && !m_engine->hasError() ) {
-        const QString label2 = QStringLiteral("eval(arguments[%1])()").arg(skipArguments - 1);
-        result = call( label2, &result, fnArgs.mid(skipArguments) );
-    }
+    if ( result.isCallable() && canContinue() && !m_engine->hasError() )
+        result = call( QStringLiteral("_()"), &result, fnArgs.mid(skipArguments) );
 
     if (m_abort != Abort::None)
         return m_abortWithSuccess ? CommandFinished : CommandStop;
@@ -2712,6 +2732,10 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
 
 void Scriptable::logUncaughtException(const QJSValue &exc)
 {
+    if (m_lastLoggedException.equals(exc))
+        return;
+    m_lastLoggedException = exc;
+
     const auto exceptionName = exc.toString()
             .remove(QRegularExpression("^Error: "))
             .trimmed();
@@ -2971,6 +2995,28 @@ QJSValue Scriptable::eval(const QString &script, const QString &label)
     if (m_engine->hasError())
         return QJSValue();
 
+    const QStringView trimmed = QStringView(script).trimmed();
+
+    // Fast path: simple identifier → global property lookup
+    if (isSimpleIdentifier(trimmed)) {
+        const auto name = trimmed.toString();
+        auto globalObj = m_engine->globalObject();
+        if (globalObj.hasProperty(name))
+            return globalObj.property(name);
+    }
+
+    // Fast path: identifier() → property lookup + direct call
+    if (trimmed.endsWith(QLatin1String("()"))) {
+        const QStringView name = trimmed.chopped(2);
+        if (isSimpleIdentifier(name)) {
+            const auto nameStr = name.toString();
+            auto globalObj = m_engine->globalObject();
+            auto fn = globalObj.property(nameStr);
+            if (fn.isCallable())
+                return call(scriptToLabel(nameStr), &fn);
+        }
+    }
+
     return evalAndCatch(script, label);
 }
 
@@ -2987,10 +3033,7 @@ QJSValue Scriptable::evalAndCatch(const QString &script, const QString &label)
     //   QJSEngine::hasError()
     const auto result = m_engine->evaluate(script, QString(), 1, &exceptionStackTrace);
     if (!exceptionStackTrace.isEmpty()) {
-        if (!m_lastLoggedException.equals(result)) {
-            m_lastLoggedException = result;
-            logUncaughtException(result);
-        }
+        logUncaughtException(result);
         m_engine->throwError(result);
     }
 

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -2995,25 +2995,23 @@ QJSValue Scriptable::eval(const QString &script, const QString &label)
     if (m_engine->hasError())
         return QJSValue();
 
-    const QStringView trimmed = QStringView(script).trimmed();
+    // If script is just an identifier or a simple function call, look up the
+    // global function and call it to avoid much slower eval.
+    QStringView trimmed = QStringView(script).trimmed();
 
-    // Fast path: simple identifier → global property lookup
+    const bool needCall = trimmed.endsWith(QLatin1String("()"));
+    if (needCall)
+        trimmed.chop(2);
+
     if (isSimpleIdentifier(trimmed)) {
         const auto name = trimmed.toString();
         auto globalObj = m_engine->globalObject();
-        if (globalObj.hasProperty(name))
-            return globalObj.property(name);
-    }
-
-    // Fast path: identifier() → property lookup + direct call
-    if (trimmed.endsWith(QLatin1String("()"))) {
-        const QStringView name = trimmed.chopped(2);
-        if (isSimpleIdentifier(name)) {
-            const auto nameStr = name.toString();
-            auto globalObj = m_engine->globalObject();
-            auto fn = globalObj.property(nameStr);
-            if (fn.isCallable())
-                return call(nameStr, &fn);
+        if (globalObj.hasProperty(name)) {
+            auto obj = globalObj.property(name);
+            if (!needCall)
+                return obj;
+            if (obj.isCallable())
+                return call(name, &obj);
         }
     }
 

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -123,19 +123,28 @@ QString argumentError()
     return Scriptable::tr("Invalid number of arguments!");
 }
 
-QString exceptionBacktrace(const QStringList &stack)
+QString exceptionBacktrace(const QJSValue &exception, const QStringList &stack)
 {
     if ( stack.isEmpty() )
         return {};
 
-    return QStringLiteral("\n\n--- backtrace ---\n%1\n--- end backtrace ---")
-        .arg(stack.join(QLatin1String("\n")));
-}
+    QStringList annotatedStack = stack;
+    for (auto &frame : annotatedStack) {
+        if (frame.contains('\n')) {
+            auto lines = frame.split('\n');
+            int i = 0;
+            for (auto &line : lines)
+                line.prepend(QStringLiteral("%1|").arg(++i, /*fieldWidth=*/2));
+            frame = lines.join('\n') + '\n';
+        }
+    }
 
-QString exceptionBacktrace(const QJSValue &exception)
-{
-    const auto backtraceValue = exception.property("stack");
-    return backtraceValue.isUndefined() ? QString() : exceptionBacktrace(backtraceValue.toString().split("\n"));
+    const auto lineNumber = exception.property("lineNumber");
+    const auto line = lineNumber.isNumber() ? lineNumber.toInt() : 0;
+    const auto lineIndicator = (line > 0) ? QStringLiteral("At line %1 in:\n").arg(line) : QString();
+
+    return QStringLiteral("\n\n--- backtrace ---\n%1%2\n--- end backtrace ---")
+        .arg(lineIndicator, annotatedStack.join(QLatin1String("\n")));
 }
 
 QJSValue evaluateStrict(QJSEngine *engine, const QString &script)
@@ -144,7 +153,7 @@ QJSValue evaluateStrict(QJSEngine *engine, const QString &script)
     if ( v.isError() ) {
         const auto scriptText = QStringLiteral("--- SCRIPT BEGIN ---\n%1\n--- SCRIPT END ---").arg(script);
         log( QStringLiteral("Exception during evaluate: %1%2\n\n%3")
-            .arg(v.toString(), exceptionBacktrace(v), scriptText), LogError );
+            .arg(v.toString(), exceptionBacktrace(v, {}), scriptText), LogError );
     }
     return v;
 }
@@ -234,14 +243,6 @@ QJSValue checksumForArgument(Scriptable *scriptable, QCryptographicHash::Algorit
     const auto data = scriptable->makeByteArray(scriptable->argument(0));
     const QByteArray hash = QCryptographicHash::hash(data, method).toHex();
     return QLatin1String(hash);
-}
-
-QString scriptToLabel(const QString &script)
-{
-    constexpr auto maxScriptSize = 30;
-    if (maxScriptSize < script.size())
-        return script.left(maxScriptSize).simplified() + QLatin1String("...");
-    return script;
 }
 
 std::optional<QStringConverter::Encoding> encodingFromNameOrThrow(const QJSValue &codecName, Scriptable *scriptable)
@@ -2710,7 +2711,6 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
             skipArguments += m_skipArguments;
         } else {
             cmd = toString(fnArgs[skipArguments]);
-            label = scriptToLabel(cmd);
             result = eval(cmd, label);
             ++skipArguments;
         }
@@ -2740,7 +2740,7 @@ void Scriptable::logUncaughtException(const QJSValue &exc)
             .remove(QRegularExpression("^Error: "))
             .trimmed();
 
-    const QString backtraceText = exceptionBacktrace(m_stack);
+    const QString backtraceText = exceptionBacktrace(exc, m_stack);
     const auto exceptionText = QStringLiteral("ScriptError: %3%4").arg(exceptionName, backtraceText);
 
     // Show exception popups only if the script was launched from application.
@@ -3013,7 +3013,7 @@ QJSValue Scriptable::eval(const QString &script, const QString &label)
             auto globalObj = m_engine->globalObject();
             auto fn = globalObj.property(nameStr);
             if (fn.isCallable())
-                return call(scriptToLabel(nameStr), &fn);
+                return call(nameStr, &fn);
         }
     }
 
@@ -3056,7 +3056,7 @@ void Scriptable::setActionName(const QString &actionName)
 
 QJSValue Scriptable::eval(const QString &script)
 {
-    return eval(script, scriptToLabel(script));
+    return eval(script, script);
 }
 
 QJSValue Scriptable::call(const QString &functionName)

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -317,26 +317,24 @@ Scriptable::Scriptable(
 
     m_safeCall = evaluateStrict(m_engine, QStringLiteral(
         "(function() {"
-            "try {return this.apply(global, arguments);}"
-            "catch(e) {_copyqUncaughtException = e; throw e;}"
-        "})"
-    ));
+            "try {return {result: this.apply(global, arguments)};}"
+            "catch(e) {throw {exception: e};}"
+        "})"));
 
     m_safeEval = evaluateStrict(m_engine, QStringLiteral(
         "(function(){"
-            "var _eval = eval;"
+            "const _eval = eval;"
             "return function(script) {"
-                "try {return _eval(script);}"
-                "catch(e) {_copyqUncaughtException = e; throw e;}"
+                "try {return {result: _eval(script)};}"
+                "catch(e) {throw {exception: e};}"
             "}"
-        "})()"
-    ));
+        "})()"));
 
     m_createFn = evaluateStrict(m_engine, QStringLiteral(
         "(function(from, name) {"
-            "var f = function() {"
+            "const f = function() {"
                 "_copyqArguments = arguments;"
-                "var v = from[name]();"
+                "const v = from[name]();"
                 "_copyqArguments = null;"
                 "return v;"
             "};"
@@ -346,9 +344,9 @@ Scriptable::Scriptable(
     ));
     m_createFnB = evaluateStrict(m_engine, QStringLiteral(
         "(function(from, name) {"
-            "var f = function() {"
+            "const f = function() {"
                 "_copyqArguments = arguments;"
-                "var v = from[name]();"
+                "const v = from[name]();"
                 "_copyqArguments = null;"
                 "return ByteArray(v);"
             "};"
@@ -514,11 +512,8 @@ QString Scriptable::arg(int i, const QString &defaultValue)
 
 QJSValue Scriptable::throwError(const QString &errorMessage)
 {
-    QJSValue throwFn = evaluateStrict(m_engine,  QStringLiteral(
-        "(function(text) {throw new Error(text);})"
-    ));
-    const auto exc = throwFn.call({errorMessage});
-    m_engine->throwError(QJSValue::GenericError, errorMessage);
+    auto exc = m_engine->newErrorObject(QJSValue::GenericError, errorMessage);
+    m_engine->throwError(exc);
     return exc;
 }
 
@@ -532,29 +527,27 @@ QJSValue Scriptable::throwImportError(const QString &filePath)
     return throwError( tr("Failed to import file \"%1\"").arg(filePath) );
 }
 
-bool Scriptable::hasUncaughtException() const
+QJSValue Scriptable::unwrapResultOrException(const QJSValue &resultOrException)
 {
-    return m_hasUncaughtException;
+    if (resultOrException.hasOwnProperty(QStringLiteral("result")))
+        return resultOrException.property(QStringLiteral("result"));
+
+    auto exc = resultOrException.property(QStringLiteral("exception"));
+    logUncaughtException(exc);
+    m_engine->throwError(exc);
+    return exc;
 }
 
 void Scriptable::clearExceptions()
 {
-    m_hasUncaughtException = false;
+    if (m_engine->hasError())
+        m_engine->catchError();
 
     if (m_abort == Abort::CurrentEvaluation) {
         m_engine->setInterrupted(false);
         m_abort = Abort::None;
         m_abortWithSuccess = false;
     }
-}
-
-void Scriptable::setUncaughtException(const QJSValue &exc)
-{
-    if (m_abort != Abort::None || m_hasUncaughtException)
-        return;
-
-    m_hasUncaughtException = true;
-    logUncaughtException(exc);
 }
 
 QJSValue Scriptable::getPlugins()
@@ -583,15 +576,18 @@ QJSValue Scriptable::call(const QString &label, QJSValue *fn, const QVariantList
 
 QJSValue Scriptable::call(const QString &label, QJSValue *fn, const QJSValueList &arguments)
 {
-    if ( hasUncaughtException() )
+    if ( m_engine->hasError() )
         return {};
 
     m_stack.prepend(label);
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack push: %1").arg(m_stack.join('|')) );
+
     const auto v = m_safeCall.callWithInstance(*fn, arguments);
+    const auto result = unwrapResultOrException(v);
+
     m_stack.pop_front();
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack pop: %1").arg(m_stack.join('|')) );
-    return v;
+    return result;
 }
 
 QJSValue Scriptable::ByteArray() const
@@ -2647,7 +2643,7 @@ bool Scriptable::sourceScriptCommands()
         const auto script = QStringLiteral("(function(){%1\n;})()").arg(command.cmd);
         const auto label = QStringLiteral("source@<%1>").arg(command.name);
         eval(script, label);
-        if ( hasUncaughtException() )
+        if ( m_engine->hasError() )
             return false;
     }
 
@@ -2706,7 +2702,7 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
     const auto evalFn = globalObject.property("eval");
 
     QString label;
-    while ( skipArguments < fnArgs.size() && canContinue() && !hasUncaughtException() ) {
+    while ( skipArguments < fnArgs.size() && canContinue() && !m_engine->hasError() ) {
         if ( result.isCallable() ) {
             const auto arguments = fnArgs.mid(skipArguments);
             if ( result.strictlyEquals(evalFn) )
@@ -2724,7 +2720,7 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
         }
     }
 
-    if ( result.isCallable() && canContinue() && !hasUncaughtException() ) {
+    if ( result.isCallable() && canContinue() && !m_engine->hasError() ) {
         const QString label2 = QStringLiteral("eval(arguments[%1])()").arg(skipArguments - 1);
         result = call( label2, &result, fnArgs.mid(skipArguments) );
     }
@@ -2732,7 +2728,7 @@ int Scriptable::executeArgumentsSimple(const QStringList &args)
     if (m_abort != Abort::None)
         return m_abortWithSuccess ? CommandFinished : CommandStop;
 
-    if ( hasUncaughtException() )
+    if ( m_engine->hasError() )
         return CommandException;
 
     const auto message = serializeScriptValue(result);
@@ -2998,12 +2994,15 @@ QJSValue Scriptable::screenshot(bool select)
 
 QJSValue Scriptable::eval(const QString &script, const QString &label)
 {
-    if (hasUncaughtException())
+    if (m_engine->hasError())
         return QJSValue();
 
     m_stack.prepend(QStringLiteral("eval:") + label);
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack push: %1").arg(m_stack.join('|')) );
-    const auto result = m_safeEval.call({QJSValue(script)});
+
+    const auto v = m_safeEval.call({QJSValue(script)});
+    const auto result = unwrapResultOrException(v);
+
     m_stack.pop_front();
     COPYQ_LOG_VERBOSE( QStringLiteral("Stack pop: %1").arg(m_stack.join('|')) );
     return result;

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -419,6 +419,7 @@ private:
     bool sourceScriptCommands();
     void callDisplayFunctions(QJSValueList displayFunctions);
     void logUncaughtException(const QJSValue &exc);
+    QJSValue unwrapResultOrException(const QJSValue &resultOrException);
     void showExceptionMessage(const QString &message);
     QVector<int> getRows() const;
 
@@ -504,6 +505,7 @@ private:
     QJSValue m_createFn;
     QJSValue m_createFnB;
     QJSValue m_createProperty;
+    QJSValue m_safeCall;
 
     QJSValue m_byteArrayPrototype;
     QJSValue m_filePrototype;

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -53,9 +53,6 @@ class Scriptable final : public QObject
 
     Q_PROPERTY(QJSValue plugins READ getPlugins CONSTANT)
 
-    Q_PROPERTY(QJSValue _copyqUncaughtException READ uncaughtException WRITE setUncaughtException)
-    Q_PROPERTY(QJSValue _copyqHasUncaughtException READ hasUncaughtException)
-
 public:
     Scriptable(
             QJSEngine *engine,
@@ -107,10 +104,7 @@ public:
     QJSValue throwExportError(const QString &filePath);
     QJSValue throwImportError(const QString &filePath);
 
-    bool hasUncaughtException() const;
     void clearExceptions();
-    QJSValue uncaughtException() const { return {}; }
-    void setUncaughtException(const QJSValue &exc);
 
     QJSEngine *engine() const { return m_engine; }
 
@@ -421,6 +415,7 @@ private:
     void onFetchCurrentClipboardOwner(QString *title);
     void onSaveData(const QVariantMap &data);
 
+    QJSValue unwrapResultOrException(const QJSValue &resultOrException);
     bool sourceScriptCommands();
     void callDisplayFunctions(QJSValueList displayFunctions);
     void logUncaughtException(const QJSValue &exc);
@@ -503,15 +498,13 @@ private:
 
     PlatformClipboardPtr m_clipboard;
 
-    bool m_hasUncaughtException = false;
-
     QStringList m_stack;
 
-    QJSValue m_safeCall;
-    QJSValue m_safeEval;
     QJSValue m_createFn;
     QJSValue m_createFnB;
     QJSValue m_createProperty;
+    QJSValue m_safeCall;
+    QJSValue m_safeEval;
 
     QJSValue m_byteArrayPrototype;
     QJSValue m_filePrototype;

--- a/src/scriptable/scriptable.h
+++ b/src/scriptable/scriptable.h
@@ -135,6 +135,7 @@ public:
     QJSValue getPlugins();
 
     QJSValue eval(const QString &script, const QString &label);
+    QJSValue evalAndCatch(const QString &script, const QString &label);
     QJSValue call(const QString &functionName);
 
     QJSValue call(const QString &label, QJSValue *fn, const QVariantList &arguments);
@@ -415,7 +416,6 @@ private:
     void onFetchCurrentClipboardOwner(QString *title);
     void onSaveData(const QVariantMap &data);
 
-    QJSValue unwrapResultOrException(const QJSValue &resultOrException);
     bool sourceScriptCommands();
     void callDisplayFunctions(QJSValueList displayFunctions);
     void logUncaughtException(const QJSValue &exc);
@@ -498,13 +498,12 @@ private:
 
     PlatformClipboardPtr m_clipboard;
 
+    QJSValue m_lastLoggedException;
     QStringList m_stack;
 
     QJSValue m_createFn;
     QJSValue m_createFnB;
     QJSValue m_createProperty;
-    QJSValue m_safeCall;
-    QJSValue m_safeEval;
 
     QJSValue m_byteArrayPrototype;
     QJSValue m_filePrototype;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -41,6 +41,7 @@ private slots:
     void commandExit();
     void commandEval();
     void commandEvalThrows();
+    void commandEvalThrowsWithLineNumber();
     void commandEvalSyntaxError();
     void commandEvalArguments();
     void commandEvalEndingWithComment();

--- a/src/tests/tests_script_commands.cpp
+++ b/src/tests/tests_script_commands.cpp
@@ -111,7 +111,8 @@ void Tests::scriptCommandWithError()
     );
     RUN_EXPECT_ERROR_WITH_STDERR(
         "", CommandError,
-        "\nsource@<bad_script>\n"
+        "At line 1 in:\n"
+        "source@<bad_script>\n"
         "--- end backtrace ---\n"
     );
 }

--- a/src/tests/tests_script_commands.cpp
+++ b/src/tests/tests_script_commands.cpp
@@ -111,7 +111,7 @@ void Tests::scriptCommandWithError()
     );
     RUN_EXPECT_ERROR_WITH_STDERR(
         "", CommandError,
-        "\neval:source@<bad_script>\n"
+        "\nsource@<bad_script>\n"
         "--- end backtrace ---\n"
     );
 }

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -53,6 +53,59 @@ void Tests::commandEvalThrows()
     RUN_EXPECT_ERROR("eval" << "throw 1", CommandException);
 }
 
+void Tests::commandEvalThrowsWithLineNumber()
+{
+    // Multi-line script: exception on a specific line
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "eval" << "var x = 1\nvar y = 2\nthrow Error('on line 3')",
+        CommandException,
+        "At line 3 in:\n"
+        " 1|var x = 1\n"
+        " 2|var y = 2\n"
+        " 3|throw Error('on line 3')\n"
+    );
+
+    // Single-line throw: line number is 1
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "throw Error('single line')", CommandException,
+        "At line 1 in:\n"
+    );
+
+    // Non-Error throw: no line number (no .lineNumber on plain string)
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "throw 'no line info'", CommandException,
+        "ScriptError: no line info\n"
+    );
+
+    // Nested eval: inner script is multiline (2 lines)
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "eval" << "eval(\"\\\\nthrow Error('nested')\")",
+        CommandException,
+        "At line 2 in:\n"
+        " 1|\n"
+        " 2|throw Error('nested')\n"
+    );
+
+    // Doubly nested eval: both inner scripts are multiline.
+    // Inner script is 3 lines, middle script is 2 lines.
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "eval" << "eval(\"\\\\neval('\\\\\\\\n\\\\\\\\nthrow Error()')\")",
+        CommandException,
+        "At line 3 in:\n"
+        " 1|\n"
+        " 2|\n"
+        " 3|throw Error()\n"
+    );
+
+    // Verify the middle frame in the doubly nested case is also numbered
+    RUN_EXPECT_ERROR_WITH_STDERR(
+        "eval" << "eval(\"\\\\neval('\\\\\\\\n\\\\\\\\nthrow Error()')\")",
+        CommandException,
+        " 2|eval('\\n\\nthrow Error()')\n"
+    );
+}
+
+
 void Tests::commandEvalSyntaxError()
 {
     RUN_EXPECT_ERROR_WITH_STDERR("eval" << "(", CommandException, "SyntaxError");


### PR DESCRIPTION
Replace the dedicated boolean exception flag with the engine's own hasError() as the sole flow-control mechanism. Restore JS try-catch wrapper for function calls so non-Error throws (e.g. throw 42) are properly detected. Add a logging guard to prevent duplicate exception messages in nested call chains.

Assisted-by: Claude (Anthropic)