### PR TITLE
Fix thumbnails hidden for tagged image items with show_simple_items

### DIFF
--- a/src/item/itemfactory.cpp
+++ b/src/item/itemfactory.cpp
@@ -173,7 +173,7 @@ public:
 
     void setTagged(bool tagged) override
     {
-        setVisible( !tagged || (m_hasText && !m_data.contains(mimeHidden)) );
+        setVisible( !tagged || ((m_hasText || hasPixmap()) && !m_data.contains(mimeHidden)) );
     }
 
 private:


### PR DESCRIPTION
When show_simple_items is enabled and an image item gets tagged (e.g. by autocommands storing copy time or window title), the item becomes invisible because the visibility check only considers text content. Include image content in the check so tagged image items remain visible.

Fixes #3578

Assisted-by: Claude (Anthropic)