### PR TITLE
Add AppImage support

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,11 +4,9 @@ name: Linux
 on:
   push:
     branches: [master]
+    tags: ['v*']
   pull_request:
     branches: [master]
-
-permissions:
-  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,7 +42,6 @@ env:
     libqt6svg6
 
     libkf6guiaddons-dev
-    libkf6guiaddons
 
     libqt6waylandclient6
     qt6-wayland
@@ -60,12 +57,17 @@ env:
   QCA_VERSION: '2.3.10'
   QTKEYCHAIN_VERSION: '0.15.0'
 
-  # FIXME: Sending signal to client process does not cause the process
-  # to exit with non-zero code with GitHub Actions. Why?
-  COPYQ_TESTS_SKIP_SIGNAL: '1'
+  LINUXDEPLOY_URL: 'https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage'
+  LINUXDEPLOY_SHA256: '4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a'
+  LINUXDEPLOY_PLUGIN_QT_URL: 'https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-x86_64.AppImage'
+  LINUXDEPLOY_PLUGIN_QT_SHA256: '15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724'
+  LINUXDEPLOY_PLUGIN_APPIMAGE_URL: 'https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-appimage-x86_64.AppImage'
+  LINUXDEPLOY_PLUGIN_APPIMAGE_SHA256: '992d502a248e14ab185448ddf6f6e7d25558cb84d4623c354c3af350c25fccb3'
 
 jobs:
   build:
+    permissions:
+      contents: read
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     strategy:
@@ -89,6 +91,7 @@ jobs:
               -ftest-coverage
               -fprofile-abs-path
               -fprofile-update=atomic
+            test_x11: true
 
           - os: ubuntu-latest
             buildname: Qt 6 Clang
@@ -96,14 +99,27 @@ jobs:
             compiler_package: clang
             with_native_notifications: false
             cmake_preset: Debug
+            test_x11: true
 
+          # Pinned to ubuntu-24.04: KDE Neon repo below uses 'noble' (24.04 codename).
+          - os: ubuntu-24.04
+            buildname: AppImage
+            compiler: g++
+            compiler_package: g++
+            with_native_notifications: true
+            cmake_preset: AppImage-Release
+            appimage: true
+            test_x11: false
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
         with:
           submodules: false
-          fetch-depth: 1
           persist-credentials: false
+          # Full commit history needed for sortable version string (git describe in CMake).
+          # Blobless filter skips file content for historical commits to speed up clone.
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Enable ccache
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
@@ -114,7 +130,28 @@ jobs:
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 
+      - name: Set up KDE Neon repo for KF6 packages
+        if: matrix.appimage
+        run: |
+          wget -qO - https://archive.neon.kde.org/public.key |
+            sudo gpg --dearmor -o /usr/share/keyrings/neon-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/neon-archive-keyring.gpg] https://archive.neon.kde.org/stable noble main" |
+            sudo tee /etc/apt/sources.list.d/neon.list
+          sudo apt-get update
+
+      - name: Install dependencies (AppImage)
+        if: matrix.appimage
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1
+        with:
+          version: 1.0
+          packages: >-
+            ${{ matrix.compiler_package }}
+            ${{ env.common_packages }}
+            ${{ env.qt6_packages }}
+            libkf6notifications-dev kf6-kstatusnotifieritem-dev
+
       - name: Install dependencies
+        if: '!matrix.appimage'
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1
         with:
           version: 1.0
@@ -134,7 +171,6 @@ jobs:
         with:
           version: ${{ matrix.custom_qt }}
           modules: qt5compat
-
 
       - name: Build QCA and QtKeychain
         if: matrix.custom_qt
@@ -202,10 +238,105 @@ jobs:
       - name: Test on X11
         working-directory: >-
           ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        if: matrix.test_x11 != false
         run: '${{github.workspace}}/utils/github/test-linux.sh'
         env:
           COPYQ_TESTS_EXECUTABLE: >-
             ${{github.workspace}}/_install/copyq/${{ matrix.cmake_preset }}/bin/copyq
