### PR TITLE
Fix AppImage Wayland plugin loading and clipboard ownership

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -81,8 +81,6 @@ jobs:
             compiler_package: g++
             custom_qt: '6.10.2'
             with_native_notifications: false
-            test_wayland: true
-            test_gnome: true
             coverage: true
             cmake_preset: Debug
             compiler_flags: >-
@@ -91,6 +89,8 @@ jobs:
               -ftest-coverage
               -fprofile-abs-path
               -fprofile-update=atomic
+            test_wayland: true
+            test_gnome: true
             test_x11: true
 
           - os: ubuntu-latest
@@ -109,7 +109,8 @@ jobs:
             with_native_notifications: true
             cmake_preset: AppImage-Release
             appimage: true
-            test_x11: false
+            test_wayland: true
+            test_x11: true
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
@@ -149,6 +150,7 @@ jobs:
             ${{ env.common_packages }}
             ${{ env.qt6_packages }}
             libkf6notifications-dev kf6-kstatusnotifieritem-dev
+            kwin-wayland kwin-wayland-backend-virtual libwayland-server0
 
       - name: Install dependencies
         if: '!matrix.appimage'
@@ -217,32 +219,9 @@ jobs:
       - name: Create gnupg directory for tests
         run: mkdir -p ~/.gnupg && chmod go-rwx ~/.gnupg
 
-      - name: Test on GNOME
-        working-directory: >-
-          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
-        if: matrix.test_gnome
-        run: '${{github.workspace}}/utils/github/test-linux-gnome-extension.sh'
-        env:
-          COPYQ_TESTS_EXECUTABLE: >-
-            ${{github.workspace}}/_install/copyq/${{ matrix.cmake_preset }}/bin/copyq
-
-      - name: Test on Wayland
-        working-directory: >-
-          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
-        if: matrix.test_wayland
-        run: '${{github.workspace}}/utils/github/test-linux-wayland.sh'
-        env:
-          COPYQ_TESTS_EXECUTABLE: >-
-            ${{github.workspace}}/_install/copyq/${{ matrix.cmake_preset }}/bin/copyq
-
-      - name: Test on X11
-        working-directory: >-
-          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
-        if: matrix.test_x11 != false
-        run: '${{github.workspace}}/utils/github/test-linux.sh'
-        env:
-          COPYQ_TESTS_EXECUTABLE: >-
-            ${{github.workspace}}/_install/copyq/${{ matrix.cmake_preset }}/bin/copyq
+      - name: Set up test environment
+        run: |
+          echo "COPYQ_TESTS_EXECUTABLE=${{github.workspace}}/_install/copyq/${{ matrix.cmake_preset }}/bin/copyq" >> "$GITHUB_ENV"
 
       - name: Set up AppImage tools
         if: matrix.appimage
@@ -280,16 +259,23 @@ jobs:
         run: |
           DESTDIR="$DESTDIR" cmake --install build/copyq/${{ matrix.cmake_preset }}
 
