### PR TITLE
Fix -Wsfinae-incomplete warning for incomplete type in signal parameter

### DIFF
--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -18,7 +18,6 @@
 
 class ItemEditorWidget;
 class ItemFactory;
-class PersistentDisplayItem;
 class QPersistentModelIndex;
 class QProgressBar;
 class QPushButton;

--- a/src/item/itemdelegate.h
+++ b/src/item/itemdelegate.h
@@ -4,6 +4,7 @@
 
 
 #include "gui/clipboardbrowsershared.h"
+#include "item/persistentdisplayitem.h"
 
 #include <QItemDelegate>
 #include <QTimer>
@@ -17,7 +18,6 @@ class ItemEditorWidget;
 class ItemFactory;
 class ItemFilter;
 class ItemWidget;
-class PersistentDisplayItem;
 using ItemFilterPtr = std::shared_ptr<ItemFilter>;
 
 constexpr int defaultItemHeight = 100;


### PR DESCRIPTION
Replace forward declaration with full include in header that declares a signal using the type, so MOC-generated meta-type registration sees the complete definition.

Assisted-by: Claude (Anthropic)