### PR TITLE
docs: update Wayland known issues section

### DIFF
--- a/docs/known-issues.rst
+++ b/docs/known-issues.rst
@@ -66,43 +66,87 @@ installed or updated.
 On GNOME, new clipboard is not stored
 -------------------------------------
 
-The app requires CopyQ Clipboard Monitor GNOME extension to be enabled so it
-can watch clipboard changes and store them. The GNOME extension can be
-installed with CopyQ 14.0.0.
+The app requires the CopyQ Clipboard Monitor GNOME Shell extension to be
+enabled so it can watch clipboard changes and store them. The extension is
+shipped with CopyQ 14.0.0 and later.
+
+.. note::
+
+    The GNOME extension is only available when CopyQ is installed on the system
+    (e.g. from a package manager). It will **not** work when running CopyQ as a
+    Flatpak or AppImage because the extension cannot be registered with the
+    GNOME Shell from a sandboxed environment.
+
+.. seealso::
+
+    :ref:`known-issue-wayland`
 
 .. _known-issue-wayland:
 
-On Linux, global shortcuts, pasting or clipboard monitoring does not work
--------------------------------------------------------------------------
+On Linux, some features do not work under Wayland
+--------------------------------------------------
 
-This can be caused by running CopyQ under a **Wayland** window manager instead
-of the X11 server.
+When running CopyQ under a **Wayland** compositor, some features may not work
+depending on the desktop environment and the protocols it supports.
 
-Depending on the desktop environment, these features may not be supported:
+**Global shortcuts** work natively if the desktop environment provides
+Portal support (``xdg-desktop-portal``).
 
-- global shortcuts
-- clipboard monitoring
-- pasting from CopyQ and issuing copy command to other apps (that is passing
-  shortcuts to application)
+**Clipboard monitoring** works natively if the compositor supports the required
+Wayland protocol. This works on KDE Plasma, Sway, Hyprland and other
+wlroots-based compositors. On **GNOME**, this protocol is not supported, but
+CopyQ ships a GNOME Shell extension that provides clipboard monitoring instead
+(see :ref:`known-issue-gnome`). If clipboard monitoring does not work with
+either method, see :ref:`wayland-xwayland-fallback` below.
+
+Querying **state of keyboard modifiers** (for example pressed Shift, Ctrl etc.
+which can be useful for some custom commands) and **mouse position** (useful
+for positioning menus) **does not work** on Wayland.
+
+See the subsections below for other fixes.
+
+Workaround: Wayland Support command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This can fix (depending on the desktop environment and installed tools):
+
+- pasting from CopyQ and issuing copy commands to other apps
 - screenshot functionality
 - retrieving and matching window titles
-- querying keyboard modifiers and mouse position
 
-**Workaround:** try using the **Wayland Support** command mentioned below or
-set ``QT_QPA_PLATFORM`` environment variable to run the app under **Xwayland**
-mode (additional package may be needed, for example:
-``xorg-x11-server-Xwayland`` in Fedora).
+Install the `Wayland Support
+<https://github.com/hluk/copyq-commands/tree/master#wayland-support>`__
+command to fix the features. It also requires some external tools to be
+installed on the system.
 
-For example, launch CopyQ with::
+.. _wayland-xwayland-fallback:
+
+Workaround: running under XWayland
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This can fix:
+
+- clipboard monitoring
+- setting and restoring window position (only window size is supported by most
+  Wayland compositors natively)
+
+Setting ``QT_QPA_PLATFORM=xcb`` environment variable forces CopyQ to run under
+XWayland mode. Unfortunately, it can cause clipboard monitoring to fail when
+the main window is closed, X11 connection errors, and other issues depending on
+the XWayland implementation.
+
+To start CopyQ under XWayland, use:
+
+.. code-block:: bash
 
     env QT_QPA_PLATFORM=xcb copyq
 
-If CopyQ autostarts, you can change ``Exec=...`` line in
+If CopyQ autostarts, you can change the ``Exec=...`` line in
 ``~/.config/autostart/copyq.desktop``::
 
     Exec=env QT_QPA_PLATFORM=xcb copyq
 
-For **Flatpak** application, see `this workaround
+For the **Flatpak** application, see `this workaround
 <https://github.com/hluk/CopyQ/issues/2948#issuecomment-2614271330>`__.
 
 .. note::
@@ -112,13 +156,10 @@ For **Flatpak** application, see `this workaround
 
 .. seealso::
 
-    `Wayland Support
-    <https://github.com/hluk/copyq-commands/tree/master/Scripts#wayland-support>`__
-    command reimplements some features on Wayland through external tools (see
-    `README <https://github.com/hluk/copyq-commands/blob/master/README.md>`__
-    for details on how to add the command).
-
     `Issue #27 <https://github.com/hluk/CopyQ/issues/27>`__
+
+    `Issue #3587 <https://github.com/hluk/CopyQ/issues/3587>`__
+    — ``QT_QPA_PLATFORM=xcb`` can break clipboard monitoring
 
 
 .. _known-issue-gnome-busy-cursor:


### PR DESCRIPTION
Recommend Wayland Support command as primary workaround instead of QT_QPA_PLATFORM=xcb. Demote XWayland fallback to last resort with a warning about clipboard monitoring failure (#3587). Document native support for global shortcuts (Portal) and clipboard monitoring (ext_data_control protocol). Add Flatpak/AppImage caveat for the GNOME extension.

Assisted-by: Claude (Anthropic)