### PR TITLE
Fix Flatpak installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,8 @@ chmod +x CopyQ-*.AppImage
 ```
 
 Alternatively, install [Flatpak](https://flatpak.org/) and `com.github.hluk.copyq` from
-[Flathub](https://flathub.org/).
-
-```bash
-flatpak install flathub com.github.hluk.copyq
-```
+[Flathub](https://flathub.org/apps/com.github.hluk.copyq).
+See [Flathub Setup](https://flathub.org/setup) for initial Flatpak/Flathub configuration.
 
 Start CopyQ from the menu or with the following command:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,12 +61,13 @@ On other Linux distributions, you can download the **AppImage** from the
     chmod +x CopyQ-*.AppImage
     ./CopyQ-*.AppImage
 
-Alternatively, you can use `Flatpak <https://flatpak.org/>`__ to install the app:
+Alternatively, you can use `Flatpak <https://flatpak.org/>`__ to install
+`CopyQ from Flathub <https://flathub.org/apps/com.github.hluk.copyq>`__.
+See `Flathub Setup <https://flathub.org/setup>`__ for initial Flatpak/Flathub
+configuration.
+
+To start CopyQ from the command line:
 
 .. code-block:: bash
 
-    # Install from Flathub.
-    flatpak install --user --from https://flathub.org/repo/appstream/com.github.hluk.copyq.flatpakref
-
-    # Run the app.
     flatpak run com.github.hluk.copyq


### PR DESCRIPTION
Point to the Flathub app page and setup guide instead of assuming the Flathub remote is already configured.

Fixes https://github.com/hluk/CopyQ/issues/3596

Assisted-by: Claude (Anthropic)