### PR TITLE
Strip null characters when concatenating selected items

### DIFF
--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -129,7 +129,11 @@ void appendTextData(const QVariantMap &data, const QString &mime, QByteArray *li
 
     if ( !lines->isEmpty() )
         lines->append('\n');
-    lines->append(text.toUtf8());
+    // Remove null characters to avoid truncating concatenated text
+    // when pasted into applications that treat '\0' as string terminator.
+    auto utf8 = text.toUtf8();
+    utf8.replace('\0', "");
+    lines->append(utf8);
 }
 
 void moveIndexes(QList<QPersistentModelIndex> &indexesToMove, int targetRow, ClipboardModel *model, MoveType moveType)
@@ -1797,8 +1801,11 @@ const QString ClipboardBrowser::selectedText() const
 {
     QString result;
 
-    for ( const auto &ind : selectionModel()->selectedIndexes() )
-        result += ind.data(Qt::EditRole).toString() + QString('\n');
+    for ( const auto &ind : selectionModel()->selectedIndexes() ) {
+        auto text = ind.data(Qt::EditRole).toString();
+        text.remove(QChar('\0'));
+        result += text + QString('\n');
+    }
     result.chop(1);
 
     return result;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -181,6 +181,7 @@ private slots:
     void searchManyItems();
     void copyItems();
     void selectAndCopyOrder();
+    void copyItemsNullCharacter();
 
     void sortAndReverse();
 

--- a/src/tests/tests_items.cpp
+++ b/src/tests/tests_items.cpp
@@ -262,6 +262,23 @@ void Tests::copyItems()
     RUN("size", "6\n");
 }
 
+void Tests::copyItemsNullCharacter()
+{
+    // Items with embedded null characters should have nulls stripped
+    // when concatenated for the clipboard (GitHub issue #3515).
+    const auto tab = QString(clipboardTabName);
+    RUN("write(0,"
+        "{'text/plain': 'A' + String.fromCharCode(0) + 'B'},"
+        "{'text/plain': 'CD'})", "");
+
+    // Select and copy all items.
+    KEYS("CTRL+A" << keyNameFor(QKeySequence::Copy));
+
+    // Clipboard should contain both items without null characters.
+    WAIT_ON_OUTPUT("clipboard", "CD\nAB");
+}
+
+
 void Tests::selectAndCopyOrder()
 {
     const auto tab = testTab(1);


### PR DESCRIPTION
Copying multiple selected items concatenates their text. If any item contains null characters, the concatenated clipboard data includes them, causing most applications to truncate the pasted text at the first null.

Strip null characters at the concatenation boundary so the combined text pastes correctly while preserving original item data in storage.

Fixes: https://github.com/hluk/CopyQ/issues/3515
Assisted-by: Claude (Anthropic)