### PR TITLE
Fix release artifact downloads in CI workflows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -70,6 +70,8 @@ jobs:
   build:
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     strategy:
@@ -392,21 +394,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      APPIMAGE: CopyQ-${{ needs.build.outputs.version }}-x86_64.AppImage
     steps:
-      - name: Download artifacts
+      - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: 'CopyQ-*.AppImage'
+          name: ${{ env.APPIMAGE }}
+          skip-decompress: true
 
       - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" CopyQ-*/*.AppImage --clobber
+          gh release upload "$GITHUB_REF_NAME" "$APPIMAGE" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,6 +25,8 @@ jobs:
   build:
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
     strategy:
@@ -152,19 +154,31 @@ jobs:
 
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      DMG_INTEL: CopyQ-${{ needs.build.outputs.version }}-macos-13.dmg
+      DMG_ARM: CopyQ-${{ needs.build.outputs.version }}-macos-12-m1.dmg
     steps:
-      - name: Download artifacts
+      - name: Download Intel DMG
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.DMG_INTEL }}
+          skip-decompress: true
+
+      - name: Download ARM DMG
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.DMG_ARM }}
+          skip-decompress: true
 
       - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" CopyQ-*/*.dmg --clobber
+          gh release upload "$GITHUB_REF_NAME" "$DMG_INTEL" "$DMG_ARM" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,6 +31,8 @@ jobs:
   build:
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     name: Windows
     runs-on: windows-2025
     defaults:
@@ -221,21 +223,32 @@ jobs:
           path: copyq-${{ steps.version.outputs.version }}-tests
           archive: true
 
-
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      PORTABLE_ZIP: copyq-${{ needs.build.outputs.version }}.zip
+      INSTALLER: copyq-${{ needs.build.outputs.version }}-setup.exe
     steps:
-      - name: Download artifacts
+      - name: Download portable zip
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.PORTABLE_ZIP }}
+          skip-decompress: true
+
+      - name: Download installer
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.INSTALLER }}
+          skip-decompress: true
 
       - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" copyq-*/*.zip copyq-*/*.exe --clobber
+          gh release upload "$GITHUB_REF_NAME" "$PORTABLE_ZIP" "$INSTALLER" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
The v16.0.0 release failed on Linux and Windows because glob patterns used to download and match artifacts were unreliable.

Replace globs with exact artifact names derived from the build version output, and always run the release job so downloads are verified on every CI run, not just tag pushes.

Assisted-by: Claude (Anthropic)