### PR TITLE
Remove release jobs from CI; create releases solely via draft-release.sh

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -392,26 +392,3 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      APPIMAGE: CopyQ-${{ needs.build.outputs.version }}-x86_64.AppImage
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.APPIMAGE }}
-          skip-decompress: true
-
-      - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" "$APPIMAGE" --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -151,34 +151,3 @@ jobs:
           name: 'crash-reports${{ matrix.bundle_suffix }}'
           path: '~/Library/Logs/DiagnosticReports/*'
           if-no-files-found: ignore
-
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      DMG_INTEL: CopyQ-${{ needs.build.outputs.version }}-macos-13.dmg
-      DMG_ARM: CopyQ-${{ needs.build.outputs.version }}-macos-12-m1.dmg
-    steps:
-      - name: Download Intel DMG
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.DMG_INTEL }}
-          skip-decompress: true
-
-      - name: Download ARM DMG
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.DMG_ARM }}
-          skip-decompress: true
-
-      - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" "$DMG_INTEL" "$DMG_ARM" --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -222,33 +222,3 @@ jobs:
           name: copyq-${{ steps.version.outputs.version }}-tests.zip
           path: copyq-${{ steps.version.outputs.version }}-tests
           archive: true
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      PORTABLE_ZIP: copyq-${{ needs.build.outputs.version }}.zip
-      INSTALLER: copyq-${{ needs.build.outputs.version }}-setup.exe
-    steps:
-      - name: Download portable zip
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.PORTABLE_ZIP }}
-          skip-decompress: true
-
-      - name: Download installer
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ env.INSTALLER }}
-          skip-decompress: true
-
-      - name: Upload to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          gh release create "$GITHUB_REF_NAME" --draft --notes "" 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" "$PORTABLE_ZIP" "$INSTALLER" --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}

--- a/utils/github/draft-release.sh
+++ b/utils/github/draft-release.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
 #
-# Drafts a GitHub release for the latest tag.
+# Creates a draft GitHub release for the latest tag with all artifacts.
 #
+# This is the single entry point for release creation.  CI workflows
+# (build-linux.yml, build-macos.yml, build-windows.yml) only build and
+# store workflow artifacts via actions/upload-artifact.  This script:
 #
-# CI workflows (build-linux.yml, build-macos.yml, build-windows.yml) attach
-# .AppImage, .dmg, .zip, and .exe files to the draft release directly. This
-# script adds: source
-# tarball, checksums-sha512.txt, and cosign.bundle.
+#   1. Validates version / tag / CHANGES.md
+#   2. Extracts the changelog body
+#   3. Creates a source tarball
+#   4. Waits for CI workflow runs to complete
+#   5. Downloads workflow artifacts locally
+#   6. Verifies all expected files are present
+#   7. Generates checksums and cosign signature
+#   8. Creates (or updates) the draft release
+#   9. Uploads ALL assets in one shot
+#
+# Idempotency: reuse the same WORKDIR to resume an interrupted run.
+# Each step skips work that is already done.
 #
 # Requirements:
 #   - gh CLI (authenticated)
@@ -19,7 +30,6 @@
 #
 #   VERSION  Expected version, e.g. 14.0.0. Must match the latest git tag.
 #   WORKDIR  Directory for artifacts (default: ./release-VERSION).
-#            Reuse the same directory to resume an interrupted run.
 
 set -euo pipefail
 
@@ -27,7 +37,9 @@ set -euo pipefail
 die() { printf 'Error: %s\n' "$1" >&2; exit 1; }
 log() { printf '==> %s\n' "$1" >&2; }
 
-# resolve repo root and validate version against latest tag
+# ---------------------------------------------------------------------------
+# Validate version and tag
+# ---------------------------------------------------------------------------
 
 repo_root="$(git rev-parse --show-toplevel)"
 changes_file="$repo_root/CHANGES.md"
@@ -53,7 +65,9 @@ mkdir -p "$workdir"
 workdir="$(cd "$workdir" && pwd)"
 log "Working directory: $workdir"
 