-          # Bundle KF6 KWindowSystem platform plugins. These are loaded at
-          # runtime via QPluginLoader, so linuxdeploy-plugin-qt doesn't detect
-          # them. Without them KWindowSystem logs:
-          #   "Could not find any platform plugin"
-          kws_src="$(qmake6 -query QT_INSTALL_PLUGINS)/kf6/kwindowsystem"
-          kws_dst="$DESTDIR/usr/plugins/kf6/kwindowsystem"
-          if [ -d "$kws_src" ]; then
-            mkdir -p "$kws_dst"
-            cp -a "$kws_src"/*.so "$kws_dst/"
-          fi
+          # Bundle Qt plugin directories that linuxdeploy-plugin-qt does not
+          # detect automatically.  Pre-placing them lets linuxdeploy resolve
+          # their shared-library dependencies (libQt6WaylandClient, etc.).
+          qt_plugins="$(qmake6 -query QT_INSTALL_PLUGINS)"
+          for dir in \
+              kf6/kwindowsystem \
+              wayland-shell-integration \
+              wayland-decoration-client \
+              wayland-graphics-integration-client \
+          ; do
+              src="$qt_plugins/$dir"
+              dst="$DESTDIR/usr/plugins/$dir"
+              if [ -d "$src" ]; then
+                  mkdir -p "$dst"
+                  cp -a "$src"/*.so "$dst/"
+              fi
+          done
 
           linuxdeploy --appdir "$DESTDIR" \
             --desktop-file "$DESTDIR/usr/share/applications/com.github.hluk.copyq.desktop" \
@@ -324,19 +310,28 @@ jobs:
           # which breaks test-signals.sh (upstream: AppImageKit#1053).
           "$APPIMAGE" --appimage-extract
           ln -sf "$PWD/squashfs-root/usr/bin/copyq" ./copyq
+          echo "COPYQ_TESTS_EXECUTABLE=$PWD/copyq" >> "$GITHUB_ENV"
+          echo "APPDIR=$PWD/squashfs-root" >> "$GITHUB_ENV"
         env:
           APPIMAGE: ${{github.workspace}}/CopyQ-${{ steps.version.outputs.version }}-x86_64.AppImage
 
-      - name: Test AppImage on X11
-        if: matrix.appimage
+      - name: Test on GNOME
         working-directory: >-
           ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        if: matrix.test_gnome
+        run: '${{github.workspace}}/utils/github/test-linux-gnome-extension.sh'
+
+      - name: Test on Wayland
+        working-directory: >-
+          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        if: matrix.test_wayland
+        run: '${{github.workspace}}/utils/github/test-linux-wayland.sh'
+
+      - name: Test on X11
+        working-directory: >-
+          ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}
+        if: matrix.test_x11
         run: '${{github.workspace}}/utils/github/test-linux.sh'
-        env:
-          COPYQ_TESTS_EXECUTABLE: >-
-            ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}/copyq
-          APPDIR: >-
-            ${{github.workspace}}/build/copyq/${{ matrix.cmake_preset }}/squashfs-root
 
       - name: Update coverage
         if: matrix.coverage

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -92,7 +92,7 @@ void setSessionName(const QString &sessionName)
 void initSession(QCoreApplication *app, const QString &sessionName)
 {
     qputenv("COPYQ_SESSION_NAME", sessionName.toLocal8Bit());
-    qputenv("COPYQ", applicationExecutablePath().toLocal8Bit());
+    qputenv("COPYQ", applicationLaunchPath().toLocal8Bit());
 
     const auto settingsPath = qEnvironmentVariable("COPYQ_SETTINGS_PATH");
     if ( !settingsPath.isEmpty() ) {

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -145,13 +145,10 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
 
     if ( sessionName.isEmpty() ) {
         QGuiApplication::setApplicationDisplayName(QStringLiteral("CopyQ"));
-        QGuiApplication::setDesktopFileName(QStringLiteral("com.github.hluk.copyq"));
     } else {
         log( QStringLiteral("Session: %1").arg(sessionName) );
         QGuiApplication::setApplicationDisplayName(
             QStringLiteral("CopyQ-%1").arg(sessionName));
-        QGuiApplication::setDesktopFileName(
-            QStringLiteral("com.github.hluk.copyq-%1").arg(sessionName));
     }
 
     QApplication::setQuitOnLastWindowClosed(false);

--- a/src/common/action.cpp
+++ b/src/common/action.cpp
@@ -2,7 +2,6 @@
 
 #include "action.h"
 
-#include "common/config.h"
 #include "common/mimetypes.h"
 #include "common/process.h"
 #include "common/processsignals.h"
@@ -27,8 +26,11 @@ void startProcess(QProcess *process, const QStringList &args, QIODevice::OpenMod
     QString executable = args.value(0);
 
     // Replace "copyq" command with full application path.
+    // Use applicationFilePath() (resolves to the binary inside the current
+    // FUSE mount for AppImages) so that child processes reuse the parent's
+    // mount instead of creating a new one.
     if (executable == "copyq")
-        executable = applicationExecutablePath();
+        executable = QCoreApplication::applicationFilePath();
 
     process->start(executable, args.mid(1), mode);
 }

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -61,7 +61,7 @@ const QString &settingsDirectoryPath()
     return path;
 }
 
-QString applicationExecutablePath()
+QString applicationLaunchPath()
 {
 #ifdef COPYQ_WITH_APPIMAGE
     if (const QString appImage = qEnvironmentVariable("APPIMAGE"); !appImage.isEmpty())

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -13,11 +13,18 @@ QString getConfigurationFilePath(const char *suffix);
 const QString &settingsDirectoryPath();
 
 /**
- * Returns the path to the CopyQ executable. When built with AppImage support
- * and running inside an AppImage, returns the AppImage path ($APPIMAGE) so
- * that child processes go through the AppRun wrapper.
+ * Returns the path to launch CopyQ from outside the current process.
+ *
+ * Inside an AppImage, the running binary lives on a temporary FUSE mount
+ * (e.g. /tmp/.mount_CopyQXXXXXX/usr/bin/copyq) that disappears when the
+ * AppImage exits. Callers that persist the path -- the $COPYQ env var
+ * exported to user scripts, and the Exec= line in the autostart desktop
+ * file -- need the stable AppImage file path ($APPIMAGE) instead.
+ *
+ * When $APPIMAGE is unset (non-AppImage build or env var not propagated),
+ * falls back to QCoreApplication::applicationFilePath().
  */
