### PR TITLE
docs: add Windows-specific launch instructions and fix OS X to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ flatpak run com.github.hluk.copyq
 
 ## Using the App
 
-To start CopyQ, double-click the program icon or run `copyq`.
+To start CopyQ, double-click the program icon or run `copyq` (on Windows, run `CopyQ.exe`, or launch it from the Start menu; no desktop icon is created by default).
 
 The list with the clipboard history is accessible by clicking on the system tray icon
 or by running `copyq toggle`.

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -6,8 +6,9 @@ This page describes the basic functionality of CopyQ clipboard manager.
 First Start
 -----------
 
-To start CopyQ, double-click the program icon or run command ``copyq``.
-This starts the graphical interface which can be accessed from the tray (NOTE: on OS X the tray defaults to the top-right of the screen and is not to be confused with Launchpad).
+To start CopyQ, double-click the program icon or run command ``copyq``
+(on Windows, run ``CopyQ.exe`` directly or launch it from the Start menu; no desktop icon is created by default).
+This starts the graphical interface which can be accessed from the tray (NOTE: on macOS the tray defaults to the top-right of the screen and is not to be confused with Launchpad).
 Click the tray icon to show application window or right-click the tray icon and select "Show/Hide" or run ``copyq show`` command.
 
 .. image:: images/copyq-show.png


### PR DESCRIPTION
Fixes #3354

- Added Windows-specific instructions for starting CopyQ (via CopyQ.exe or Start menu, since no desktop icon is created by default) in README.md and docs/basic-usage.rst
- Updated outdated "OS X" reference to "macOS" in docs/basic-usage.rst