-# extract changelog and create/update draft release
+# ---------------------------------------------------------------------------
+# Extract changelog
+# ---------------------------------------------------------------------------
 
 extract_changelog() {
     awk -v ver="$version" '
@@ -71,15 +85,9 @@ changelog_body="$(extract_changelog)"
 [[ -n "$changelog_body" ]] || die "No changelog entry for version $version in CHANGES.md"
 log "Extracted changelog ($(echo "$changelog_body" | wc -l) lines)"
 
-if gh release view "$tag" --json tagName >/dev/null 2>&1; then
-    log "Release $tag exists — updating title and body"
-    gh release edit "$tag" --draft --title "$version" --notes "$changelog_body"
-else
-    log "Creating draft release for $tag"
-    gh release create "$tag" --draft --title "$version" --notes "$changelog_body"
-fi
-
-# create source tarball and upload
+# ---------------------------------------------------------------------------
+# Create source tarball (skip if exists)
+# ---------------------------------------------------------------------------
 
 source_tarball="$workdir/CopyQ-$version.tar.gz"
 if [[ -f "$source_tarball" ]]; then
@@ -90,10 +98,9 @@ else
         --prefix="CopyQ-$version/" --output="$source_tarball" "$tag"
 fi
 
-log "Uploading source tarball to release $tag ..."
-gh release upload "$tag" "$source_tarball" --clobber
-
-# wait for CI build artifacts on the release
+# ---------------------------------------------------------------------------
+# Wait for CI builds and download artifacts
+# ---------------------------------------------------------------------------
 
 expected_assets=(
     "CopyQ-${version}-x86_64.AppImage"
@@ -103,66 +110,86 @@ expected_assets=(
     "copyq-${version}.zip"
 )
 
-wait_for_builds() {
-    local tag_sha
-    tag_sha="$(git rev-list -n 1 "$tag")"
-    if [[ -z "$tag_sha" ]]; then
-        die "Could not resolve commit SHA for tag $tag"
-    fi
-
-    log "Getting Linux build run for tag $tag (commit $tag_sha)..."
-    local linux_run
-    linux_run="$(gh run list --workflow build-linux.yml --commit "$tag_sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-    if [[ -z "$linux_run" ]]; then
-        die "Could not find Linux build run for commit $tag_sha"
-    fi
-    log "Watching Linux build (run $linux_run)..."
-    gh run watch "$linux_run" --exit-status --interval 30 || die "Linux build failed"
-
-    log "Getting macOS build run for tag $tag (commit $tag_sha)..."
-    local macos_run
-    macos_run="$(gh run list --workflow build-macos.yml --commit "$tag_sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-    if [[ -z "$macos_run" ]]; then
-        die "Could not find macOS build run for commit $tag_sha"
-    fi
-    log "Watching macOS build (run $macos_run)..."
-    gh run watch "$macos_run" --exit-status --interval 30 || die "macOS build failed"
-
-    log "Getting Windows build run for tag $tag (commit $tag_sha)..."
-    local windows_run
-    windows_run="$(gh run list --workflow build-windows.yml --commit "$tag_sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-    if [[ -z "$windows_run" ]]; then
-        die "Could not find Windows build run for commit $tag_sha"
-    fi
-    log "Watching Windows build (run $windows_run)..."
-    gh run watch "$windows_run" --exit-status --interval 30 || die "Windows build failed"
-    log "All builds completed successfully"
+# Resolve the workflow run ID for a given workflow file.
+get_run_id() {
+    local workflow="$1"
+    local tag_sha="$2"
+    gh run list --workflow "$workflow" --commit "$tag_sha" \
+        --limit 1 --json databaseId --jq '.[0].databaseId // empty'
 }
 
-has_all_assets() {
-    local assets
-    assets="$(gh release view "$tag" --json assets --jq '.assets[].name')"
-    for name in "${expected_assets[@]}"; do
-        if ! echo "$assets" | grep -qxF "$name"; then
-            return 1
+# Download all artifacts from a workflow run, flattening into $workdir.
+# gh run download creates subdirectories named after each artifact;
+# we move files up one level into $workdir.
+download_run_artifacts() {
+    local run_id="$1"
+    local tmpdir="$workdir/.dl-$$"
+    mkdir -p "$tmpdir"
+
+    gh run download "$run_id" --dir "$tmpdir" 2>/dev/null || true
+
+    # Flatten: move files from subdirectories into $workdir
+    find "$tmpdir" -mindepth 2 -type f | while IFS= read -r f; do
+        local base
+        base="$(basename "$f")"
+        if [[ ! -f "$workdir/$base" ]]; then
+            mv "$f" "$workdir/$base"
+            log "  Downloaded: $base"
         fi
+    done
+
+    rm -rf "$tmpdir"
+}
+
+wait_and_download() {
+    local tag_sha
+    tag_sha="$(git rev-list -n 1 "$tag")"
+    [[ -n "$tag_sha" ]] || die "Could not resolve commit SHA for tag $tag"
+
+    local workflows=("build-linux.yml" "build-macos.yml" "build-windows.yml")
+    local run_ids=()
+
+    for wf in "${workflows[@]}"; do
+        log "Getting run for $wf (commit $tag_sha) ..."
+        local run_id
+        run_id="$(get_run_id "$wf" "$tag_sha")"
+        [[ -n "$run_id" ]] || die "Could not find run for $wf at commit $tag_sha"
+        run_ids+=("$run_id")
+    done
+
+    for i in "${!workflows[@]}"; do
+        log "Watching ${workflows[$i]} (run ${run_ids[$i]}) ..."
+        gh run watch "${run_ids[$i]}" --exit-status --interval 30 \
+            || die "${workflows[$i]} failed"
+        log "Downloading artifacts from ${workflows[$i]} ..."
+        download_run_artifacts "${run_ids[$i]}"
+    done
+
+    log "All builds completed and artifacts downloaded"
+}
+
+# Check if all expected assets exist locally.
+has_all_local() {
+    for name in "${expected_assets[@]}"; do
+        [[ -f "$workdir/$name" ]] || return 1
     done
     return 0
 }
 
-if has_all_assets; then
-    log "All expected build artifacts already on the release"
+if has_all_local; then
+    log "All expected build artifacts already in $workdir"
 else
-    wait_for_builds
-    if ! has_all_assets; then
-        log "Current release assets:"
-        gh release view "$tag" --json assets --jq '.assets[].name' >&2
-        die "CI builds completed but not all expected assets were uploaded to the release"
+    wait_and_download
+    if ! has_all_local; then
+        log "Files in $workdir:"
+        ls -1 "$workdir" >&2
+        die "CI artifacts downloaded but not all expected files are present"
     fi
-    log "All expected build artifacts are now on the release"
 fi
 
-# download assets, checksum, and sign
+# ---------------------------------------------------------------------------
+# Checksums and cosign signature (skip if cosign.bundle exists)
+# ---------------------------------------------------------------------------
 
 all_assets=(
     "CopyQ-${version}.tar.gz"
@@ -175,12 +202,6 @@ cosign_bundle="$workdir/cosign.bundle"
 if [[ -f "$cosign_bundle" ]]; then
     log "Checksums and signature already exist"
 else
-    log "Downloading release assets ..."
-    for name in "${expected_assets[@]}"; do
-        gh release download "$tag" --dir "$workdir" --clobber \
-            --pattern "$name"
-    done
-
     log "Generating checksums ..."
     (
         cd "$workdir"
@@ -198,13 +219,30 @@ else
     log "Signature verified"
 fi
 
-# upload checksums and signature
+# ---------------------------------------------------------------------------
+# Create or update the draft release
+# ---------------------------------------------------------------------------
 
-log "Uploading checksums and signature to release $tag ..."
-gh release upload "$tag" \
-    "$checksums_file" \
-    "$cosign_bundle" \
-    --clobber
+if gh release view "$tag" --json tagName >/dev/null 2>&1; then
+    log "Release $tag exists — updating title and body"
+    gh release edit "$tag" --draft --title "$version" --notes "$changelog_body"
+else
+    log "Creating draft release for $tag"
+    gh release create "$tag" --draft --title "$version" --notes "$changelog_body"
+fi
+
+# ---------------------------------------------------------------------------
+# Upload all assets
+# ---------------------------------------------------------------------------
+
+upload_files=("$source_tarball")
+for name in "${expected_assets[@]}"; do
+    upload_files+=("$workdir/$name")
+done
+upload_files+=("$checksums_file" "$cosign_bundle")
+
+log "Uploading ${#upload_files[@]} assets to release $tag ..."
+gh release upload "$tag" "${upload_files[@]}" --clobber
 
 log "Done: $(gh release view "$tag" --json url --jq '.url')"
 log ""


### PR DESCRIPTION
CI workflows now only build and upload workflow artifacts. The
draft-release.sh script handles waiting for builds, downloading
artifacts, checksumming, signing, creating the draft release, and
uploading all assets in one shot.

Assisted-by: Claude (Anthropic)