### PR TITLE
Add StartupNotify=false to desktop entry to prevent busy cursor

### DIFF
--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -120,6 +120,22 @@ For **Flatpak** application, see `this workaround
 
     `Issue #27 <https://github.com/hluk/CopyQ/issues/27>`__
 
+
+.. _known-issue-gnome-busy-cursor:
+
+On GNOME, busy cursor after selecting tray menu item
+----------------------------------------------------
+
+When using the AppIndicator/KStatusNotifierItem GNOME Shell extension, selecting
+an item from the CopyQ tray menu may cause a busy cursor for about 15 seconds.
+This is a bug in the extension — it triggers startup notification unconditionally
+without checking the application's ``StartupNotify`` desktop entry key.
+
+.. seealso::
+
+    - `Issue #3586 <https://github.com/hluk/CopyQ/issues/3586>`__
+    - `AppIndicator extension issue #443
+      <https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/443>`__
 Scripting command "copy()" fails
 --------------------------------
 

--- a/shared/com.github.hluk.copyq.desktop.in
+++ b/shared/com.github.hluk.copyq.desktop.in
@@ -8,6 +8,7 @@ X-GNOME-Autostart-Delay=3
 # The rest is taken from Klipper application.
 Type=Application
 Terminal=false
+StartupNotify=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 X-KDE-UniqueApplet=true

--- a/src/platform/x11/x11platform.cpp
+++ b/src/platform/x11/x11platform.cpp
@@ -39,6 +39,7 @@ Icon=copyq
 GenericName=Clipboard Manager
 Type=Application
 Terminal=false
+StartupNotify=false
 X-KDE-autostart-after=panel
 X-KDE-StartupNotify=false
 X-KDE-UniqueApplet=true


### PR DESCRIPTION
On GNOME with the AppIndicator extension, selecting a tray menu item triggers the startup notification protocol, showing a busy cursor for ~15 seconds. Adding StartupNotify=false declares that CopyQ does not participate in startup notification, which is the correct Freedesktop declaration for a clipboard manager that does not open windows on activation.

Closes #3586

Assisted-by: Claude (Anthropic)