+
+      - name: Set up AppImage tools
+        if: matrix.appimage
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          dest="$HOME/.local/bin"
+
+          wget -q -O "$dest/linuxdeploy" "$LINUXDEPLOY_URL"
+          echo "$LINUXDEPLOY_SHA256  $dest/linuxdeploy" | sha256sum -c
+
+          wget -q -O "$dest/linuxdeploy-plugin-qt" "$LINUXDEPLOY_PLUGIN_QT_URL"
+          echo "$LINUXDEPLOY_PLUGIN_QT_SHA256  $dest/linuxdeploy-plugin-qt" | sha256sum -c
+
+          wget -q -O "$dest/linuxdeploy-plugin-appimage" "$LINUXDEPLOY_PLUGIN_APPIMAGE_URL"
+          echo "$LINUXDEPLOY_PLUGIN_APPIMAGE_SHA256  $dest/linuxdeploy-plugin-appimage" | sha256sum -c
+
+          chmod +x "$dest"/linuxdeploy*
+          echo "$dest" >> "$GITHUB_PATH"
+
+      - name: Get version string
+        if: matrix.appimage
+        id: version
+        uses: ./.github/actions/get-version
+        with:
+          build_dir: ${{ github.workspace }}/build/copyq/${{ matrix.cmake_preset }}
+
+      - name: Create AppImage
+        if: matrix.appimage
+        env:
+          DESTDIR: ${{github.workspace}}/AppDir
+          EXTRA_QT_MODULES: svg;tls
+          EXTRA_PLATFORM_PLUGINS: libqwayland.so
+          QMAKE: qmake6
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          DESTDIR="$DESTDIR" cmake --install build/copyq/${{ matrix.cmake_preset }}
+
+          # Bundle KF6 KWindowSystem platform plugins. These are loaded at
+          # runtime via QPluginLoader, so linuxdeploy-plugin-qt doesn't detect
+          # them. Without them KWindowSystem logs:
+          #   "Could not find any platform plugin"
+          kws_src="$(qmake6 -query QT_INSTALL_PLUGINS)/kf6/kwindowsystem"
+          kws_dst="$DESTDIR/usr/plugins/kf6/kwindowsystem"
+          if [ -d "$kws_src" ]; then
+            mkdir -p "$kws_dst"
+            cp -a "$kws_src"/*.so "$kws_dst/"
+          fi
+
+          linuxdeploy --appdir "$DESTDIR" \
+            --desktop-file "$DESTDIR/usr/share/applications/com.github.hluk.copyq.desktop" \
+            --icon-file "$DESTDIR/usr/share/icons/hicolor/scalable/apps/copyq.svg" \
+            --executable "$DESTDIR/usr/bin/copyq" \
+            --plugin qt \
+            --output appimage
+
+      - name: Upload AppImage
+        if: matrix.appimage
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          path: CopyQ-*.AppImage
+          archive: false
+
+      - name: Smoke-test AppImage
+        if: matrix.appimage
+        run: APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGE" --version
+        env:
+          APPIMAGE: ${{github.workspace}}/CopyQ-${{ steps.version.outputs.version }}-x86_64.AppImage
+
+      - name: Set up AppImage for tests
+        if: matrix.appimage
+        working-directory: >-
+          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        run: |
+          # Extract the AppImage to get the same filesystem layout as a FUSE
+          # mount. The binary uses RUNPATH=$ORIGIN/../lib for bundled libraries
+          # and APPDIR + compiled-in prefixes for plugins/translations/themes.
+          # Extraction is needed (instead of APPIMAGE_EXTRACT_AND_RUN) because
+          # the AppImage runtime's fork()+execv() does not forward signals,
+          # which breaks test-signals.sh (upstream: AppImageKit#1053).
+          "$APPIMAGE" --appimage-extract
+          ln -sf "$PWD/squashfs-root/usr/bin/copyq" ./copyq
+        env:
+          APPIMAGE: ${{github.workspace}}/CopyQ-${{ steps.version.outputs.version }}-x86_64.AppImage
+
+      - name: Test AppImage on X11
+        if: matrix.appimage
+        working-directory: >-
+          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        run: '${{github.workspace}}/utils/github/test-linux.sh'
+        env:
+          COPYQ_TESTS_EXECUTABLE: >-
+            ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}/copyq
+          APPDIR: >-
+            ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}/squashfs-root
 
       - name: Update coverage
         if: matrix.coverage
@@ -232,3 +363,21 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: 'CopyQ-*.AppImage'
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          draft: true
+          files: 'CopyQ-*/*.AppImage'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,11 +8,10 @@ on:
   pull_request:
     branches: [master]
 
