### PR TITLE
Windows: Fix blank window in RDP sessions

### DIFF
--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -298,6 +298,9 @@ bool WinPlatform::setPreventScreenCapture(WId winId, bool prevent)
     // Remote desktop clients are screen capture systems — applying
     // WDA_EXCLUDEFROMCAPTURE makes windows invisible to the remote viewer.
     if (prevent && GetSystemMetrics(SM_REMOTESESSION)) {
+        if (!SetWindowDisplayAffinity(window, WDA_NONE))
+            log("Failed to clear display affinity in remote session", LogWarning);
+
         static bool logged = false;
         if (!logged) {
             logged = true;
@@ -317,7 +320,6 @@ bool WinPlatform::setPreventScreenCapture(WId winId, bool prevent)
             }
         }
 
-        SetWindowDisplayAffinity(window, WDA_NONE);
         return false;
     }
 


### PR DESCRIPTION
Clear the window display affinity before showing the warning dialog
so the window is visible during the dialog's nested event loop.
Remove the Settings-based persistence of the warning acknowledgment.

Fixes #3621

Assisted-by: Claude (Anthropic)