-QString applicationExecutablePath();
+QString applicationLaunchPath();
 
 /**
  * Adjusts a compile-time install path for the runtime environment.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,8 +134,8 @@ int startServer(int argc, char *argv[], QString sessionName)
 
 void startServerInBackground(const char *argv0, const QString &sessionName)
 {
-    // QCoreApplication is not yet instantiated, so applicationExecutablePath()
-    // cannot be used here. Duplicate its $APPIMAGE logic directly.
+    // QCoreApplication is not yet instantiated. Resolve the $APPIMAGE path
+    // directly so the detached server launches via the AppImage entry point.
 #ifdef COPYQ_WITH_APPIMAGE
     const QString appImage = qEnvironmentVariable("APPIMAGE");
     const QString executable = appImage.isEmpty() ? QString::fromUtf8(argv0) : appImage;
@@ -286,6 +286,16 @@ QByteArray logLabelForType(AppType appType, const QStringList &arguments)
 
 int startApplication(int argc, char **argv)
 {
+#ifdef COPYQ_WITH_APPIMAGE
+    // Override QT_PLUGIN_PATH so the bundled Qt plugins are used instead of
+    // any host-provided plugins (which may be linked against an incompatible
+    // Qt version).  The linuxdeploy AppRun sets APPDIR and LD_LIBRARY_PATH
+    // but does not handle Qt-specific env vars — qt.conf alone is not
+    // sufficient when the host session sets QT_PLUGIN_PATH.
+    if (const QByteArray appDir = qgetenv("APPDIR"); !appDir.isEmpty())
+        qputenv("QT_PLUGIN_PATH", appDir + "/usr/plugins");
+#endif
+
     setSessionName(QString());
 
     const AppArguments args = parseArguments(argc, argv);
@@ -318,6 +328,9 @@ int startApplication(int argc, char **argv)
     // If server hasn't been run yet and no argument were specified
     // then run this process as server.
     case AppType::Server:
+        // Set before QApplication construction so portal registration and
+        // taskbar icon matching use the correct app ID.
+        QGuiApplication::setDesktopFileName(QStringLiteral("com.github.hluk.copyq"));
         return startServer(argc, argv, args.sessionName);
 
     // If argument was specified and server is running

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -78,8 +78,12 @@ QString getDesktopFilename()
     if ( QFile::exists(path) )
         return path;
 
+    const QString sessionName = qApp->property("CopyQ_session_name").toString();
+    const QString desktopName = sessionName.isEmpty()
+        ? QGuiApplication::desktopFileName()
+        : QStringLiteral("%1-%2").arg(QGuiApplication::desktopFileName(), sessionName);
     return QStringLiteral("%1/autostart/%2.desktop")
-        .arg( configDir, QGuiApplication::desktopFileName() );
+        .arg( configDir, desktopName );
 }
 #endif
 
@@ -217,7 +221,7 @@ void X11Platform::setAutostartEnabled(bool enable)
 #ifdef COPYQ_AUTOSTART_COMMAND
     QString cmd = COPYQ_AUTOSTART_COMMAND;
 #else
-    QString cmd = "\"" + applicationExecutablePath() + "\"";
+    QString cmd = "\"" + applicationLaunchPath() + "\"";
 #endif
     const QString sessionName = qApp->property("CopyQ_session_name").toString();
     if ( !sessionName.isEmpty() )

--- a/src/platform/x11/x11platformclipboard.cpp
+++ b/src/platform/x11/x11platformclipboard.cpp
@@ -642,8 +642,7 @@ void X11PlatformClipboard::setData(ClipboardMode mode, const QVariantMap &dataMa
             // See: https://invent.kde.org/frameworks/kguiaddons/-/merge_requests/184
             if (dataMap.contains(mimeTextUtf8))
                 data->setText(dataMap.value(mimeTextUtf8).toString());
-            else
-                KSystemClipboard::instance()->setMimeData(data, qmode);
+            KSystemClipboard::instance()->setMimeData(data, qmode);
         }
     }
 }


### PR DESCRIPTION
Set QT_PLUGIN_PATH to the bundled plugins directory inside AppImage to
avoid loading incompatible host Qt plugins.

Use applicationFilePath() instead of $APPIMAGE for child processes so
they reuse the parent's FUSE mount rather than creating a second one.

Call setDesktopFileName() only for the server process, before
QApplication construction, to avoid redundant portal registration in
child processes.

Bundle wayland-shell-integration, wayland-decoration-client, and
wayland-graphics-integration-client plugin directories in the AppImage.
Remove the non-functional EXTRA_QT_PLUGINS env var.

Always call KSystemClipboard::setMimeData() in the Wayland path of
X11PlatformClipboard::setData(), even when data contains mimeTextUtf8.
Previously the setText() UTF-8 workaround was in an if/else with
setMimeData(), so data containing mimeTextUtf8 never issued a
wlr-data-control set_selection — causing "Failed to provide clipboard"
in commandCopy. Also fixes a QMimeData ownership leak.

Fixes #3557

Assisted-by: Claude (Anthropic)