### PR TITLE
Fix spurious QString::arg warnings on KDE Plasma

### DIFF
--- a/src/gui/iconfactory.cpp
+++ b/src/gui/iconfactory.cpp
@@ -520,6 +520,14 @@ public:
         return new AppIconEngine(*this);
     }
 
+    // Return the theme icon name so that platform integrations (e.g. KDE
+    // Plasma) can identify the icon directly instead of falling back to
+    // glob-based lookups that produce spurious QString::arg warnings.
+    QString iconName() override
+    {
+        return QStringLiteral(COPYQ_ICON_NAME);
+    }
+
     QPixmap doCreatePixmap(QSize size, QIcon::Mode, QIcon::State, QPainter *) override
     {
         // If copyq-normal icon exist in theme, omit changing color.


### PR DESCRIPTION
Override iconName() in the app icon engine to return the theme icon name, allowing platform integrations to resolve the icon directly instead of falling back to glob-based lookups.

Fixes #3632

Assisted-by: Claude (Anthropic)