### PR TITLE
Disable IM unconditionally at FakeVim install time

### DIFF
--- a/plugins/itemfakevim/itemfakevim.cpp
+++ b/plugins/itemfakevim/itemfakevim.cpp
@@ -14,7 +14,6 @@ using namespace FakeVim::Internal;
 #include <QMessageBox>
 #include <QMetaMethod>
 #include <QKeyEvent>
-#include <QInputMethodEvent>
 #include <QProcess>
 #include <QPaintEvent>
 #include <QPainter>
@@ -164,33 +163,26 @@ public:
         m_handler->installEventFilter();
         m_handler->setupWidget();
         m_handler->enterCommandMode();
-    }
-
-    void setInsertMode(bool insertMode)
-    {
-        m_insertMode = insertMode;
-        m_textEditWidget->setAttribute(Qt::WA_InputMethodEnabled, insertMode);
+        // Disable input method so the platform IM framework (ibus, fcitx,
+        // Wayland text-input) does not intercept key presses.  With IM
+        // enabled, presses arrive as QInputMethodEvents instead of
+        // QKeyEvents, which bypasses FakeVim's key handler and breaks
+        // undo grouping (each character becomes a separate undo step)
+        // and visual-block insert replay.
+        m_textEditWidget->setAttribute(Qt::WA_InputMethodEnabled, false);
     }
 
     bool eventFilter(QObject *obj, QEvent *ev) override
     {
-        // Block all input method events in command mode.
-        // On Wayland compositors with press-and-hold for alternative
-        // characters (KDE Plasma 6.7+), key events are intercepted at the
-        // compositor level. Preedit events trigger an alternatives popup,
-        // and commit events insert text — both bypass FakeVim's QKeyEvent
-        // filter. Block the entire IM interaction in command mode and
-        // route any committed text through FakeVim's input handler.
-        if (obj == m_textEditWidget && !m_insertMode) {
-            if (ev->type() == QEvent::InputMethod) {
-                auto *imEvent = static_cast<QInputMethodEvent *>(ev);
-                const QString text = imEvent->commitString();
-                if (!text.isEmpty())
-                    m_handler->handleInput(text);
-                return true;
-            }
-            if (ev->type() == QEvent::InputMethodQuery)
-                return true;
+        // Block input method events unconditionally.  Disabling
+        // WA_InputMethodEnabled is not sufficient on Wayland where the
+        // compositor can still deliver IM events via the text-input
+        // protocol.  Letting them through would bypass FakeVim's
+        // QKeyEvent handler and insert raw text into the document.
+        if (ev->type() == QEvent::InputMethod
+            || ev->type() == QEvent::InputMethodQuery)
+        {
+            return true;
         }
 
         // Handle completion popup.
@@ -441,7 +433,6 @@ private:
 
     bool m_hasBlockSelection = false;
 
-    bool m_insertMode = false;
 
     using Selection = QAbstractTextDocumentLayout::Selection;
     using SelectionList = QVector<Selection>;
@@ -681,7 +672,7 @@ private:
     QLabel *m_statusBarIcon;
 };
 
-void connectSignals(FakeVimHandler *handler, Proxy *proxy, TextEditWrapper *wrapper)
+void connectSignals(FakeVimHandler *handler, Proxy *proxy)
 {
     handler->commandBufferChanged
             .set([proxy](const QString &contents, int cursorPos, int anchorPos, int messageLevel) {
@@ -743,11 +734,6 @@ void connectSignals(FakeVimHandler *handler, Proxy *proxy, TextEditWrapper *wrap
             *output = QString::fromLocal8Bit(proc.readAllStandardOutput());
         }
     );
-    handler->modeChanged.set(
-        [wrapper](bool insertMode) {
-            wrapper->setInsertMode(insertMode);
-        }
-    );
 }
 
 bool installEditor(QAbstractScrollArea *textEdit, const QString &sourceFileName, ItemFakeVimLoader *loader)
@@ -767,7 +753,7 @@ bool installEditor(QAbstractScrollArea *textEdit, const QString &sourceFileName,
 
     // Connect slots to FakeVimHandler signals.
     auto proxy = new Proxy(wrapper, statusBar, wrapper);
-    connectSignals( &wrapper->fakeVimHandler(), proxy, wrapper );
+    connectSignals( &wrapper->fakeVimHandler(), proxy );
 
     wrapper->install();
 

--- a/src/tests/itemfakevimtests.cpp
+++ b/src/tests/itemfakevimtests.cpp
@@ -83,6 +83,12 @@ void ItemFakeVimTests::blockSelection()
     RUN(args << "edit" << "0", "");
     KEYS(":ggl" << FAKEVIM_CTRL "+V" << ":jjs_" << "ESC" << "::wq" << "ENTER");
     RUN(args << "read" << "0", "A_C\nD_F\nG_I");
+
+    // Test block insert with 'I' command.
+    // Start from "A_C\nD_F\nG_I" (result of previous 's' test).
+    RUN(args << "edit" << "0", "");
+    KEYS(":ggl" << FAKEVIM_CTRL "+V" << ":jjI_" << "ESC" << "::wq" << "ENTER");
+    RUN(args << "read" << "0", "A__C\nD__F\nG__I");
 }
 
 void ItemFakeVimTests::search()
@@ -133,4 +139,16 @@ void ItemFakeVimTests::incDecNumbers()
     RUN(args << "edit" << "0", "");
     KEYS("l" << "2" << FAKEVIM_CTRL "+x" << "l" << "3" << FAKEVIM_CTRL "+x" << "F2");
     RUN(args << "read" << "0", "1 -1 -2");
+}
+
+void ItemFakeVimTests::undoGroupsInsertSession()
+{
+    const QString tab1 = testTab(1);
+    const Args args = Args() << "tab" << tab1;
+
+    // Type "Hello" in insert mode, then undo in the same session.
+    // Undo should remove the entire insert session, not just one character.
+    RUN(args << "edit", "");
+    KEYS(":iHello" << "ESC" << ":u:wq" << "ENTER");
+    RUN(args << "read" << "0", "");
 }

--- a/src/tests/itemfakevimtests.h
+++ b/src/tests/itemfakevimtests.h
@@ -29,6 +29,8 @@ private slots:
 
     void incDecNumbers();
 
+    void undoGroupsInsertSession();
+
 private:
     TestInterfacePtr m_test;
 };


### PR DESCRIPTION
Disable WA_InputMethodEnabled once in TextEditWrapper::install() and block QEvent::InputMethod/InputMethodQuery in eventFilter(). The attribute alone is insufficient on Wayland where the compositor can still deliver IM events via the text-input protocol.  Together these prevent the platform IM framework from intercepting key presses, which broke undo grouping (each character became a separate undo step) and visual-block insert replay.

Remove the per-mode-change workarounds that were insufficient:
- setInsertMode() method and m_insertMode member
- modeChanged signal connection
- QInputMethodEvent include

Assisted-by: Claude (Anthropic)