### PR TITLE
feat: Default to second item in clipboard list

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -1725,7 +1725,7 @@ bool ClipboardBrowser::loadItems(const QByteArray &itemData)
 
     d.rowsInserted(QModelIndex(), 0, m.rowCount());
     if ( hasFocus() )
-        setCurrent(0);
+        setCurrent(std::min(1, m.rowCount() - 1));  // Select 2nd item if available, else 1st
     onItemCountChanged();
 
     return true;


### PR DESCRIPTION
## Summary
When opening the clipboard list, the first item (current clipboard content) is selected by default. This PR changes the default selection to the second item when available.

## Motivation
The first item usually mirrors the current clipboard, so selecting it by default is redundant. Selecting the second item enables a faster workflow: `<shortcut to open app> + Enter` pastes the previous clipboard entry.

That's what ClipX was doing and this behavior has been requested before: https://github.com/hluk/CopyQ/issues/3366

## Change
- Replace default `setCurrent(0)` with:
  `setCurrent(std::min(1, m.rowCount() - 1))`

## Behavior

### Before
- `<shortcut to open app> + Enter` → pastes the current system clipboard content
  (effectively the same as `Ctrl + V`)

### After
- `<shortcut to open app> + Enter` → pastes the previous clipboard entry
  (the item that was overwritten in the system clipboard)

### Selection logic
- If 2+ items → second item is selected
- If only 1 item → first item remains selected

## Notes
Minimal change, no impact on other selection logic.