### PR TITLE
Document focus-stealing issue with workaround

### DIFF
--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -189,8 +189,3 @@ clipboard silently. For example, the following command updates to the next item:
 The item can then be pasted with the normal system paste shortcut
 (``Ctrl+V`` or ``Cmd+V``).
 
-.. seealso::
-
-    - `Cycle Items - Quick <https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items---quick>`__
-    - `Cycle Items <https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items>`__
-    - `Issue #3540 <https://github.com/hluk/CopyQ/issues/3540>`__

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -164,18 +164,23 @@ window.  This can cause side effects in the target application such as:
 * Application menus closing
 * Auto-hide windows hiding (e.g. ConEmu Quake mode)
 
-**Workaround:** Use global shortcuts to cycle through clipboard history and
+.. seealso::
+    - `Issue #3540 <https://github.com/hluk/CopyQ/issues/3540>`__
+
+Workaround
+^^^^^^^^^^
+Use global shortcuts to cycle through clipboard history and
 paste without showing the CopyQ window.
 
 The `Cycle Items - Quick
 <https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items---quick>`__
-command previews items in popups and automatically pastes the selected item
-when the shortcut modifiers are released -- without ever opening the CopyQ
+command previews items in notifications and automatically pastes the selected item
+when the shortcut modifier(s) are released―without ever opening the main
 window.
 
 A simpler alternative is to assign a global shortcut to ``next()`` or
-``previous()``, which cycle through clipboard history and update the system
-clipboard silently:
+``previous()``. These functions cycle through clipboard history and update the system
+clipboard silently. For example, the following command updates to the next item:
 
 .. code-block:: js
 

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -188,4 +188,3 @@ clipboard silently. For example, the following command updates to the next item:
 
 The item can then be pasted with the normal system paste shortcut
 (``Ctrl+V`` or ``Cmd+V``).
-

--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -147,3 +147,45 @@ An alternative under Windows is to use a Powershell script to override the ``cop
     Name=Override copy()
 
 The delays are added to make sure no focus issues occur and the text is copied to the clipboard.
+
+
+.. _known-issue-focus-stealing:
+
+CopyQ steals keyboard focus when showing window or menu
+-------------------------------------------------------
+
+When CopyQ shows its main window or tray menu (via global shortcut, tray icon
+click, or script), it transfers keyboard focus from the previously active
+window.  This can cause side effects in the target application such as:
+
+* File renames aborting (e.g. pressing F2 in file managers)
+* Combo boxes selecting all their content
+* Short-lived widgets dismissing (Start menu, PowerToys, extension dialogs)
+* Application menus closing
+* Auto-hide windows hiding (e.g. ConEmu Quake mode)
+
+**Workaround:** Use global shortcuts to cycle through clipboard history and
+paste without showing the CopyQ window.
+
+The `Cycle Items - Quick
+<https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items---quick>`__
+command previews items in popups and automatically pastes the selected item
+when the shortcut modifiers are released -- without ever opening the CopyQ
+window.
+
+A simpler alternative is to assign a global shortcut to ``next()`` or
+``previous()``, which cycle through clipboard history and update the system
+clipboard silently:
+
+.. code-block:: js
+
+    next()
+
+The item can then be pasted with the normal system paste shortcut
+(``Ctrl+V`` or ``Cmd+V``).
+
+.. seealso::
+
+    - `Cycle Items - Quick <https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items---quick>`__
+    - `Cycle Items <https://github.com/hluk/copyq-commands/blob/master/README.md#cycle-items>`__
+    - `Issue #3540 <https://github.com/hluk/CopyQ/issues/3540>`__


### PR DESCRIPTION
When CopyQ shows its main window or tray menu, it steals keyboard focus
from the previously active window. This can cause side effects such as
file renames aborting, combo boxes selecting content, and short-lived
widgets dismissing.

Add a known-issues.rst section documenting the problem and a practical
workaround: use next()/previous() global shortcuts to cycle clipboard
history without opening any window.

Closes: https://github.com/hluk/CopyQ/issues/3540

Assisted-by: Claude (Anthropic)