-permissions:
-  contents: read
-
 jobs:
   codespell:
+    permissions:
+      contents: read
     name: Check for spelling errors
     runs-on: ubuntu-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ OPTION(WITH_QCA_ENCRYPTION "Enable QCA-based tab encryption" ON)
 OPTION(WITH_KEYCHAIN "Enable system keyring integration using QtKeychain" ON)
 OPTION(WITH_GNOME_CLIPBOARD_EXTENSION "Install GNOME extension, required for clipboard monitoring" ON)
 OPTION(WITH_AUDIO "Build with audio playback support (miniaudio)" ON)
+OPTION(WITH_APPIMAGE "Enable AppImage runtime support (uses $APPIMAGE/$APPDIR env vars)" OFF)
 
 add_definitions( -DQT_USE_STRINGBUILDER  )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,6 +16,20 @@
             }
         },
         {
+            "name": "AppImage-Release",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/copyq/${presetName}",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "/usr",
+                "WITH_APPIMAGE": "TRUE",
+                "WITH_TESTS": "TRUE",
+                "WITH_QCA_ENCRYPTION": "TRUE",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+            }
+        },
+        {
             "name": "macOS-10",
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/copyq/${presetName}",
@@ -79,6 +93,11 @@
             "configurePreset": "Debug",
             "configuration": "Debug",
             "targets": "install"
+        },
+        {
+            "name": "AppImage-Release",
+            "configurePreset": "AppImage-Release",
+            "configuration": "Release"
         },
         {
             "name": "macOS-10",

--- a/README.md
+++ b/README.md
@@ -119,7 +119,15 @@ Install `copyq` package.
 
 ### Other Linux Distributions
 
-Install [Flatpak](https://flatpak.org/) and `com.github.hluk.copyq` from
+Download the latest **AppImage** from
+[GitHub Releases](https://github.com/hluk/CopyQ/releases):
+
+```bash
+chmod +x CopyQ-*.AppImage
+./CopyQ-*.AppImage
+```
+
+Alternatively, install [Flatpak](https://flatpak.org/) and `com.github.hluk.copyq` from
 [Flathub](https://flathub.org/).
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,7 @@ Artifacts produced by CI (attached automatically by GitHub Actions):
 - Windows portable zip (`copyq-VERSION.zip`)
 - macOS Intel DMG (`CopyQ-VERSION-macos-13.dmg`)
 - macOS Apple Silicon DMG (`CopyQ-VERSION-macos-12-m1.dmg`)
+- Linux AppImage (`CopyQ-VERSION-x86_64.AppImage`)
 
 # Build Flatpak
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -53,8 +53,15 @@ On **Fedora**, install "copyq" package:
 
     sudo dnf install copyq
 
-On other Linux distributions, you can use `Flatpak <https://flatpak.org/>`__
-to install the app:
+On other Linux distributions, you can download the **AppImage** from the
+`Releases page <https://github.com/hluk/CopyQ/releases>`__:
+
+.. code-block:: bash
+
+    chmod +x CopyQ-*.AppImage
+    ./CopyQ-*.AppImage
+
+Alternatively, you can use `Flatpak <https://flatpak.org/>`__ to install the app:
 
 .. code-block:: bash
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,11 @@ foreach (copyq_qt_module ${copyq_qt_modules})
 endforeach()
 
 set_target_properties(copyq-common PROPERTIES COMPILE_DEFINITIONS "${copyq_DEFINITIONS}")
+
+if(WITH_APPIMAGE)
+    target_compile_definitions(copyq-common PRIVATE COPYQ_WITH_APPIMAGE)
+    target_compile_definitions(${COPYQ_EXECUTABLE_NAME} PRIVATE COPYQ_WITH_APPIMAGE)
+endif()
 set_target_properties(${COPYQ_EXECUTABLE_NAME} PROPERTIES LINK_FLAGS "${copyq_LINK_FLAGS}")
 target_link_libraries(copyq-common ${copyq_LIBRARIES})
 target_link_libraries(${COPYQ_EXECUTABLE_NAME} ${copyq_LIBRARIES})

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -5,6 +5,7 @@
 #include "common/commandstore.h"
 #include "common/settings.h"
 #include "common/textdata.h"
+#include "common/config.h"
 #include "item/serialize.h"
 #include "platform/platformnativeinterface.h"
 #ifdef Q_OS_UNIX
@@ -41,7 +42,7 @@ void installTranslator()
     }
 
 #ifdef COPYQ_TRANSLATION_PREFIX
-    const QString translationPrefix = COPYQ_TRANSLATION_PREFIX;
+    const QString translationPrefix = adjustedInstallPath(QStringLiteral(COPYQ_TRANSLATION_PREFIX));
 #else
     const QString translationPrefix = platformNativeInterface()->translationPrefix();
 #endif
@@ -91,7 +92,7 @@ void setSessionName(const QString &sessionName)
 void initSession(QCoreApplication *app, const QString &sessionName)
 {
     qputenv("COPYQ_SESSION_NAME", sessionName.toLocal8Bit());
-    qputenv("COPYQ", QCoreApplication::applicationFilePath().toLocal8Bit());
+    qputenv("COPYQ", applicationExecutablePath().toLocal8Bit());
 
     const auto settingsPath = qEnvironmentVariable("COPYQ_SETTINGS_PATH");
     if ( !settingsPath.isEmpty() ) {
@@ -162,6 +163,11 @@ void App::exit(int exitCode)
 {
     if ( wasClosed() )
         return;
+
+    // Prefer signal exit code if a Unix signal triggered the shutdown.
+    const QVariant signalCode = m_app->property("CopyQ_signal_exit_code");
+    if (signalCode.isValid())
+        exitCode = signalCode.toInt();
 
     if (!m_started)
         ::exit(exitCode);

--- a/src/common/action.cpp
+++ b/src/common/action.cpp
@@ -2,6 +2,7 @@
 
 #include "action.h"
 
+#include "common/config.h"
 #include "common/mimetypes.h"
 #include "common/process.h"
 #include "common/processsignals.h"
@@ -27,7 +28,7 @@ void startProcess(QProcess *process, const QStringList &args, QIODevice::OpenMod
 
     // Replace "copyq" command with full application path.
     if (executable == "copyq")
-        executable = QCoreApplication::applicationFilePath();
+        executable = applicationExecutablePath();
 
     process->start(executable, args.mid(1), mode);
 }

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -60,3 +60,21 @@ const QString &settingsDirectoryPath()
         QDir::cleanPath( getConfigurationFilePath() + QLatin1String("/..") );
     return path;
 }
+
+QString applicationExecutablePath()
+{
+#ifdef COPYQ_WITH_APPIMAGE
+    if (const QString appImage = qEnvironmentVariable("APPIMAGE"); !appImage.isEmpty())
+        return appImage;
+#endif
+    return QCoreApplication::applicationFilePath();
+}
+
+QString adjustedInstallPath(const QString &compiledPath)
+{
+#ifdef COPYQ_WITH_APPIMAGE
+    if (const QString appDir = qEnvironmentVariable("APPDIR"); !appDir.isEmpty())
+        return appDir + compiledPath;
+#endif
+    return compiledPath;
+}

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -11,3 +11,17 @@ const QString &getConfigurationFilePath();
 QString getConfigurationFilePath(const char *suffix);
 
 const QString &settingsDirectoryPath();
+
+/**
+ * Returns the path to the CopyQ executable. When built with AppImage support
+ * and running inside an AppImage, returns the AppImage path ($APPIMAGE) so
+ * that child processes go through the AppRun wrapper.
+ */
+QString applicationExecutablePath();
+
+/**
+ * Adjusts a compile-time install path for the runtime environment.
+ * With AppImage support, prepends $APPDIR so bundled resources are found.
+ * Without AppImage support, returns the path unchanged.
+ */
+QString adjustedInstallPath(const QString &compiledPath);

--- a/src/common/diagnostics.cpp
+++ b/src/common/diagnostics.cpp
@@ -3,6 +3,7 @@
 #include "common/diagnostics.h"
 
 #include "common/audioplayer.h"
+#include "common/config.h"
 #include "common/log.h"
 #include "common/version.h"
 #include "item/serialize.h"
@@ -29,7 +30,7 @@ namespace {
 QString pluginsPath()
 {
 #ifdef COPYQ_PLUGIN_PREFIX
-    return QStringLiteral(COPYQ_PLUGIN_PREFIX);
+    return adjustedInstallPath(QStringLiteral(COPYQ_PLUGIN_PREFIX));
 #else
     QDir dir;
     if (platformNativeInterface()->findPluginDir(&dir))
@@ -41,7 +42,7 @@ QString pluginsPath()
 QString themesPath()
 {
 #ifdef COPYQ_THEME_PREFIX
-    return QStringLiteral(COPYQ_THEME_PREFIX);
+    return adjustedInstallPath(QStringLiteral(COPYQ_THEME_PREFIX));
 #else
     return platformNativeInterface()->themePrefix();
 #endif
@@ -50,7 +51,7 @@ QString themesPath()
 QString translationsPath()
 {
 #ifdef COPYQ_TRANSLATION_PREFIX
-    return QStringLiteral(COPYQ_TRANSLATION_PREFIX);
+    return adjustedInstallPath(QStringLiteral(COPYQ_TRANSLATION_PREFIX));
 #else
     return platformNativeInterface()->translationPrefix();
 #endif

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -211,7 +211,7 @@ QString getFontStyleSheet(const QString &fontString, double scale = 1.0)
 QString themePrefix()
 {
 #ifdef COPYQ_THEME_PREFIX
-    return COPYQ_THEME_PREFIX;
+    return adjustedInstallPath(QStringLiteral(COPYQ_THEME_PREFIX));
 #else
     return platformNativeInterface()->themePrefix();
 #endif

--- a/src/item/itemfactory.cpp
+++ b/src/item/itemfactory.cpp
@@ -38,7 +38,7 @@ namespace {
 bool findPluginDir(QDir *pluginsDir)
 {
 #ifdef COPYQ_PLUGIN_PREFIX
-    pluginsDir->setPath(COPYQ_PLUGIN_PREFIX);
+    pluginsDir->setPath(adjustedInstallPath(QStringLiteral(COPYQ_PLUGIN_PREFIX)));
     if ( pluginsDir->isReadable() )
         return true;
 #endif
@@ -467,7 +467,7 @@ ItemSaverPtr ItemFactory::loadItems(const QString &tabName, QAbstractItemModel *
     return nullptr;
 }
 
-ItemSaverPtr ItemFactory::initializeTab(const QString &tabName, QAbstractItemModel *model, int maxItems)
+ItemSaverPtr ItemFactory::initializeTab(const QString &tabName, QAbstractItemModel *model, int maxItems) const
 {
     for (const auto &loader : m_loaders) {
         if ( loader->isEnabled() && loader->canSaveItems(tabName) ) {

--- a/src/item/itemfactory.h
+++ b/src/item/itemfactory.h
@@ -98,7 +98,7 @@ public:
      * Initialize tab.
      * @return the first plugin (or nullptr) for which ItemLoaderInterface::initializeTab() returned true
      */
-    ItemSaverPtr initializeTab(const QString &tabName, QAbstractItemModel *model, int maxItems);
+    ItemSaverPtr initializeTab(const QString &tabName, QAbstractItemModel *model, int maxItems) const;
 
     /**
      * Return true only if any plugin (ItemLoaderInterface::matches()) returns true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "app/clipboardclient.h"
 #include "app/clipboardserver.h"
 #include "common/commandstatus.h"
+#include "common/config.h"
 #include "common/log.h"
 #include "common/messagehandlerforqt.h"
 #include "common/textdata.h"
@@ -21,6 +22,7 @@
 #include <QSettings>
 
 #include <exception>
+#include <cstring>
 
 Q_DECLARE_METATYPE(QByteArray*)
 
@@ -130,10 +132,18 @@ int startServer(int argc, char *argv[], QString sessionName)
     return app.exec();
 }
 
-void startServerInBackground(const QString &applicationPath, QString sessionName)
+void startServerInBackground(const char *argv0, const QString &sessionName)
 {
+    // QCoreApplication is not yet instantiated, so applicationExecutablePath()
+    // cannot be used here. Duplicate its $APPIMAGE logic directly.
+#ifdef COPYQ_WITH_APPIMAGE
+    const QString appImage = qEnvironmentVariable("APPIMAGE");
+    const QString executable = appImage.isEmpty() ? QString::fromUtf8(argv0) : appImage;
+#else
+    const QString executable = QString::fromUtf8(argv0);
+#endif
     const QStringList arguments{QStringLiteral("-s"), sessionName};
-    const bool started = QProcess::startDetached(applicationPath, arguments);
+    const bool started = QProcess::startDetached(executable, arguments);
 
     if (!started)
         log("Failed to start the server", LogError);
@@ -279,6 +289,13 @@ int startApplication(int argc, char **argv)
     setSessionName(QString());
 
     const AppArguments args = parseArguments(argc, argv);
+    // Qt normalizes --session to -session and treats it as a Session Manager
+    // restore request. Skip the "--" prefix so Qt sees "session" instead.
+    if (!args.sessionName.isEmpty() && argc > 1
+        && std::strcmp(argv[1], "--session") == 0)
+    {
+        argv[1] += 2;
+    }
 
     setLogLabel( logLabelForType(args.appType, args.arguments) );
     installMessageHandlerForQt();
@@ -309,7 +326,7 @@ int startApplication(int argc, char **argv)
         return startClient(argc, argv, args.arguments, args.sessionName);
 
     case AppType::StartServerInBackground:
-        startServerInBackground( QString::fromUtf8(argv[0]), args.sessionName );
+        startServerInBackground(argv[0], args.sessionName);
         if (args.arguments.isEmpty())
             return 0;
         return startClient(argc, argv, args.arguments, args.sessionName);

--- a/src/platform/unix/unixsignalhandler.cpp
+++ b/src/platform/unix/unixsignalhandler.cpp
@@ -6,6 +6,7 @@
 
 #include <QCoreApplication>
 #include <QSocketNotifier>
+#include <QVariant>
 
 #include <csignal>
 #include <sys/socket.h>
@@ -52,8 +53,12 @@ void handleSignal()
     } else if (data.pid != QCoreApplication::applicationPid()) {
         log("PID not matching on a Unix signal", LogError);
     } else {
+        const int exitCode = 128 + data.code;
         log( QStringLiteral("Terminating application on signal %1").arg(data.code) );
-        QCoreApplication::exit(128 + data.code);
+        auto *app = QCoreApplication::instance();
+        app->setProperty("CopyQ_quitting", QVariant(true));
+        app->setProperty("CopyQ_signal_exit_code", QVariant(exitCode));
+        QCoreApplication::exit(exitCode);
     }
 
     signalFdNotifier->setEnabled(true);

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -6,6 +6,7 @@
 
 #include "app/applicationexceptionhandler.h"
 #include "common/log.h"
+#include "common/config.h"
 #include "common/textdata.h"
 
 #include <QApplication>
@@ -216,7 +217,7 @@ void X11Platform::setAutostartEnabled(bool enable)
 #ifdef COPYQ_AUTOSTART_COMMAND
     QString cmd = COPYQ_AUTOSTART_COMMAND;
 #else
-    QString cmd = "\"" + QApplication::applicationFilePath() + "\"";
+    QString cmd = "\"" + applicationExecutablePath() + "\"";
 #endif
     const QString sessionName = qApp->property("CopyQ_session_name").toString();
     if ( !sessionName.isEmpty() )

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -35,6 +35,7 @@ private slots:
     void commandVersion();
     void badCommand();
     void badSessionName();
+    void commandSession();
 
     void commandCatchExceptions();
 

--- a/src/tests/tests_cli.cpp
+++ b/src/tests/tests_cli.cpp
@@ -203,6 +203,11 @@ void Tests::badSessionName()
     RUN_EXPECT_ERROR("-s" << "spaces disallowed" << "", CommandBadSyntax);
 }
 
+void Tests::commandSession()
+{
+    RUN("--session" << sessionName << "eval" << "print(1)", "1");
+}
+
 void Tests::commandCatchExceptions()
 {
     RUN("try { removeTab('MISSING') } catch(e) { print(e) }",

--- a/utils/github/draft-release.sh
+++ b/utils/github/draft-release.sh
@@ -3,8 +3,9 @@
 # Drafts a GitHub release for the latest tag.
 #
 #
-# CI workflows (build-macos.yml, build-windows.yml) attach .dmg, .zip,
-# and .exe files to the draft release directly. This script adds: source
+# CI workflows (build-linux.yml, build-macos.yml, build-windows.yml) attach
+# .AppImage, .dmg, .zip, and .exe files to the draft release directly. This
+# script adds: source
 # tarball, checksums-sha512.txt, and cosign.bundle.
 #
 # Requirements:
@@ -86,7 +87,7 @@ if [[ -f "$source_tarball" ]]; then
 else
     log "Creating source tarball ..."
     git -C "$repo_root" archive --format=tar.gz \
-        --prefix="Copyq-$version/" --output="$source_tarball" "$tag"
+        --prefix="CopyQ-$version/" --output="$source_tarball" "$tag"
 fi
 
 log "Uploading source tarball to release $tag ..."
@@ -95,6 +96,7 @@ gh release upload "$tag" "$source_tarball" --clobber
 # wait for CI build artifacts on the release
 
 expected_assets=(
+    "CopyQ-${version}-x86_64.AppImage"
     "CopyQ-${version}-macos-12-m1.dmg"
     "CopyQ-${version}-macos-13.dmg"
     "copyq-${version}-setup.exe"
@@ -107,6 +109,15 @@ wait_for_builds() {
     if [[ -z "$tag_sha" ]]; then
         die "Could not resolve commit SHA for tag $tag"
     fi
+
+    log "Getting Linux build run for tag $tag (commit $tag_sha)..."
+    local linux_run
+    linux_run="$(gh run list --workflow build-linux.yml --commit "$tag_sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+    if [[ -z "$linux_run" ]]; then
+        die "Could not find Linux build run for commit $tag_sha"
+    fi
+    log "Watching Linux build (run $linux_run)..."
+    gh run watch "$linux_run" --exit-status --interval 30 || die "Linux build failed"
 
     log "Getting macOS build run for tag $tag (commit $tag_sha)..."
     local macos_run
@@ -125,7 +136,7 @@ wait_for_builds() {
     fi
     log "Watching Windows build (run $windows_run)..."
     gh run watch "$windows_run" --exit-status --interval 30 || die "Windows build failed"
-    log "Both builds completed successfully"
+    log "All builds completed successfully"
 }
 
 has_all_assets() {

--- a/utils/github/test-signals.sh
+++ b/utils/github/test-signals.sh
@@ -5,6 +5,7 @@ set -xeuo pipefail
 export COPYQ_SESSION_NAME=__COPYQ_SIGTEST
 
 source "$(dirname "$0")/test-start-server.sh"
+copyq="${COPYQ_TESTS_EXECUTABLE:-./copyq}"
 
 exit_code=0
 
@@ -12,14 +13,14 @@ exit_code=0
 if [[ ${COPYQ_TESTS_SKIP_SIGNAL:-0} == "1" ]]; then
     echo "⚠️ Skipping signal test"
 else
-    ./copyq 'sleep(100000)' &
+    "$copyq" 'sleep(100000)' &
     copyq_sleep_pid=$!
 
     sigterm=15
     expected_exit_code=$((128 + sigterm))
 
     sleep 2
-    if ! pkill -$sigterm -f '^\./copyq sleep\(100000\)$'; then
+    if ! kill -$sigterm $copyq_sleep_pid; then
         echo "❌ FAILED: Could not send SIGTERM to the command"
         kill $copyq_sleep_pid
         exit_code=1
@@ -39,10 +40,10 @@ else
     fi
 fi
 
-./copyq 'sleep(100000)' &
+"$copyq" 'sleep(100000)' &
 copyq_sleep_pid=$!
 
-./copyq 'while(true){read(9999999);}' &
+"$copyq" 'while(true){read(9999999);}' &
 copyq_loop_pid=$!
 
 trap "kill -9 $copyq_sleep_pid $copyq_loop_pid || true" TERM INT

--- a/utils/github/test-start-server.sh
+++ b/utils/github/test-start-server.sh
@@ -6,15 +6,18 @@
 export COPYQ_LOG_LEVEL=DEBUG
 export QT_LOGGING_RULES="*.debug=true;qt.*.debug=false;qt.*.warning=true"
 
-./copyq &
+copyq="${COPYQ_TESTS_EXECUTABLE:-./copyq}"
+
+"$copyq" &
 copyq_pid=$!
 
 # Wait for server to start
-for i in {1..3}; do
+retries=3
+for i in {1..$retries}; do
     echo "Trying to start CopyQ server ($i)"
-    if ./copyq 'serverLog("Server started")'; then
+    if "$copyq" 'serverLog("Server started")'; then
         break
-    elif [[ $i == 5 ]]; then
+    elif [[ $i == $retries ]]; then
         echo "❌ FAILED: Could not start CopyQ server"
         exit 1
     fi


### PR DESCRIPTION
Add CI workflow entry to build and upload AppImage artifacts using linuxdeploy with Qt and AppImage plugins. Include KDE Neon KF6 packages for native notification support and bundle TLS and Wayland platform plugins.

Add Release CMake preset for AppImage builds.

Fix child process spawning inside AppImage by routing through the AppImage wrapper instead of the internal FUSE-mounted binary.

Fix resource discovery (themes, translations, plugins) inside AppImage by adjusting compile-time paths to the AppImage mount point at runtime.

Fix autostart desktop entry to reference the AppImage executable.

Assisted-by: Claude (Anthropic)