### PR TITLE
Fix Wayland portal shortcuts overridden by non-default sessions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -330,7 +330,12 @@ int startApplication(int argc, char **argv)
     case AppType::Server:
         // Set before QApplication construction so portal registration and
         // taskbar icon matching use the correct app ID.
-        QGuiApplication::setDesktopFileName(QStringLiteral("com.github.hluk.copyq"));
+        if (args.sessionName.isEmpty()) {
+            QGuiApplication::setDesktopFileName(QStringLiteral("com.github.hluk.copyq"));
+        } else {
+            QGuiApplication::setDesktopFileName(
+                QStringLiteral("com.github.hluk.copyq-%1").arg(args.sessionName));
+        }
         return startServer(argc, argv, args.sessionName);
 
     // If argument was specified and server is running

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -78,12 +78,8 @@ QString getDesktopFilename()
     if ( QFile::exists(path) )
         return path;
 
-    const QString sessionName = qApp->property("CopyQ_session_name").toString();
-    const QString desktopName = sessionName.isEmpty()
-        ? QGuiApplication::desktopFileName()
-        : QStringLiteral("%1-%2").arg(QGuiApplication::desktopFileName(), sessionName);
     return QStringLiteral("%1/autostart/%2.desktop")
-        .arg( configDir, desktopName );
+        .arg( configDir, QGuiApplication::desktopFileName() );
 }
 #endif
 


### PR DESCRIPTION
Use a session-specific desktop file name so each CopyQ session registers with a distinct app ID in the Wayland portal. This prevents a second session from overwriting the global shortcuts of the first.

Remove the now-redundant manual session suffix in the autostart desktop file lookup to avoid doubling it.

Assisted-by: Claude (Anthropic)