### PR TITLE
Harden sync, clipboard, and large-tab behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,10 @@
   its first frame as a generic image fallback for applications without WebP
   clipboard support (#3661).
 
+- Do not treat removal of CopyQ's private clipboard-owner marker as new
+  clipboard content, preventing pasted items from moving to the top when the
+  corresponding history option is disabled (#3646).
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,9 @@
   preventing some X11 window managers from cascading its position on each
   toggle (#3643).
 
+- Keep item tags within the attainable item width so right-aligned tags remain
+  visible when the main window is wider than the maximum item width (#3013).
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,10 @@
   clipboard content, preventing pasted items from moving to the top when the
   corresponding history option is disabled (#3646).
 
+- Keep application shortcut defaults independent of translated key names so
+  AppImage builds retain shortcuts even when matching Qt translation catalogs
+  are unavailable (#3649).
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,8 +25,8 @@
   files on disk and shared storage (#3368, #3579).
 
 - Preserve synchronized item data when copying or moving large items out of a
-  synchronized tab, and leave the source untouched when backing files cannot
-  be read (#3622).
+  synchronized tab, and cancel activation, transfer, or removal commands when
+  backing files cannot be read so the source remains untouched (#3622).
 
 - Prevent filesystem reconciliation from turning transient missing-file
   observations into deletion of synchronized backing files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,24 @@
 - Save synchronized item files through atomic replacement so a failed or
   partial write retains the previous complete file.
 
+- Run automatic commands for whitespace-only clipboard data before treating
+  it as empty, allowing commands to ignore CRLF-only clipboard changes (#3654).
+
+- Keep large tabs responsive by deferring initial construction until after UI
+  activation, using incremental list layout, and limiting item-widget resizing,
+  positioning and lookup work to materialized rows.
+
+- Defer synchronized-tab reconciliation until after focus changes and match
+  model rows to backing files in linear rather than quadratic time.
+
+- Keep the last valid clipboard snapshot when Windows temporarily locks the
+  clipboard or advertises an image that cannot yet be materialized, and retry
+  the read without publishing a false `<EMPTY>` state (#3613).
+
+- Keep animated WebP data intact when activating an item while also exposing
+  its first frame as a generic image fallback for applications without WebP
+  clipboard support (#3661).
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,27 @@
 - Fixed null characters in concatenated selected items breaking paste in
   other applications.
 
+- Remove temporary image files after drag-and-drop completes.
+
 - Handle possible file operation errors and locks when synchronizing items to
   files on disk and shared storage (#3368, #3579).
+
+- Preserve synchronized item data when copying or moving large items out of a
+  synchronized tab, and leave the source untouched when backing files cannot
+  be read (#3622).
+
+- Prevent filesystem reconciliation from turning transient missing-file
+  observations into deletion of synchronized backing files.
+
+- Keep the highest-priority synchronized files visible when a directory has
+  more items than the tab limit, without deleting files that fall outside the
+  visible set.
+
+- Keep URI-list imports into synchronized tabs all-or-nothing so a failed file
+  copy cannot discard the original item or silently import only a subset.
+
+- Save synchronized item files through atomic replacement so a failed or
+  partial write retains the previous complete file.
 
 - Avoids potential crash on fetching very large data in clipboard.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,10 +44,6 @@
 - Run automatic commands for whitespace-only clipboard data before treating
   it as empty, allowing commands to ignore CRLF-only clipboard changes (#3654).
 
-- Keep large tabs responsive by deferring initial construction until after UI
-  activation, using incremental list layout, and limiting item-widget resizing,
-  positioning and lookup work to materialized rows.
-
 - Defer synchronized-tab reconciliation until after focus changes and match
   model rows to backing files in linear rather than quadratic time.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,10 @@
   AppImage builds retain shortcuts even when matching Qt translation catalogs
   are unavailable (#3649).
 
+- Avoid reapplying the normal window state whenever the main window is shown,
+  preventing some X11 window managers from cascading its position on each
+  toggle (#3643).
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,9 @@
 - Keep item tags within the attainable item width so right-aligned tags remain
   visible when the main window is wider than the maximum item width (#3013).
 
+- Display the actual tab names and respect the selected-tab list when importing
+  legacy v3 archives instead of importing every tab contained in the backup.
+
 - Avoids potential crash on fetching very large data in clipboard.
 
 - Wayland: Fixed portal shortcuts handling in non-default app sessions.

--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -1565,13 +1565,13 @@ unlike in GUI, where row numbers start from 1 by default.
 
    .. code-block:: js
 
-       if (!hasData()) {
-           updateClipboardData();
-       } else if (runAutomaticCommands()) {
-           saveData();
-           updateClipboardData();
-       } else {
+       if (!runAutomaticCommands()) {
            clearClipboardData();
+       } else {
+           if (hasData()) {
+               saveData();
+           }
+           updateClipboardData();
        }
 
 .. js:function:: onOwnClipboardChanged()

--- a/plugins/itemimage/itemimage.cpp
+++ b/plugins/itemimage/itemimage.cpp
@@ -221,7 +221,8 @@ QStringList ItemImageLoader::formatsToSave() const
     return {
         QLatin1String("image/svg+xml"),
         QLatin1String("image/png"),
-        QLatin1String("image/gif")
+        QLatin1String("image/gif"),
+        QLatin1String("image/webp")
     };
 }
 

--- a/plugins/itemsync/filewatcher.cpp
+++ b/plugins/itemsync/filewatcher.cpp
@@ -1050,6 +1050,11 @@ void FileWatcher::updateItems()
         for (const auto &file : files)
             m_observedFiles.insert(file);
         m_fileList = listFiles(files, m_formatSettings, m_maxItems, m_dir);
+        m_fileIndexes.clear();
+        m_fileIndexes.reserve(m_fileList.size());
+        for (int i = 0; i < m_fileList.size(); ++i)
+            m_fileIndexes.insert(m_fileList[i].baseName, i);
+
         m_batchIndexData.reserve(m_model->rowCount());
         for (int row = 0; row < m_model->rowCount(); ++row) {
             const QModelIndex index = m_model->index(row, 0);
@@ -1070,20 +1075,16 @@ void FileWatcher::updateItems()
         if ( baseName.isEmpty() )
             continue;
 
-        const auto it = std::find_if(
-            std::begin(m_fileList), std::end(m_fileList),
-            [&](const BaseNameExtensions &baseNameExtensions) {
-                return baseNameExtensions.baseName == baseName;
-            });
-
         QVariantMap dataMap;
         QVariantMap mimeToExtension;
         const QVariantMap currentItemData = index.data(contentType::data).toMap();
 
-        const bool foundInFileList = it != m_fileList.cend();
+        const auto fileIndex = m_fileIndexes.find(baseName);
+        const bool foundInFileList = fileIndex != m_fileIndexes.end();
         if ( foundInFileList ) {
-            updateDataAndWatchFile(m_dir, *it, &dataMap, &mimeToExtension);
-            m_fileList.erase(it);
+            updateDataAndWatchFile(
+                m_dir, m_fileList[fileIndex.value()], &dataMap, &mimeToExtension);
+            m_fileIndexes.erase(fileIndex);
         }
 
         if ( mimeToExtension.isEmpty() ) {
@@ -1129,12 +1130,19 @@ void FileWatcher::updateItems()
 
     t.restart();
 
-    insertItemsFromFiles(m_dir, m_fileList);
+    BaseNameExtensionsList newFiles;
+    newFiles.reserve(m_fileIndexes.size());
+    for (const auto &file : m_fileList) {
+        if (m_fileIndexes.contains(file.baseName))
+            newFiles.append(file);
+    }
+    insertItemsFromFiles(m_dir, newFiles);
 
     if ( t.elapsed() > 100 )
         qCInfo(fileWatcher) << "Items created in" << t.elapsed() << "ms";
 
     m_fileList.clear();
+    m_fileIndexes.clear();
     m_observedFiles.clear();
     m_batchIndexData.clear();
 
@@ -1145,8 +1153,11 @@ void FileWatcher::updateItems()
 void FileWatcher::setUpdatesEnabled(bool enabled)
 {
     m_updatesEnabled = enabled;
-    if (enabled)
-        updateItems();
+    if (enabled) {
+        // Focus changes must remain cheap. Reconcile after the current UI
+        // event returns so showing or switching to a large tab can paint first.
+        m_updateTimer.start(0);
+    }
     else if ( m_batchIndexData.isEmpty() )
         m_updateTimer.stop();
 }

--- a/plugins/itemsync/filewatcher.cpp
+++ b/plugins/itemsync/filewatcher.cpp
@@ -8,15 +8,16 @@
 #include <QAbstractItemModel>
 #include <QCryptographicHash>
 #include <QDataStream>
-#include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QElapsedTimer>
 #include <QLoggingCategory>
 #include <QMimeData>
 #include <QRegularExpression>
-#include <QUrl>
+#include <QSaveFile>
+#include <QScopedValueRollback>
 #include <QThread>
+#include <QUrl>
 
 #include <array>
 #include <vector>
@@ -144,27 +145,57 @@ public:
         return QStringLiteral("%1\n%2").arg(m_path, m_format);
     }
 
+    bool tryReadAll(QByteArray *bytes, int retryCount) const
+    {
+        Q_ASSERT(bytes);
+
+        const int attempts = 1 + retryCount;
+        QString lastError;
+        for (int attempt = 0; attempt < attempts; ++attempt) {
+            QFile f(m_path);
+            if ( !f.open(QIODevice::ReadOnly) ) {
+                lastError = f.errorString();
+            } else if ( m_format.isEmpty() ) {
+                const QByteArray result = f.readAll();
+                if (f.error() == QFileDevice::NoError) {
+                    *bytes = result;
+                    return true;
+                }
+                lastError = f.errorString();
+            } else {
+                QDataStream stream(&f);
+                QVariantMap dataMap;
+                if ( deserializeData(&stream, &dataMap) && dataMap.contains(m_format) ) {
+                    *bytes = dataMap.value(m_format).toByteArray();
+                    return true;
+                }
+                lastError = QStringLiteral("incomplete or invalid synchronized item data");
+            }
+
+            if (attempt + 1 < attempts) {
+                qCDebug(fileWatcher)
+                    << "Retrying read of" << m_path
+                    << "(attempt" << (attempt + 2) << "of" << attempts << ")"
+                    << lastError;
+                QThread::msleep(fileOpRetryDelayMs);
+            }
+        }
+
+        if ( QFileInfo::exists(m_path) ) {
+            qCWarning(fileWatcher)
+                << "Failed to read synchronized item data" << m_path
+                << "-" << lastError;
+        } else {
+            qCDebug(fileWatcher) << "Sync file no longer exists" << m_path;
+        }
+        return false;
+    }
+
     QByteArray readAll() const
     {
-        QFile f(m_path);
-        const bool opened = retryFileOp([&f]{ return f.open(QIODevice::ReadOnly); }, "open for reading", f, /*retryCount=*/0);
-        if (!opened) {
-            logFailedToOpenForReading(m_path, f.errorString());
-            return QByteArray();
-        }
-
-        if ( m_format.isEmpty() )
-            return f.readAll();
-
-        QDataStream stream(&f);
-        QVariantMap dataMap;
-        if ( !deserializeData(&stream, &dataMap) ) {
-            qCCritical(fileWatcher)
-                << "Failed to read file" << m_path << f.errorString();
-            return QByteArray();
-        }
-
-        return dataMap.value(m_format).toByteArray();
+        QByteArray bytes;
+        tryReadAll(&bytes, maxFileOpRetries);
+        return bytes;
     }
 
     bool operator==(const SyncDataFile &other) const {
@@ -199,6 +230,59 @@ void registerSyncDataFileConverter()
     QMetaType::registerConverter(&SyncDataFile::toString);
     qRegisterMetaType<SyncDataFile>("SyncDataFile");
 }
+
+bool FileWatcher::materializeItemDataForCopy(QVariantMap *data, QString *error)
+{
+    Q_ASSERT(data);
+
+    QVariantMap detached = *data;
+    const int syncDataFileType = qMetaTypeId<SyncDataFile>();
+    for (auto it = detached.begin(); it != detached.end(); ++it) {
+        if (it.value().typeId() != syncDataFileType)
+            continue;
+
+        const SyncDataFile source = it.value().value<SyncDataFile>();
+        QByteArray bytes;
+        if ( !source.tryReadAll(&bytes, maxFileOpRetries) ) {
+            if (error) {
+                *error = QStringLiteral("Failed to read synchronized item data from %1")
+                    .arg(source.path());
+            }
+            return false;
+        }
+
+        it.value() = bytes;
+    }
+
+    *data = detached;
+    return true;
+}
+
+namespace {
+
+bool hasDetachedPayload(const QVariantMap &data)
+{
+    const int syncDataFileType = qMetaTypeId<SyncDataFile>();
+    const QVariantMap noSaveData = data.value(mimeNoSave).toMap();
+    bool hasPayload = false;
+    for (auto it = data.constBegin(); it != data.constEnd(); ++it) {
+        const QString &format = it.key();
+        if ( format.startsWith(COPYQ_MIME_PREFIX_ITEMSYNC)
+             || format.startsWith(COPYQ_MIME_PRIVATE_PREFIX)
+             || noSaveData.contains(format) )
+        {
+            continue;
+        }
+
+        hasPayload = true;
+        if (it.value().typeId() == syncDataFileType)
+            return false;
+    }
+
+    return hasPayload;
+}
+
+} // namespace
 
 struct Ext {
     Ext() : extension(), format() {}
@@ -350,17 +434,40 @@ Ext findByExtension(const QString &fileName, const QList<FileFormat> &formatSett
 bool saveItemFile(const QString &filePath, const QByteArray &bytes,
                   QStringList *existingFiles, bool hashChanged = true)
 {
-    if ( !existingFiles->removeOne(filePath) || hashChanged ) {
-        QFile f(filePath);
-        const bool opened = retryFileOp([&f]{ return f.open(QIODevice::WriteOnly); }, "open for writing", f);
-        if ( !opened || f.write(bytes) == -1 ) {
-            qCCritical(fileWatcher)
-                << "Failed to save item file:" << f.errorString();
-            return false;
+    const bool alreadyExists = existingFiles->removeOne(filePath);
+    if (alreadyExists && !hashChanged)
+        return true;
+
+    QString lastError;
+    const int attempts = 1 + maxFileOpRetries;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        QSaveFile file(filePath);
+        file.setDirectWriteFallback(false);
+
+        if ( !file.open(QIODevice::WriteOnly) ) {
+            lastError = file.errorString();
+        } else if ( file.write(bytes) != bytes.size() ) {
+            lastError = file.errorString();
+            file.cancelWriting();
+        } else if ( file.commit() ) {
+            return true;
+        } else {
+            lastError = file.errorString();
+        }
+
+        if (attempt + 1 < attempts) {
+            qCDebug(fileWatcher)
+                << "Retrying atomic save" << filePath
+                << "(attempt" << (attempt + 2) << "of" << attempts << ")"
+                << lastError;
+            QThread::msleep(fileOpRetryDelayMs);
         }
     }
 
-    return true;
+    qCCritical(fileWatcher)
+        << "Failed to atomically save item file" << filePath
+        << "-" << lastError;
+    return false;
 }
 
 bool canUseFile(const QFileInfo &info)
@@ -442,8 +549,7 @@ QStringList listFiles(const QDir &dir)
     while (!dirs.isEmpty()) {
         const QDir subDir = dirs.takeFirst();
         const QFileInfoList infos = subDir.entryInfoList(
-            QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot
-            | QDir::Readable | QDir::Writable);
+            QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
         for (const QFileInfo &info : infos) {
             if ( !canUseFile(info) )
                 continue;
@@ -690,6 +796,41 @@ void removeFiles(
     }
 }
 
+template <typename Predicate>
+bool anyBackingFileMatches(
+    const QDir &dir, const QString &baseName, const QVariantMap &itemData,
+    Predicate predicate)
+{
+    const QString basePath = dir.absoluteFilePath(baseName);
+    const QVariantMap mimeToExtension = itemData.value(mimeExtensionMap).toMap();
+    if (mimeToExtension.isEmpty())
+        return predicate(basePath);
+
+    for (const auto &extension : mimeToExtension) {
+        if ( predicate(basePath + extension.toString()) )
+            return true;
+    }
+
+    return false;
+}
+
+bool anyBackingFileExists(
+    const QDir &dir, const QString &baseName, const QVariantMap &itemData)
+{
+    return anyBackingFileMatches(
+        dir, baseName, itemData,
+        [](const QString &path) { return QFileInfo::exists(path); });
+}
+
+bool anyBackingFileWasListed(
+    const QDir &dir, const QString &baseName, const QVariantMap &itemData,
+    const QSet<QString> &observedFiles)
+{
+    return anyBackingFileMatches(
+        dir, baseName, itemData,
+        [&observedFiles](const QString &path) { return observedFiles.contains(path); });
+}
+
 } // namespace
 
 QString FileWatcher::getBaseName(const QModelIndex &index)
@@ -770,7 +911,7 @@ FileWatcher::FileWatcher(
     connect( m_model, &QAbstractItemModel::rowsInserted,
              this, &FileWatcher::onRowsInserted );
     connect( m_model, &QAbstractItemModel::rowsAboutToBeRemoved,
-             this, &FileWatcher::onRowsRemoved );
+             this, &FileWatcher::onRowsAboutToBeRemoved );
     connect( model, &QAbstractItemModel::rowsMoved,
              this, &FileWatcher::onRowsMoved );
     connect( m_model, &QAbstractItemModel::dataChanged,
@@ -883,7 +1024,7 @@ void FileWatcher::insertItemsFromFiles(const QDir &dir, const BaseNameExtensions
 
         items.erase(items.begin(), items.begin() + i);
         if ( space < items.size() )
-            items.erase(items.begin(), items.begin() + space);
+            items.erase(items.begin() + space, items.end());
         createItems( items, m_model->rowCount() );
     }
 
@@ -902,10 +1043,12 @@ void FileWatcher::updateItems()
     QElapsedTimer t;
     t.start();
 
-    m_lastUpdateTimeMs = QDateTime::currentMSecsSinceEpoch();
-
     if ( m_batchIndexData.isEmpty() ) {
         const QStringList files = listFiles(m_dir);
+        m_observedFiles.clear();
+        m_observedFiles.reserve(files.size());
+        for (const auto &file : files)
+            m_observedFiles.insert(file);
         m_fileList = listFiles(files, m_formatSettings, m_maxItems, m_dir);
         m_batchIndexData.reserve(m_model->rowCount());
         for (int row = 0; row < m_model->rowCount(); ++row) {
@@ -935,6 +1078,7 @@ void FileWatcher::updateItems()
 
         QVariantMap dataMap;
         QVariantMap mimeToExtension;
+        const QVariantMap currentItemData = index.data(contentType::data).toMap();
 
         const bool foundInFileList = it != m_fileList.cend();
         if ( foundInFileList ) {
@@ -949,7 +1093,25 @@ void FileWatcher::updateItems()
                 qCInfo(fileWatcher)
                     << "Skipping update for" << baseName
                     << "- files exist but could not be read";
+            } else if (
+                !anyBackingFileWasListed(
+                    m_dir, baseName, currentItemData, m_observedFiles)
+                && anyBackingFileExists(m_dir, baseName, currentItemData) )
+            {
+                // Network/cloud directory listings can be temporarily
+                // incomplete even while direct access to the expected files
+                // still succeeds. A file that was present in the complete
+                // listing but omitted from the capped item list is different:
+                // remove only its model row so higher-priority files can enter.
+                qCInfo(fileWatcher)
+                    << "Skipping removal of" << baseName
+                    << "- expected files still exist but were not listed";
             } else {
+                // Reconciliation reflects external filesystem state. It is
+                // not a user-owned delete operation and must never cascade
+                // into deleting backing files that a transient listing may
+                // simply have failed to report.
+                QScopedValueRollback<bool> guard(m_removeFilesForRemovedRows, false);
                 m_model->removeRow(index.row());
             }
         } else {
@@ -973,19 +1135,11 @@ void FileWatcher::updateItems()
         qCInfo(fileWatcher) << "Items created in" << t.elapsed() << "ms";
 
     m_fileList.clear();
+    m_observedFiles.clear();
     m_batchIndexData.clear();
 
     if (m_updatesEnabled)
         m_updateTimer.start(m_interval);
-}
-
-void FileWatcher::updateItemsIfNeeded()
-{
-    const auto time = QDateTime::currentMSecsSinceEpoch();
-    if (time < m_lastUpdateTimeMs + m_interval)
-        return;
-
-    updateItems();
 }
 
 void FileWatcher::setUpdatesEnabled(bool enabled)
@@ -1010,14 +1164,15 @@ void FileWatcher::onDataChanged(const QModelIndex &a, const QModelIndex &b)
     saveItems(a.row(), b.row(), UpdateType::Changed);
 }
 
-void FileWatcher::onRowsRemoved(const QModelIndex &, int first, int last)
+void FileWatcher::onRowsAboutToBeRemoved(const QModelIndex &, int first, int last)
 {
     if (first < m_moveEnd)
         m_moveEnd -= std::min(m_moveEnd, last) - first + 1;
 
-    const bool wasFull = m_maxItems >= m_model->rowCount();
+    const bool wasFull = m_model->rowCount() >= m_maxItems;
 
-    removeFilesForRemovedIndexes(path(), indexList(first, last), /*ownOnly=*/true);
+    if (m_removeFilesForRemovedRows)
+        removeFilesForRemovedIndexes(path(), indexList(first, last), /*ownOnly=*/true);
 
     // If the tab is no longer full, try to add new files.
     if (wasFull)
@@ -1092,14 +1247,14 @@ QString FileWatcher::oldBaseName(const QModelIndex &index) const
     return index.data(contentType::data).toMap().value(mimeOldBaseName).toString();
 }
 
-void FileWatcher::createItems(const QVector<QVariantMap> &items, int targetRow)
+bool FileWatcher::createItems(const QVector<QVariantMap> &items, int targetRow)
 {
     if ( items.isEmpty() )
-        return;
+        return false;
 
     const int row = qMax( 0, qMin(targetRow, m_model->rowCount()) );
     if ( !m_model->insertRows(row, items.size()) )
-        return;
+        return false;
 
     // Find index if it was moved after inserted.
     const int rows = m_model->rowCount();
@@ -1115,6 +1270,8 @@ void FileWatcher::createItems(const QVector<QVariantMap> &items, int targetRow)
                 break;
         }
     }
+
+    return it == std::end(items);
 }
 
 void FileWatcher::updateIndexData(const QModelIndex &index, QVariantMap *itemData)
@@ -1281,9 +1438,24 @@ bool FileWatcher::renameMoveCopy(
             if ( !syncPath.isEmpty() ) {
                 oldBasePath = syncPath + '/' + oldBaseName;
                 if ( !copyFormatFiles(oldBasePath, newBasePath, mimeToExtension) ) {
+                    if ( !hasDetachedPayload(itemData) ) {
+                        qCWarning(fileWatcher)
+                            << "Aborting cross-tab copy of" << oldBaseName
+                            << "to" << baseName
+                            << "- source files are unavailable and no detached data exist";
+                        return false;
+                    }
+
+                    // The caller supplied an owned snapshot of the item. Save
+                    // that snapshot under the new base name instead of keeping
+                    // references to unavailable files in the source tab.
                     qCWarning(fileWatcher)
-                        << "Skipping cross-tab copy of" << oldBaseName
-                        << "to" << baseName;
+                        << "Source files unavailable while copying" << oldBaseName
+                        << "to" << baseName
+                        << "- saving detached item data";
+                    itemData.remove(mimeSyncPath);
+                    itemData.insert(mimeBaseName, baseName);
+                    updateIndexData(index, &itemData);
                     continue;
                 }
             } else if ( !olderBaseName.isEmpty() ) {
@@ -1363,42 +1535,101 @@ void FileWatcher::updateDataAndWatchFile(const QDir &dir, const BaseNameExtensio
     }
 }
 
-bool FileWatcher::copyFilesFromUriList(const QByteArray &uriData, int targetRow, const QSet<QString> &baseNames)
+bool FileWatcher::copyFilesFromUriList(
+    const QByteArray &uriData, int targetRow, const QSet<QString> &baseNames)
 {
     QMimeData tmpData;
     tmpData.setData(mimeUriList, uriData);
 
+    const QList<QUrl> urls = tmpData.urls();
+    if ( urls.isEmpty() || urls.size() > m_maxItems ) {
+        qCWarning(fileWatcher)
+            << "Cannot import URI list into synchronized tab: invalid item count"
+            << urls.size();
+        return false;
+    }
+
     QVector<QVariantMap> items;
+    items.reserve(urls.size());
+    QStringList copiedFiles;
 
-    for ( const auto &url : tmpData.urls() ) {
-        if ( !url.isLocalFile() )
-            continue;
+    const auto rollbackCopiedFiles = [&copiedFiles]() {
+        for (const auto &path : copiedFiles) {
+            QFile target(path);
+            if ( !retryFileOp([&target]{ return target.remove(); }, "remove", target)
+                 && target.exists() )
+            {
+                qCWarning(fileWatcher)
+                    << "Failed to roll back copied URI file" << path;
+            }
+        }
+    };
 
-        QFile f(url.toLocalFile());
+    for (const auto &url : urls) {
+        if ( !url.isLocalFile() ) {
+            qCWarning(fileWatcher)
+                << "Cannot import non-local URI into synchronized tab" << url;
+            rollbackCopiedFiles();
+            return false;
+        }
 
-        if ( !f.exists() )
-            continue;
+        QFile source(url.toLocalFile());
+        if ( !source.exists() ) {
+            qCWarning(fileWatcher)
+                << "Cannot import missing file into synchronized tab"
+                << source.fileName();
+            rollbackCopiedFiles();
+            return false;
+        }
 
         QString extName;
         QString baseName;
-        getBaseNameAndExtension( QFileInfo(f).fileName(), &baseName, &extName,
-                                 m_formatSettings );
+        getBaseNameAndExtension(
+            QFileInfo(source).fileName(), &baseName, &extName, m_formatSettings);
 
-        if ( !renameToUnique(m_dir, baseNames, &baseName, m_formatSettings) )
-            continue;
+        if ( !renameToUnique(m_dir, baseNames, &baseName, m_formatSettings) ) {
+            rollbackCopiedFiles();
+            return false;
+        }
 
         const QString targetFilePath = m_dir.absoluteFilePath(baseName + extName);
-        f.copy(targetFilePath);
-        Ext ext;
-        if ( getBaseNameExtension(targetFilePath, m_formatSettings, &baseName, &ext, m_dir) ) {
-            BaseNameExtensions baseNameExts(baseName, {ext});
-            const QVariantMap item = itemDataFromFiles(m_dir, baseNameExts);
-            items.append(item);
-            if (items.size() >= m_maxItems)
-                break;
+        if ( !retryFileOp(
+                 [&source, &targetFilePath]{ return source.copy(targetFilePath); },
+                 "copy", source) )
+        {
+            qCWarning(fileWatcher)
+                << "Failed to copy URI file" << source.fileName()
+                << "to" << targetFilePath << "-" << source.errorString();
+            QFile::remove(targetFilePath);
+            rollbackCopiedFiles();
+            return false;
         }
+        copiedFiles.append(targetFilePath);
+
+        Ext ext;
+        if ( !getBaseNameExtension(
+                 targetFilePath, m_formatSettings, &baseName, &ext, m_dir) )
+        {
+            qCWarning(fileWatcher)
+                << "Copied URI file has no supported synchronized format"
+                << targetFilePath;
+            rollbackCopiedFiles();
+            return false;
+        }
+
+        BaseNameExtensions baseNameExts(baseName, {ext});
+        const QVariantMap item = itemDataFromFiles(m_dir, baseNameExts);
+        if ( item.isEmpty() ) {
+            qCWarning(fileWatcher)
+                << "Failed to read copied URI file" << targetFilePath;
+            rollbackCopiedFiles();
+            return false;
+        }
+        items.append(item);
     }
 
-    createItems(items, targetRow);
-    return !items.isEmpty();
+    // If model insertion fails, keep both the original URI item and the copied
+    // files. The watcher can recover the files later; deleting either side
+    // would turn an insertion failure into data loss.
+    return createItems(items, targetRow);
 }

--- a/plugins/itemsync/filewatcher.h
+++ b/plugins/itemsync/filewatcher.h
@@ -6,6 +6,7 @@
 #include "common/mimetypes.h"
 
 #include <QDir>
+#include <QHash>
 #include <QLockFile>
 #include <QObject>
 #include <QPersistentModelIndex>
@@ -156,6 +157,9 @@ private:
 
     QList<QPersistentModelIndex> m_batchIndexData;
     BaseNameExtensionsList m_fileList;
+    // Stable indexes into m_fileList make reconciliation linear while the
+    // ordered list remains available for inserting newly discovered items.
+    QHash<QString, int> m_fileIndexes;
     QSet<QString> m_observedFiles;
     int m_lastBatchIndex = -1;
     int m_itemDataThreshold = -1;

--- a/plugins/itemsync/filewatcher.h
+++ b/plugins/itemsync/filewatcher.h
@@ -64,6 +64,15 @@ public:
      */
     static bool isOwnBaseName(const QString &baseName);
 
+    /**
+     * Replace lazy file-backed values with detached byte arrays.
+     *
+     * Returns false without modifying @a data if any source file cannot be
+     * read. This must happen before copied item data can outlive files owned
+     * by the synchronized source tab.
+     */
+    static bool materializeItemDataForCopy(QVariantMap *data, QString *error);
+
     static void removeFilesForRemovedIndexes(
         const QString &tabPath, const QList<QPersistentModelIndex> &indexes,
         bool ownOnly = false);
@@ -98,8 +107,6 @@ public:
      */
     void updateItems();
 
-    void updateItemsIfNeeded();
-
     void setUpdatesEnabled(bool enabled);
 
 private:
@@ -107,13 +114,13 @@ private:
 
     void onDataChanged(const QModelIndex &a, const QModelIndex &b);
 
-    void onRowsRemoved(const QModelIndex &, int first, int last);
+    void onRowsAboutToBeRemoved(const QModelIndex &, int first, int last);
 
     void onRowsMoved(const QModelIndex &, int start, int end, const QModelIndex &, int destinationRow);
 
     QString oldBaseName(const QModelIndex &index) const;
 
-    void createItems(const QVector<QVariantMap> &dataMaps, int targetRow);
+    bool createItems(const QVector<QVariantMap> &dataMaps, int targetRow);
 
     void updateIndexData(const QModelIndex &index, QVariantMap *itemData);
 
@@ -136,16 +143,20 @@ private:
     QTimer m_updateTimer;
     QTimer m_moveTimer;
     int m_moveEnd = -1;
+    // Disabled only while watcher reconciliation removes stale model rows.
+    // User/model-owned removals still delete files through
+    // onRowsAboutToBeRemoved().
+    bool m_removeFilesForRemovedRows = true;
     int m_interval = 0;
     const QList<FileFormat> &m_formatSettings;
     QDir m_dir;
     bool m_valid;
     int m_maxItems;
     bool m_updatesEnabled = false;
-    qint64 m_lastUpdateTimeMs = 0;
 
     QList<QPersistentModelIndex> m_batchIndexData;
     BaseNameExtensionsList m_fileList;
+    QSet<QString> m_observedFiles;
     int m_lastBatchIndex = -1;
     int m_itemDataThreshold = -1;
 

--- a/plugins/itemsync/itemsync.cpp
+++ b/plugins/itemsync/itemsync.cpp
@@ -472,22 +472,33 @@ void ItemSyncSaver::itemsRemovedByUser(const QList<QPersistentModelIndex> &index
     FileWatcher::removeFilesForRemovedIndexes(m_tabPath, indexList);
 }
 
-QVariantMap ItemSyncSaver::copyItem(const QAbstractItemModel &, const QVariantMap &itemData)
+bool ItemSyncSaver::copyItem(
+    const QAbstractItemModel &, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *error)
 {
-    if (m_watcher)
-        m_watcher->updateItemsIfNeeded();
+    Q_ASSERT(copiedItemData);
 
-    QVariantMap copiedItemData;
-    for (auto it = itemData.begin(); it != itemData.constEnd(); ++it) {
+    QVariantMap detachedItemData;
+    for (auto it = itemData.constBegin(); it != itemData.constEnd(); ++it) {
         const auto &format = it.key();
         if ( !format.startsWith(mimePrivateSyncPrefix) )
-            copiedItemData[format] = it.value();
+            detachedItemData.insert(format, it.value());
     }
 
-    copiedItemData.insert(mimeSyncPath, m_tabPath);
+    QString materializeError;
+    if ( !FileWatcher::materializeItemDataForCopy(&detachedItemData, &materializeError) ) {
+        qCWarning(plugin) << materializeError;
+        if (error) {
+            *error = tr("Failed to read synchronized item data. "
+                        "The source item was left unchanged.");
+        }
+        return false;
+    }
+
+    detachedItemData.insert(mimeSyncPath, m_tabPath);
 
     // Add text/uri-list if no data are present.
-    if ( hasOnlyInternalData(copiedItemData) ) {
+    if ( hasOnlyInternalData(detachedItemData) ) {
         QByteArray uriData;
 
         const QVariantMap mimeToExtension = itemData.value(mimeExtensionMap).toMap();
@@ -503,11 +514,12 @@ QVariantMap ItemSyncSaver::copyItem(const QAbstractItemModel &, const QVariantMa
 
         QVariantMap noSaveData;
         noSaveData.insert(mimeUriList, FileWatcher::calculateHash(uriData));
-        copiedItemData.insert(mimeUriList, uriData);
-        copiedItemData.insert(mimeNoSave, noSaveData);
+        detachedItemData.insert(mimeUriList, uriData);
+        detachedItemData.insert(mimeNoSave, noSaveData);
     }
 
-    return copiedItemData;
+    *copiedItemData = detachedItemData;
+    return true;
 }
 
 void ItemSyncSaver::setFocus(bool focus)

--- a/plugins/itemsync/itemsync.h
+++ b/plugins/itemsync/itemsync.h
@@ -52,7 +52,11 @@ public:
 
     void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList) override;
 
-    QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData) override;
+    bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error) override;
 
     void setFocus(bool focus) override;
 

--- a/plugins/itemtags/itemtags.cpp
+++ b/plugins/itemtags/itemtags.cpp
@@ -359,8 +359,13 @@ ItemTags::ItemTags(ItemWidget *childItem, const Tags &tags)
 void ItemTags::updateSize(QSize maximumSize, int idealWidth)
 {
     setMaximumSize(maximumSize);
-    m_tagWidget->setFixedWidth(idealWidth);
-    ItemWidgetWrapper::updateSize(maximumSize, idealWidth);
+
+    // The viewport can be wider than the configured maximum item width. Keep
+    // the right-aligned tag strip and the wrapped item on the same attainable
+    // width; otherwise the tags are laid out beyond this widget and clipped.
+    const int width = qMin(maximumSize.width(), idealWidth);
+    m_tagWidget->setFixedWidth(width);
+    ItemWidgetWrapper::updateSize(maximumSize, width);
     adjustSize();
 }
 

--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -30,12 +30,20 @@ bool hasSameData(const QVariantMap &data, const QVariantMap &lastData)
 {
     for (auto it = lastData.constBegin(); it != lastData.constEnd(); ++it) {
         const auto &format = it.key();
+        // Ownership identifies who is currently providing the bytes, not the
+        // clipboard content itself. Some applications republish pasted data
+        // without CopyQ's owner marker; treating that metadata loss as new
+        // content stores the same item again and can move it to the top.
+        if (format == mimeOwner)
+            continue;
         if ( !data.contains(format) )
             return false;
     }
 
     for (auto it = data.constBegin(); it != data.constEnd(); ++it) {
         const auto &format = it.key();
+        if (format == mimeOwner)
+            continue;
         if ( !data[format].toByteArray().isEmpty()
              && data[format] != lastData.value(format) )
         {

--- a/src/app/clipboardmonitor.cpp
+++ b/src/app/clipboardmonitor.cpp
@@ -12,8 +12,19 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QTimer>
+
+#include <array>
+#include <utility>
 
 namespace {
+
+constexpr std::array<int, 4> clipboardReadRetryDelayMs{50, 100, 200, 400};
+
+int modeIndex(ClipboardMode mode)
+{
+    return mode == ClipboardMode::Clipboard ? 0 : 1;
+}
 
 bool hasSameData(const QVariantMap &data, const QVariantMap &lastData)
 {
@@ -47,8 +58,9 @@ bool isClipboardDataSecret(const QVariantMap &data)
 
 } // namespace
 
-ClipboardMonitor::ClipboardMonitor(const QStringList &formats)
-    : m_clipboard(platformNativeInterface()->clipboard())
+ClipboardMonitor::ClipboardMonitor(
+        const QStringList &formats, PlatformClipboardPtr clipboard)
+    : m_clipboard(clipboard ? std::move(clipboard) : platformNativeInterface()->clipboard())
     , m_formats(formats)
     , m_ownerMonitor(this)
 {
@@ -109,9 +121,39 @@ void ClipboardMonitor::setClipboardOwner(const QString &owner)
 
 void ClipboardMonitor::onClipboardChanged(ClipboardMode mode)
 {
+    const int index = modeIndex(mode);
+    const quint64 generation = ++m_readGenerations[index];
+    processClipboardChanged(mode, generation, 0);
+}
+
+void ClipboardMonitor::processClipboardChanged(
+        ClipboardMode mode, quint64 generation, int retryAttempt)
+{
     m_ownerMonitor.update();
 
-    QVariantMap data = m_clipboard->data(mode, m_formats);
+    const ClipboardReadResult readResult = m_clipboard->readData(mode, m_formats);
+    if (!readResult.isComplete) {
+        const int index = modeIndex(mode);
+        if (generation != m_readGenerations[index])
+            return;
+
+        if (retryAttempt >= static_cast<int>(clipboardReadRetryDelayMs.size())) {
+            log(QStringLiteral("Clipboard data remained unavailable after %1 retries; keeping the last valid snapshot")
+                .arg(retryAttempt), LogWarning);
+            return;
+        }
+
+        const int delay = clipboardReadRetryDelayMs[retryAttempt];
+        COPYQ_LOG(QStringLiteral("Clipboard data unavailable; retrying in %1 ms")
+                  .arg(delay));
+        QTimer::singleShot(delay, this, [this, mode, generation, retryAttempt, index]() {
+            if (generation == m_readGenerations[index])
+                processClipboardChanged(mode, generation, retryAttempt + 1);
+        });
+        return;
+    }
+
+    QVariantMap data = readResult.data;
     auto clipboardData = mode == ClipboardMode::Clipboard
             ? &m_clipboardData : &m_selectionData;
 

--- a/src/app/clipboardmonitor.h
+++ b/src/app/clipboardmonitor.h
@@ -11,12 +11,16 @@
 
 #include <QVariantMap>
 
+#include <array>
+
 class ClipboardMonitor final : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit ClipboardMonitor(const QStringList &formats);
+    explicit ClipboardMonitor(
+        const QStringList &formats,
+        PlatformClipboardPtr clipboard = {});
     void startMonitoring();
     QString currentClipboardOwner();
     void setClipboardOwner(const QString &owner);
@@ -33,6 +37,8 @@ signals:
 
 private:
     void onClipboardChanged(ClipboardMode mode);
+    void processClipboardChanged(
+            ClipboardMode mode, quint64 generation, int retryAttempt);
 
     QVariantMap m_clipboardData;
     QVariantMap m_selectionData;
@@ -55,4 +61,5 @@ private:
 #endif
 
     QString m_clipboardOwner;
+    std::array<quint64, 2> m_readGenerations{};
 };

--- a/src/common/clipboarddataguard.cpp
+++ b/src/common/clipboarddataguard.cpp
@@ -174,6 +174,7 @@ ClipboardDataGuard::ClipboardDataGuard(const QMimeData *data, const long int *cl
     // - https://bugzilla.redhat.com/show_bug.cgi?id=2326881
     m_connection = QObject::connect(m_data, &QObject::destroyed, [this](){
         m_data = nullptr;
+        m_failed = true;
         log( QByteArrayLiteral("Aborting clipboard cloning: Data deleted"), LogWarning );
     });
     m_timerExpire.start();
@@ -201,19 +202,31 @@ QByteArray ClipboardDataGuard::data(const QString &mime)
     ElapsedGuard _(QStringLiteral("data"), mime);
 
     const qint64 maxBytes = maxBytesForMime(mime);
-    if (maxBytes == 0)
+    if (maxBytes == 0) {
+        if (mime.startsWith(QLatin1String("image/"))
+            || mime == QLatin1String("application/x-qt-image"))
+        {
+            m_imageWasOmitted = true;
+        }
         return {};
+    }
 
     const QMimeData *md = mimeData();
     QByteArray bytes;
     try {
         bytes = md->data(mime);
     } catch (const std::bad_alloc &) {
+        m_failed = true;
         log(QStringLiteral("Out of memory reading clipboard data for %1").arg(mime), LogError);
         return {};
     }
 
     if (maxBytes > 0 && bytes.size() > maxBytes) {
+        if (mime.startsWith(QLatin1String("image/"))
+            || mime == QLatin1String("application/x-qt-image"))
+        {
+            m_imageWasOmitted = true;
+        }
         log( QStringLiteral("Skipping oversized clipboard data for %1: %2 bytes (limit: %3)")
             .arg(mime).arg(bytes.size()).arg(maxBytes), LogNote );
         return {};
@@ -232,6 +245,7 @@ QList<QUrl> ClipboardDataGuard::urls()
     try {
         return md->urls();
     } catch (const std::bad_alloc &) {
+        m_failed = true;
         log(QStringLiteral("Out of memory reading clipboard URLs"), LogError);
         return {};
     }
@@ -247,6 +261,7 @@ QString ClipboardDataGuard::text()
     try {
         return md->text();
     } catch (const std::bad_alloc &) {
+        m_failed = true;
         log(QStringLiteral("Out of memory reading clipboard text"), LogError);
         return {};
     }
@@ -265,8 +280,10 @@ QImage ClipboardDataGuard::getImageData()
     // Use "image/" as probe: matches broad rules like image/.*:0
     // but not format-specific ones like image/png:0.
     const qint64 maxBytes = maxBytesForMime(QStringLiteral("image/"));
-    if (maxBytes == 0)
+    if (maxBytes == 0) {
+        m_imageWasOmitted = true;
         return {};
+    }
 
     const QMimeData *md = mimeData();
     QImage image;
@@ -276,6 +293,7 @@ QImage ClipboardDataGuard::getImageData()
         //       calling QMimeData::hasImage() on X11 clipboard.
         image = md->imageData().value<QImage>();
     } catch (const std::bad_alloc &) {
+        m_failed = true;
         log(QStringLiteral("Out of memory reading clipboard image data"), LogError);
         return {};
     }
@@ -290,6 +308,7 @@ QImage ClipboardDataGuard::getImageData()
     }
 
     if (maxBytes > 0 && !image.isNull() && image.sizeInBytes() > maxBytes) {
+        m_imageWasOmitted = true;
         log( QStringLiteral("Skipping oversized image data: %1 bytes (limit: %2)")
             .arg(image.sizeInBytes()).arg(maxBytes), LogNote );
         return {};
@@ -326,6 +345,7 @@ QByteArray ClipboardDataGuard::getUtf8Data(const QString &format)
             bytes = data(format);
         }
     } catch (const std::bad_alloc &) {
+        m_failed = true;
         log(QStringLiteral("Out of memory reading clipboard data for %1").arg(format), LogError);
         return {};
     }
@@ -340,23 +360,28 @@ QByteArray ClipboardDataGuard::getUtf8Data(const QString &format)
 }
 
 bool ClipboardDataGuard::isExpired() {
-    if (!m_data)
+    if (!m_data) {
+        m_failed = true;
         return true;
+    }
 
     if (qApp && qApp->property("CopyQ_quitting").toBool()) {
         m_data = nullptr;
+        m_failed = true;
         log( QByteArrayLiteral("Aborting clipboard cloning: Application quitting"), LogWarning );
         return true;
     }
 
     if (m_clipboardSequenceNumber && *m_clipboardSequenceNumber != m_clipboardSequenceNumberOriginal) {
         m_data = nullptr;
+        m_failed = true;
         log( QByteArrayLiteral("Aborting clipboard cloning: Clipboard changed again"), LogWarning );
         return true;
     }
 
     if (m_timerExpire.elapsed() > clipboardCopyTimeoutMs()) {
         m_data = nullptr;
+        m_failed = true;
         log( QByteArrayLiteral("Aborting clipboard cloning: Data access took too long"), LogWarning );
         return true;
     }

--- a/src/common/clipboarddataguard.h
+++ b/src/common/clipboarddataguard.h
@@ -33,6 +33,8 @@ public:
     QImage getImageData();
     QByteArray getUtf8Data(const QString &format);
     bool isExpired();
+    bool hasFailed() const { return m_failed; }
+    bool imageWasOmitted() const { return m_imageWasOmitted; }
     const QMimeData *mimeData();
 
 private:
@@ -41,4 +43,6 @@ private:
     const long int *m_clipboardSequenceNumber;
     long int m_clipboardSequenceNumberOriginal;
     QMetaObject::Connection m_connection;
+    bool m_failed = false;
+    bool m_imageWasOmitted = false;
 };

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -18,7 +18,6 @@
 #include <QImageWriter>
 #include <QKeyEvent>
 #include <QMimeData>
-#include <QMovie>
 #include <QObject>
 #include <QProcess>
 #include <QRegularExpression>
@@ -89,12 +88,10 @@ bool canCloneImageData(const QImage &image)
 bool setImageData(
     QByteArray &bytes, const char *imageFormat, const std::unique_ptr<QMimeData> &mimeData)
 {
-    // Omit converting animated images to static ones.
-    QBuffer buffer(&bytes);
-    const QMovie animatedImage(&buffer, imageFormat);
-    if ( animatedImage.frameCount() > 1 )
-        return false;
-
+    // Keep the original encoded bytes below and additionally publish the first
+    // frame as generic image data. Applications that understand the original
+    // animated format can still request it, while other paste targets receive
+    // a standard static image instead of seeing an unusable clipboard entry.
     const auto image = QImage::fromData(bytes, imageFormat);
     if ( image.isNull() )
         return false;
@@ -154,6 +151,15 @@ bool isBinaryImageFormat(const QString &format)
            && !format.contains(QStringLiteral("svg"));
 }
 
+bool preserveEncodedImageFormat(const QString &format)
+{
+    // These formats can contain animation. Re-encoding through QImage would
+    // retain only one frame, so keep the original bytes and create a separate
+    // generic fallback instead.
+    return format == QLatin1String("image/gif")
+        || format == QLatin1String("image/webp");
+}
+
 } // namespace
 
 QVariantMap cloneData(ClipboardDataGuard &data, const QStringList &formats)
@@ -169,13 +175,26 @@ QVariantMap cloneData(ClipboardDataGuard &data, const QStringList &formats)
      Images in SVG and other XML formats are expected to be relatively small
      so these doesn't have to be ignored.
      */
-    const bool skipBinaryImageFormats = formats.contains(mimeText) && data.hasText();
-
     QStringList imageFormats;
+    QByteArray encodedImageFallback;
+    QByteArray encodedImageFallbackFormat;
     for (const auto &mime : formats) {
         if (isBinaryImageFormat(mime)) {
-            if (!skipBinaryImageFormats)
-                imageFormats.append(mime);
+            if ( preserveEncodedImageFormat(mime) ) {
+                if ( !data.hasFormat(mime) )
+                    continue;
+
+                const QByteArray bytes = data.data(mime);
+                if ( !bytes.isEmpty() ) {
+                    newdata.insert(mime, bytes);
+                    if (encodedImageFallback.isEmpty()) {
+                        encodedImageFallback = bytes;
+                        encodedImageFallbackFormat = getImageFormatFromMime(mime).toUtf8();
+                    }
+                    continue;
+                }
+            }
+            imageFormats.append(mime);
         } else {
             const QByteArray bytes = data.getUtf8Data(mime);
             if ( bytes.isEmpty() )
@@ -185,13 +204,27 @@ QVariantMap cloneData(ClipboardDataGuard &data, const QStringList &formats)
         }
     }
 
+    // Some applications advertise expensive image renderings alongside text
+    // (for example when copying a spreadsheet).  Read inexpensive text first
+    // and only suppress those images when actual text bytes were obtained.
+    // Merely advertising an empty text format must not hide a valid image.
+    if (!newdata.value(mimeText).toByteArray().isEmpty()
+        || !newdata.value(mimeTextUtf8).toByteArray().isEmpty()
+        || !newdata.value(mimeHtml).toByteArray().isEmpty())
+    {
+        imageFormats.clear();
+    }
+
     // Retrieve images last since this can take a while.
     if ( !imageFormats.isEmpty() ) {
-        const QImage image = data.getImageData();
+        QImage image = data.getImageData();
+        if ( image.isNull() && !encodedImageFallback.isEmpty() ) {
+            image.loadFromData(encodedImageFallback, encodedImageFallbackFormat.constData());
+        }
         if ( canCloneImageData(image) ) {
             for (const auto &mime : imageFormats) {
                 const QString format = getImageFormatFromMime(mime);
-                if ( !format.isEmpty() )
+                if ( !format.isEmpty() && !newdata.contains(mime) )
                     cloneImageData(image, format, mime, &newdata);
             }
         }

--- a/src/common/shortcuts.cpp
+++ b/src/common/shortcuts.cpp
@@ -3,7 +3,6 @@
 #include "shortcuts.h"
 
 #include <QKeySequence>
-#include <QObject>
 #include <QString>
 
 namespace {
@@ -28,10 +27,11 @@ int indexOfKeyHint(const QString &name)
 
 QString shortcutToRemove()
 {
+    // This is serialized/parsing syntax, not a user-facing label.
 #ifdef Q_OS_MAC
-    return QObject::tr("Backspace", "Key to remove item or MIME on OS X");
+    return QStringLiteral("Backspace");
 #else
-    return QObject::tr("Delete", "Key to remove item or MIME");
+    return QStringLiteral("Delete");
 #endif
 }
 

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -64,7 +64,7 @@ public:
 
     ~TemporaryDragAndDropImage()
     {
-        if ( m_filePath.isEmpty() )
+        if ( !m_filePath.isEmpty() )
             QFile::remove(m_filePath);
     }
 
@@ -638,16 +638,44 @@ void ClipboardBrowser::dragDropScroll()
     }
 }
 
-QVariantMap ClipboardBrowser::copyIndex(const QModelIndex &index) const
+QVariantMap ClipboardBrowser::copyIndex(
+    const QModelIndex &index, QString *error) const
 {
-    auto data = index.data(contentType::data).toMap();
-    return m_itemSaver ? m_itemSaver->copyItem(m, data) : data;
+    if (error)
+        error->clear();
+
+    const auto data = index.data(contentType::data).toMap();
+    if (!m_itemSaver)
+        return data;
+
+    QVariantMap copiedData;
+    if ( !m_itemSaver->copyItem(m, data, &copiedData, error) ) {
+        if (error && error->isEmpty())
+            *error = tr("Failed to copy item data.");
+        return {};
+    }
+
+    return copiedData;
 }
 
-QVariantMap ClipboardBrowser::copyIndexes(const QModelIndexList &indexes) const
+QVariantMap ClipboardBrowser::copyIndexes(
+    const QModelIndexList &indexes, QString *error) const
 {
+    QString localError;
+    QString *copyError = error ? error : &localError;
+    copyError->clear();
+
     if (indexes.size() == 1)
-        return copyIndex( indexes.first() );
+        return copyIndex(indexes.first(), copyError);
+
+    QVector<QVariantMap> copiedItems;
+    copiedItems.reserve(indexes.size());
+    for (const auto &index : indexes) {
+        const auto itemData = copyIndex(index, copyError);
+        if ( !copyError->isEmpty() )
+            return {};
+        copiedItems.append(itemData);
+    }
 
     QByteArray bytes;
     QByteArray text;
@@ -658,10 +686,7 @@ QVariantMap ClipboardBrowser::copyIndexes(const QModelIndexList &indexes) const
     {
         QDataStream stream(&bytes, QIODevice::WriteOnly);
 
-        for (const auto &index : indexes) {
-            auto itemData = index.data(contentType::data).toMap();
-            itemData = m_itemSaver ? m_itemSaver->copyItem(m, itemData) : itemData;
-
+        for (const auto &itemData : copiedItems) {
             stream << itemData;
 
             appendTextData(itemData, mimeText, &text);
@@ -855,9 +880,18 @@ void ClipboardBrowser::onEditorInvalidate()
 
 void ClipboardBrowser::setClipboardFromEditor()
 {
-    QModelIndex index = m_editor->index();
-    if (index.isValid())
-        emit changeClipboard( copyIndex(index) );
+    const QModelIndex index = m_editor->index();
+    if ( !index.isValid() )
+        return;
+
+    QString errorString;
+    const auto data = copyIndex(index, &errorString);
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
+
+    emit changeClipboard(data);
 }
 
 void ClipboardBrowser::onEditorNeedsChangeClipboard(const QByteArray &bytes, const QString &mime)
@@ -1052,9 +1086,14 @@ void ClipboardBrowser::mouseMoveEvent(QMouseEvent *event)
         selected.append(targetIndex);
     }
 
-    QVariantMap data = copyIndexes(selected);
+    QString errorString;
+    const QVariantMap data = copyIndexes(selected, &errorString);
 
     m_dragStartPosition = QPoint();
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
     auto drag = new QDrag(this);
     drag->setMimeData( createMimeData(data) );
     drag->setPixmap( renderItemPreview(selected, 150, 150) );
@@ -1338,7 +1377,12 @@ void ClipboardBrowser::moveToClipboard(const QModelIndex &ind)
 
 void ClipboardBrowser::moveToClipboard(const QModelIndexList &indexes)
 {
-    const auto data = copyIndexes(indexes);
+    QString errorString;
+    const auto data = copyIndexes(indexes, &errorString);
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
 
     if ( m_sharedData->moveItemOnReturnKey
          && m_itemSaver && m_itemSaver->canMoveItems(indexes) )
@@ -1658,11 +1702,11 @@ bool ClipboardBrowser::addAndSelect(const QVariantMap &data, int row)
     return added;
 }
 
-void ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
+bool ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
 {
     if ( moveToTop(hash(data)) ) {
         COPYQ_LOG("New item: Moving existing to top");
-        return;
+        return true;
     }
 
     // When selecting text under X11, clipboard data may change whenever selection changes.
@@ -1689,16 +1733,14 @@ void ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
                 for (auto it = data.constBegin(); it != data.constEnd(); ++it)
                     newData.insert(it.key(), it.value());
 
-                m.setData(firstIndex, newData, contentType::data);
-
-                return;
+                return m.setData(firstIndex, newData, contentType::data);
             }
         }
     }
 
     COPYQ_LOG("New item: Adding");
 
-    add(data);
+    return add(data);
 }
 
 void ClipboardBrowser::setItemsData(const QMap<QPersistentModelIndex, QVariantMap> &itemsData)

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -211,13 +211,15 @@ ClipboardBrowser::ClipboardBrowser(
 {
     setObjectName("ClipboardBrowser");
 
+    // Item size hints can be expensive and tabs can contain tens of thousands
+    // of rows. Keep the Qt layout cooperative instead of blocking the GUI
+    // thread until every row has been positioned.
     setLayoutMode(QListView::Batched);
     setBatchSize(1);
     setFrameShape(QFrame::NoFrame);
     setTabKeyNavigation(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     setWrapping(false);
-    setLayoutMode(QListView::SinglePass);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setAlternatingRowColors(true);
 
@@ -1768,7 +1770,10 @@ bool ClipboardBrowser::loadItems(const QByteArray &itemData)
         deserializeData(&m, &stream);
     }
 
-    d.rowsInserted(QModelIndex(), 0, m.rowCount());
+    // Model signals are blocked while loading, so synchronize the delegate
+    // once with the exact inclusive range of rows that now exists.
+    if (m.rowCount() > 0)
+        d.rowsInserted(QModelIndex(), 0, m.rowCount() - 1);
     if ( hasFocus() )
         setCurrent(0);
     onItemCountChanged();

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -215,7 +215,9 @@ ClipboardBrowser::ClipboardBrowser(
     // of rows. Keep the Qt layout cooperative instead of blocking the GUI
     // thread until every row has been positioned.
     setLayoutMode(QListView::Batched);
-    setBatchSize(1);
+    // Laying out a single row per batch repeatedly resizes the viewport and
+    // scrollbar, causing visible flicker while a large tab is materialized.
+    setBatchSize(100);
     setFrameShape(QFrame::NoFrame);
     setTabKeyNavigation(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -211,17 +211,11 @@ ClipboardBrowser::ClipboardBrowser(
 {
     setObjectName("ClipboardBrowser");
 
-    // Item size hints can be expensive and tabs can contain tens of thousands
-    // of rows. Keep the Qt layout cooperative instead of blocking the GUI
-    // thread until every row has been positioned.
-    setLayoutMode(QListView::Batched);
-    // Laying out a single row per batch repeatedly resizes the viewport and
-    // scrollbar, causing visible flicker while a large tab is materialized.
-    setBatchSize(100);
     setFrameShape(QFrame::NoFrame);
     setTabKeyNavigation(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);
     setWrapping(false);
+    setLayoutMode(QListView::SinglePass);
     setEditTriggers(QAbstractItemView::NoEditTriggers);
     setAlternatingRowColors(true);
 
@@ -561,15 +555,7 @@ void ClipboardBrowser::preloadCurrentPage()
 
     const QRect rect = viewport()->contentsRect();
     const int top = rect.top();
-    auto firstVisibleIndex = indexNear(top);
-    if (!firstVisibleIndex.isValid()) {
-        // Batched layout may not have populated indexAt() geometry on the
-        // first presentation yet. Materialize the first visible model page
-        // directly; subsequent layout passes will position those widgets.
-        const int firstVisibleRow = findNextVisibleRow(0);
-        if (firstVisibleRow != -1)
-            firstVisibleIndex = index(firstVisibleRow);
-    }
+    const auto firstVisibleIndex = indexNear(top);
     preload(rect.height(), 1, firstVisibleIndex);
 }
 
@@ -935,11 +921,8 @@ void ClipboardBrowser::resizeEvent(QResizeEvent *event)
 
 void ClipboardBrowser::showEvent(QShowEvent *event)
 {
+    preloadCurrentPage();
     QListView::showEvent(event);
-    // The viewport is not visible until the base show event is handled.
-    // Queue preloading so all rows on the first page are materialized without
-    // requiring an initial scroll or selection change.
-    m_timerPreload.start();
 }
 
 void ClipboardBrowser::currentChanged(const QModelIndex &current, const QModelIndex &previous)

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -927,8 +927,11 @@ void ClipboardBrowser::resizeEvent(QResizeEvent *event)
 
 void ClipboardBrowser::showEvent(QShowEvent *event)
 {
-    preloadCurrentPage();
     QListView::showEvent(event);
+    // The viewport is not visible until the base show event is handled.
+    // Queue preloading so all rows on the first page are materialized without
+    // requiring an initial scroll or selection change.
+    m_timerPreload.start();
 }
 
 void ClipboardBrowser::currentChanged(const QModelIndex &current, const QModelIndex &previous)

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -561,7 +561,15 @@ void ClipboardBrowser::preloadCurrentPage()
 
     const QRect rect = viewport()->contentsRect();
     const int top = rect.top();
-    const auto firstVisibleIndex = indexNear(top);
+    auto firstVisibleIndex = indexNear(top);
+    if (!firstVisibleIndex.isValid()) {
+        // Batched layout may not have populated indexAt() geometry on the
+        // first presentation yet. Materialize the first visible model page
+        // directly; subsequent layout passes will position those widgets.
+        const int firstVisibleRow = findNextVisibleRow(0);
+        if (firstVisibleRow != -1)
+            firstVisibleIndex = index(firstVisibleRow);
+    }
     preload(rect.height(), 1, firstVisibleIndex);
 }
 

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -92,9 +92,9 @@ class ClipboardBrowser final : public QListView
          */
         void keyboardSearch(const QString &text) override;
 
-        QVariantMap copyIndex(const QModelIndex &index) const;
+        QVariantMap copyIndex(const QModelIndex &index, QString *error = nullptr) const;
 
-        QVariantMap copyIndexes(const QModelIndexList &indexes) const;
+        QVariantMap copyIndexes(const QModelIndexList &indexes, QString *error = nullptr) const;
 
         void removeIndexes(const QModelIndexList &indexes, QString *error = nullptr);
 
@@ -128,7 +128,7 @@ class ClipboardBrowser final : public QListView
         /**
          * Add item and remove duplicates.
          */
-        void addUnique(const QVariantMap &data, ClipboardMode mode);
+        bool addUnique(const QVariantMap &data, ClipboardMode mode);
 
         void setItemsData(const QMap<QPersistentModelIndex, QVariantMap> &itemsData);
 

--- a/src/gui/clipboardbrowserplaceholder.cpp
+++ b/src/gui/clipboardbrowserplaceholder.cpp
@@ -218,7 +218,10 @@ void ClipboardBrowserPlaceholder::showEvent(QShowEvent *event)
 {
     qCDebug(logCategory) << "Showing tab:" << m_tabName;
     QWidget::showEvent(event);
-    scheduleBrowserCreation();
+    QTimer::singleShot(0, this, [this](){
+        if ( isVisible() )
+            createBrowser();
+    });
 }
 
 void ClipboardBrowserPlaceholder::hideEvent(QHideEvent *event)
@@ -232,7 +235,8 @@ void ClipboardBrowserPlaceholder::hideEvent(QHideEvent *event)
 bool ClipboardBrowserPlaceholder::event(QEvent *event)
 {
     if (event->type() == QEvent::WindowActivate && isVisible()) {
-        scheduleBrowserCreation();
+        if (!m_browser && !m_loadButton)
+            createBrowser();
     } else if (event->type() == QEvent::WindowDeactivate && isVisible()) {
         restartPasswordExpiry();
     }
@@ -252,22 +256,6 @@ bool ClipboardBrowserPlaceholder::expire()
 
     restartExpiring();
     return false;
-}
-
-void ClipboardBrowserPlaceholder::scheduleBrowserCreation()
-{
-    if (m_browser || m_loadButton || m_browserCreationScheduled)
-        return;
-
-    // Loading a large tab can involve substantial deserialization and plugin
-    // setup. Queue one coalesced load so the window/tab activation event can
-    // finish and the placeholder can be painted before that work starts.
-    m_browserCreationScheduled = true;
-    QTimer::singleShot(0, this, [this](){
-        m_browserCreationScheduled = false;
-        if (isVisible() && !m_browser && !m_loadButton)
-            createBrowser();
-    });
 }
 
 void ClipboardBrowserPlaceholder::setActiveWidget(QWidget *widget)

--- a/src/gui/clipboardbrowserplaceholder.cpp
+++ b/src/gui/clipboardbrowserplaceholder.cpp
@@ -218,10 +218,7 @@ void ClipboardBrowserPlaceholder::showEvent(QShowEvent *event)
 {
     qCDebug(logCategory) << "Showing tab:" << m_tabName;
     QWidget::showEvent(event);
-    QTimer::singleShot(0, this, [this](){
-        if ( isVisible() )
-            createBrowser();
-    });
+    scheduleBrowserCreation();
 }
 
 void ClipboardBrowserPlaceholder::hideEvent(QHideEvent *event)
@@ -235,8 +232,7 @@ void ClipboardBrowserPlaceholder::hideEvent(QHideEvent *event)
 bool ClipboardBrowserPlaceholder::event(QEvent *event)
 {
     if (event->type() == QEvent::WindowActivate && isVisible()) {
-        if (!m_browser && !m_loadButton)
-            createBrowser();
+        scheduleBrowserCreation();
     } else if (event->type() == QEvent::WindowDeactivate && isVisible()) {
         restartPasswordExpiry();
     }
@@ -256,6 +252,22 @@ bool ClipboardBrowserPlaceholder::expire()
 
     restartExpiring();
     return false;
+}
+
+void ClipboardBrowserPlaceholder::scheduleBrowserCreation()
+{
+    if (m_browser || m_loadButton || m_browserCreationScheduled)
+        return;
+
+    // Loading a large tab can involve substantial deserialization and plugin
+    // setup. Queue one coalesced load so the window/tab activation event can
+    // finish and the placeholder can be painted before that work starts.
+    m_browserCreationScheduled = true;
+    QTimer::singleShot(0, this, [this](){
+        m_browserCreationScheduled = false;
+        if (isVisible() && !m_browser && !m_loadButton)
+            createBrowser();
+    });
 }
 
 void ClipboardBrowserPlaceholder::setActiveWidget(QWidget *widget)

--- a/src/gui/clipboardbrowserplaceholder.h
+++ b/src/gui/clipboardbrowserplaceholder.h
@@ -65,6 +65,7 @@ protected:
     bool event(QEvent *event) override;
 
 private:
+    void scheduleBrowserCreation();
     void setActiveWidget(QWidget *widget);
 
     bool canExpire() const;
@@ -80,6 +81,7 @@ private:
     void onFilterProgressChanged(int percent);
 
     ClipboardBrowser *m_browser = nullptr;
+    bool m_browserCreationScheduled = false;
     QPushButton *m_loadButton = nullptr;
     QProgressBar *m_filterProgressBar = nullptr;
 

--- a/src/gui/clipboardbrowserplaceholder.h
+++ b/src/gui/clipboardbrowserplaceholder.h
@@ -65,7 +65,6 @@ protected:
     bool event(QEvent *event) override;
 
 private:
-    void scheduleBrowserCreation();
     void setActiveWidget(QWidget *widget);
 
     bool canExpire() const;
@@ -81,7 +80,6 @@ private:
     void onFilterProgressChanged(int percent);
 
     ClipboardBrowser *m_browser = nullptr;
-    bool m_browserCreationScheduled = false;
     QPushButton *m_loadButton = nullptr;
     QProgressBar *m_filterProgressBar = nullptr;
 

--- a/src/gui/clipboarddialog.cpp
+++ b/src/gui/clipboarddialog.cpp
@@ -216,7 +216,8 @@ void ClipboardDialog::init()
     WindowGeometryGuard::create(this);
 
     ui->actionRemove_Format->setIcon( getIcon("list-remove", IconTrash) );
-    ui->actionRemove_Format->setShortcut(shortcutToRemove());
+    ui->actionRemove_Format->setShortcut(
+        QKeySequence(shortcutToRemove(), QKeySequence::PortableText));
     ui->listWidgetFormats->addAction(ui->actionRemove_Format);
 
     onListWidgetFormatsCurrentItemChanged(nullptr, nullptr);

--- a/src/gui/commandcompleter.cpp
+++ b/src/gui/commandcompleter.cpp
@@ -218,7 +218,8 @@ CommandCompleter::CommandCompleter(QPlainTextEdit *editor)
     connect( m_editor, &QPlainTextEdit::cursorPositionChanged,
              m_completer->popup(), &QWidget::hide );
 
-    auto shortcut = new QShortcut(tr("Ctrl+Space", "Shortcut to show completion menu"), editor);
+    auto shortcut = new QShortcut(
+        QKeySequence(QStringLiteral("Ctrl+Space"), QKeySequence::PortableText), editor);
     connect( shortcut, &QShortcut::activated,
              this, &CommandCompleter::showCompletion );
 }

--- a/src/gui/filtercompleter.cpp
+++ b/src/gui/filtercompleter.cpp
@@ -6,6 +6,7 @@
 #include <QApplication>
 #include <QAction>
 #include <QEvent>
+#include <QKeySequence>
 #include <QLineEdit>
 #include <QMoveEvent>
 
@@ -169,7 +170,8 @@ FilterCompleter::FilterCompleter(QLineEdit *lineEdit)
     QWidget *window = lineEdit->window();
     if (window) {
         auto act = new QAction(this);
-        act->setShortcut(tr("Alt+Down", "Filter completion shortcut"));
+        act->setShortcut(
+            QKeySequence(QStringLiteral("Alt+Down"), QKeySequence::PortableText));
         connect(act, &QAction::triggered, this, &FilterCompleter::onComplete);
         window->addAction(act);
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -938,7 +938,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
 bool MainWindow::focusNextPrevChild(bool next)
 {
-    auto c = browser();
+    auto c = browserOrNull();
     if (!c)
         return false;
 
@@ -2074,7 +2074,7 @@ bool MainWindow::isWindowVisible() const
 void MainWindow::onEscape()
 {
     if ( browseMode() ) {
-        auto c = browser();
+        auto c = browserOrNull();
         if (c && !c->hasFocus()) {
             enterBrowseMode();
             return;
@@ -2883,7 +2883,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *ev)
     const auto translate = (m_options.navigationStyle == NavigationStyle::Vi)
         ? translateToVi : translateToEmacs;
 
-    if (object == this || object == browser()) {
+    if (object == this || object == browserOrNull()) {
         const KeyMods keyMods = translate({key, modifiers});
         if ( hadleKeyOverride(object, ev, keyMods) )
             return true;
@@ -2930,7 +2930,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         return;
     }
 
-    auto c = browser();
+    auto c = browserOrNull();
     if (c && c->isInternalEditorOpen())
         return;
 
@@ -3265,11 +3265,16 @@ void MainWindow::showWindow()
 
     ensureWindowOnScreen(this);
 
-    auto c = browser();
+    // Do not force-load an expired or not-yet-created large tab while the
+    // window-show event is still on the stack. The visible placeholder queues
+    // creation and onBrowserLoaded() completes focus and tab setup.
+    auto c = browserOrNull();
     if (c) {
         if ( !c->isInternalEditorOpen() )
             c->scrollTo( c->currentIndex() );
         c->setFocus();
+    } else if (auto placeholder = getPlaceholder()) {
+        placeholder->setFocus();
     }
 
     raiseWindow(this);
@@ -3287,7 +3292,7 @@ void MainWindow::hideWindow()
     // is closed.
     if ( !browseMode() ) {
         enterBrowseMode();
-        auto c = browser();
+        auto c = browserOrNull();
         if (c)
             c->setCurrent(0);
     }
@@ -3426,8 +3431,10 @@ void MainWindow::tabChanged(int current, int)
     emit tabGroupSelected(currentIsTabGroup);
 
     if (!currentIsTabGroup) {
-        // update item menu (necessary for keyboard shortcuts to work)
-        auto c = browser();
+        // Do not construct an unloaded tab inside the currentChanged signal.
+        // The placeholder queues loading and onBrowserLoaded() re-enters this
+        // method once the browser is ready.
+        auto c = browserOrNull();
         if (c) {
             c->filterItems( browseMode() ? nullptr : ui->searchBar->filter() );
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -2518,7 +2518,14 @@ bool MainWindow::importDataV3(QDataStream *in, ImportOptions options)
         tabs.append(oldTabName);
     }
 
-    const ImportSelection importSelection = getImportSelection(data, options, this);
+    // V3 stores complete tab maps in the metadata, while newer formats store
+    // only tab names there and stream the tab payloads separately. Normalize
+    // the metadata before opening the shared selection dialog so it receives
+    // the actual names instead of trying to convert QVariantMap values to
+    // strings.
+    QVariantMap selectionData = data;
+    selectionData[QStringLiteral("tabs")] = tabs;
+    const ImportSelection importSelection = getImportSelection(selectionData, options, this);
     if (!canImport(importSelection))
         return false;
 
@@ -2526,7 +2533,7 @@ bool MainWindow::importDataV3(QDataStream *in, ImportOptions options)
     for (const auto &tabMapValue : tabsList) {
         const auto tabMap = tabMapValue.toMap();
         const auto oldTabName = tabMap["name"].toString();
-        if ( !tabs.contains(oldTabName) )
+        if ( !importSelection.tabs.contains(oldTabName) )
             continue;
 
         if ( !importTabData(oldTabName, tabMap, tabProps, {}) )

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1352,11 +1352,30 @@ void MainWindow::onItemCommandActionTriggered(CommandAction *commandAction, cons
 
     if ( !command.tab.isEmpty() && command.tab != c->tabName() ) {
         auto c2 = tab(command.tab);
-        if (c2) {
-            for (int i = selected.size() - 1; i >= 0; --i) {
-                const auto data = c->copyIndex(selected[i]);
-                if ( !data.isEmpty() )
-                    c2->addUnique(data, ClipboardMode::Clipboard);
+        if (!c2) {
+            showError( tr("Target tab %1 is not available.").arg(quoteString(command.tab)) );
+            return;
+        }
+
+        QVector<QVariantMap> copiedItems;
+        copiedItems.reserve(selected.size());
+        for (int i = selected.size() - 1; i >= 0; --i) {
+            QString errorString;
+            const auto data = c->copyIndex(selected[i], &errorString);
+            if ( !errorString.isEmpty() ) {
+                showError(errorString);
+                return;
+            }
+            copiedItems.append(data);
+        }
+
+        for (const auto &data : copiedItems) {
+            if ( !c2->addUnique(data, ClipboardMode::Clipboard) ) {
+                showError(
+                    tr("Failed to add copied items to tab %1. "
+                       "The source items were left unchanged.")
+                    .arg(quoteString(command.tab)) );
+                return;
             }
         }
     }
@@ -4351,7 +4370,13 @@ void MainWindow::copyItems()
     if ( indexes.isEmpty() )
         return;
 
-    const auto data = c->copyIndexes(indexes);
+    QString errorString;
+    const auto data = c->copyIndexes(indexes, &errorString);
+    if ( !errorString.isEmpty() ) {
+        showError(errorString);
+        return;
+    }
+
     setClipboard(data);
 }
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -3258,10 +3258,18 @@ void MainWindow::showWindow()
 
     moveToCurrentWorkspace(this);
 
-    if ( !isGeometryGuardBlockedUntilHidden(this) && (m_wasMaximized || isMaximized()) )
+    if ( !isGeometryGuardBlockedUntilHidden(this) && (m_wasMaximized || isMaximized()) ) {
         showMaximized();
-    else
+    } else if (isMinimized()) {
+        // Restoring a minimized window requires clearing the minimized state.
         showNormal();
+    } else {
+        // Showing a hidden or inactive normal window is only a visibility
+        // transition. Calling showNormal() here also rewrites the native window
+        // state, which can make X11 window managers place the window again on
+        // every toggle (issue #3643).
+        show();
+    }
 
     ensureWindowOnScreen(this);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1337,13 +1337,23 @@ void MainWindow::onItemCommandActionTriggered(CommandAction *commandAction, cons
     if ( !command.cmd.isEmpty() ) {
         if (command.transform) {
             for (const auto &index : selected) {
-                auto actionData = selectionData(*c, index, {index});
+                QString errorString;
+                auto actionData = selectionData(*c, index, {index}, &errorString);
+                if ( !errorString.isEmpty() ) {
+                    showError(errorString);
+                    return;
+                }
                 if ( !triggeredShortcut.isEmpty() )
                     actionData.insert(mimeShortcut, triggeredShortcut);
                 action(actionData, command, index);
             }
         } else {
-            auto actionData = selectionData(*c);
+            QString errorString;
+            auto actionData = selectionData(*c, &errorString);
+            if ( !errorString.isEmpty() ) {
+                showError(errorString);
+                return;
+            }
             if ( !triggeredShortcut.isEmpty() )
                 actionData.insert(mimeShortcut, triggeredShortcut);
             action(actionData, command, QModelIndex());
@@ -1380,8 +1390,21 @@ void MainWindow::onItemCommandActionTriggered(CommandAction *commandAction, cons
         }
     }
 
-    if ( command.remove && (command.tab.isEmpty() || command.tab != c->tabName()) )
+    if ( command.remove && (command.tab.isEmpty() || command.tab != c->tabName()) ) {
+        // A remove-only command has no action or destination path that would
+        // otherwise materialize lazy synchronized data. Verify ownership
+        // before deleting so an unreadable backing file cannot be discarded as
+        // though it had been copied successfully.
+        if (command.cmd.isEmpty() && command.tab.isEmpty()) {
+            QString errorString;
+            c->copyIndexes(selected, &errorString);
+            if ( !errorString.isEmpty() ) {
+                showError(errorString);
+                return;
+            }
+        }
         c->removeIndexes(selected);
+    }
 
     if (command.hideWindow)
         hideWindow();

--- a/src/gui/menuitems.cpp
+++ b/src/gui/menuitems.cpp
@@ -26,11 +26,15 @@ void addMenuItem(
     item.iconId = iconId;
 }
 
+// Keep shortcut identity independent of UI translations. Portable packages can
+// contain CopyQ translations without the matching Qt key-name catalogs, making
+// translated NativeText impossible for QKeySequence to parse.
 void addMenuItem(
         MenuItems &items, Actions::Id id, const QString &text, const QString &settingsKey,
-        const QString &shortcutText, const QString &iconName, ushort iconId = 0)
+        const char *shortcutPortableText, const QString &iconName, ushort iconId = 0)
 {
-    const auto shortcut = QKeySequence(shortcutText, QKeySequence::NativeText);
+    const auto shortcut = QKeySequence(
+        QString::fromLatin1(shortcutPortableText), QKeySequence::PortableText);
     addMenuItem(items, id, text, settingsKey, shortcut, iconName, iconId);
 }
 
@@ -41,32 +45,32 @@ MenuItems menuItems()
     MenuItems items;
     addMenuItem( items, Actions::File_New, QObject::tr("&New Item"), QStringLiteral("new"), QKeySequence::New,
                   QStringLiteral("document-new"), IconFileLines );
-    addMenuItem( items, Actions::File_Import, QObject::tr("&Import..."), QStringLiteral("import"), QObject::tr("Ctrl+Shift+I"),
+    addMenuItem( items, Actions::File_Import, QObject::tr("&Import..."), QStringLiteral("import"), "Ctrl+Shift+I",
                   QStringLiteral("document-open"), IconFolderOpen );
     addMenuItem( items, Actions::File_Export, QObject::tr("&Export..."), QStringLiteral("export"), QKeySequence::Save,
                   QStringLiteral("document-save"), IconFloppyDisk );
-    addMenuItem( items, Actions::File_Preferences, QObject::tr("&Preferences..."), QStringLiteral("preferences"), QObject::tr("Ctrl+P"),
+    addMenuItem( items, Actions::File_Preferences, QObject::tr("&Preferences..."), QStringLiteral("preferences"), "Ctrl+P",
                   QStringLiteral("preferences-other"), IconWrench );
     addMenuItem( items, Actions::File_Commands,
                   QObject::tr("C&ommands..."),
-                  QStringLiteral("commands"), QObject::tr("F6"), QStringLiteral("system-run"), IconGear );
+                  QStringLiteral("commands"), "F6", QStringLiteral("system-run"), IconGear );
 
     addMenuItem( items, Actions::File_ShowClipboardContent, QObject::tr("Show &Clipboard Content"),
-                  QStringLiteral("show_clipboard_content"), QObject::tr("Ctrl+Shift+C"), QStringLiteral("dialog-information"), IconPaste );
+                  QStringLiteral("show_clipboard_content"), "Ctrl+Shift+C", QStringLiteral("dialog-information"), IconPaste );
     addMenuItem( items, Actions::File_ShowPreview, QObject::tr("&Show Preview"),
-                 QStringLiteral("show_item_preview"), QObject::tr("F7"), QStringLiteral("document-print-preview"), IconEye );
+                 QStringLiteral("show_item_preview"), "F7", QStringLiteral("document-print-preview"), IconEye );
     addMenuItem( items, Actions::File_ToggleClipboardStoring, QObject::tr("&Toggle Clipboard Storing"),
-                  QStringLiteral("toggle_clipboard_storing"), QObject::tr("Ctrl+Shift+X"), QStringLiteral(""), IconBan );
+                  QStringLiteral("toggle_clipboard_storing"), "Ctrl+Shift+X", QStringLiteral(""), IconBan );
     addMenuItem( items, Actions::File_ProcessManager, QObject::tr("P&rocess Manager"),
-                  QStringLiteral("process_manager"), QObject::tr("Ctrl+Shift+Z"), QStringLiteral("system-search"), IconGears );
-    addMenuItem( items, Actions::File_Exit, QObject::tr("E&xit"), QStringLiteral("exit"), QObject::tr("Ctrl+Q"),
+                  QStringLiteral("process_manager"), "Ctrl+Shift+Z", QStringLiteral("system-search"), IconGears );
+    addMenuItem( items, Actions::File_Exit, QObject::tr("E&xit"), QStringLiteral("exit"), "Ctrl+Q",
                   QStringLiteral("application-exit"), IconPowerOff );
 
     addMenuItem( items, Actions::Edit_SortSelectedItems, QObject::tr("&Sort Selected Items"),
-                  QStringLiteral("sort_selected_items"), QObject::tr("Ctrl+Shift+S"),
+                  QStringLiteral("sort_selected_items"), "Ctrl+Shift+S",
                   QStringLiteral("view-sort-ascending"), IconArrowDownAZ );
     addMenuItem( items, Actions::Edit_ReverseSelectedItems, QObject::tr("&Reverse Selected Items"),
-                  QStringLiteral("reverse_selected_items"), QObject::tr("Ctrl+Shift+R"),
+                  QStringLiteral("reverse_selected_items"), "Ctrl+Shift+R",
                   QStringLiteral("view-sort-descending"), IconArrowUpAZ );
     addMenuItem( items, Actions::Edit_PasteItems, QObject::tr("&Paste Items"),
                   QStringLiteral("paste_selected_items"), QKeySequence::Paste, QStringLiteral("edit-paste"), IconPaste );
@@ -76,9 +80,9 @@ MenuItems menuItems()
                   QStringLiteral("find_items"), QKeySequence::FindNext, QStringLiteral("edit-find"), IconMagnifyingGlass );
 
     addMenuItem(items, Actions::Editor_Save, QObject::tr("Save Item"),
-                QStringLiteral("editor_save"), QObject::tr("F2", "Shortcut to save item editor changes"), QStringLiteral("document-save"), IconFloppyDisk);
+                QStringLiteral("editor_save"), "F2", QStringLiteral("document-save"), IconFloppyDisk);
     addMenuItem(items, Actions::Editor_Cancel, QObject::tr("Cancel Editing"),
-                QStringLiteral("editor_cancel"), QObject::tr("Escape", "Shortcut to revert item editor changes"), QStringLiteral("document-revert"), IconTrash);
+                QStringLiteral("editor_cancel"), "Escape", QStringLiteral("document-revert"), IconTrash);
     addMenuItem(items, Actions::Editor_Undo, QObject::tr("Undo"),
                 QStringLiteral("editor_undo"), QKeySequence::Undo, QStringLiteral("edit-undo"), IconRotateLeft);
     addMenuItem(items, Actions::Editor_Redo, QObject::tr("Redo"),
@@ -107,51 +111,52 @@ MenuItems menuItems()
                               "copies selected items to clipboard and moves them to top (depending on settings)"),
                   QStringLiteral("move_to_clipboard"), QKeySequence(), QStringLiteral("clipboard"), IconPaste );
     addMenuItem( items, Actions::Item_ShowContent, QObject::tr("&Show Content..."),
-                  QStringLiteral("show_item_content"), QObject::tr("F4"), QStringLiteral("dialog-information"), IconCircleInfo );
+                  QStringLiteral("show_item_content"), "F4", QStringLiteral("dialog-information"), IconCircleInfo );
     addMenuItem( items, Actions::Item_Remove, QObject::tr("&Remove"),
-                  QStringLiteral("delete_item"),  shortcutToRemove(), QStringLiteral("list-remove"), IconTrash );
-    addMenuItem( items, Actions::Item_Edit, QObject::tr("&Edit"), QStringLiteral("edit"), QObject::tr("F2"),
+                  QStringLiteral("delete_item"),
+                  QKeySequence(shortcutToRemove(), QKeySequence::PortableText), QStringLiteral("list-remove"), IconTrash );
+    addMenuItem( items, Actions::Item_Edit, QObject::tr("&Edit"), QStringLiteral("edit"), "F2",
                   QStringLiteral("accessories-text-editor"), IconPenToSquare );
     addMenuItem( items, Actions::Item_EditNotes, QObject::tr("Edit &Notes"),
-                  QStringLiteral("edit_notes"), QObject::tr("Shift+F2"), QStringLiteral("accessories-text-editor"), IconPenToSquare );
+                  QStringLiteral("edit_notes"), "Shift+F2", QStringLiteral("accessories-text-editor"), IconPenToSquare );
     addMenuItem( items, Actions::Item_EditWithEditor, QObject::tr("E&dit with Editor"),
-                  QStringLiteral("editor"), QObject::tr("Ctrl+E"), QStringLiteral("accessories-text-editor"), IconPencil );
-    addMenuItem( items, Actions::Item_Action, QObject::tr("&Action..."), QStringLiteral("system-run"), QObject::tr("F5"),
+                  QStringLiteral("editor"), "Ctrl+E", QStringLiteral("accessories-text-editor"), IconPencil );
+    addMenuItem( items, Actions::Item_Action, QObject::tr("&Action..."), QStringLiteral("system-run"), "F5",
                   QStringLiteral("action"), IconBolt );
 
     addMenuItem( items, Actions::Item_MoveUp, QObject::tr("Move Up"),
-                  QStringLiteral("move_up"),  QObject::tr("Ctrl+Up"), QStringLiteral("go-up"), IconAngleUp );
+                  QStringLiteral("move_up"),  "Ctrl+Up", QStringLiteral("go-up"), IconAngleUp );
     addMenuItem( items, Actions::Item_MoveDown, QObject::tr("Move Down"),
-                  QStringLiteral("move_down"),  QObject::tr("Ctrl+Down"), QStringLiteral("go-down"), IconAngleDown );
+                  QStringLiteral("move_down"),  "Ctrl+Down", QStringLiteral("go-down"), IconAngleDown );
     addMenuItem( items, Actions::Item_MoveToTop, QObject::tr("Move to Top"),
-                  QStringLiteral("move_to_top"),  QObject::tr("Ctrl+Home"), QStringLiteral("go-top"), IconAnglesUp );
+                  QStringLiteral("move_to_top"),  "Ctrl+Home", QStringLiteral("go-top"), IconAnglesUp );
     addMenuItem( items, Actions::Item_MoveToBottom, QObject::tr("Move to Bottom"),
-                  QStringLiteral("move_to_bottom"),  QObject::tr("Ctrl+End"), QStringLiteral("go-bottom"), IconAnglesDown );
+                  QStringLiteral("move_to_bottom"),  "Ctrl+End", QStringLiteral("go-bottom"), IconAnglesDown );
 
     addMenuItem( items, Actions::Tabs_NewTab, QObject::tr("&New Tab"),
-                  QStringLiteral("new_tab"), QObject::tr("Ctrl+T"), QStringLiteral(":/images/tab_new") );
+                  QStringLiteral("new_tab"), "Ctrl+T", QStringLiteral(":/images/tab_new") );
     addMenuItem( items, Actions::Tabs_RenameTab, QObject::tr("R&ename Tab"),
-                  QStringLiteral("rename_tab"), QObject::tr("Ctrl+F2"), QStringLiteral(":/images/tab_rename") );
+                  QStringLiteral("rename_tab"), "Ctrl+F2", QStringLiteral(":/images/tab_rename") );
     addMenuItem( items, Actions::Tabs_RemoveTab, QObject::tr("Re&move Tab"),
-                  QStringLiteral("remove_tab"), QObject::tr("Ctrl+W"), QStringLiteral(":/images/tab_remove") );
+                  QStringLiteral("remove_tab"), "Ctrl+W", QStringLiteral(":/images/tab_remove") );
     addMenuItem( items, Actions::Tabs_ChangeTabIcon, QObject::tr("&Change Tab Icon"),
-                  QStringLiteral("change_tab_icon"), QObject::tr("Ctrl+Shift+T"), QStringLiteral(":/images/tab_icon") );
+                  QStringLiteral("change_tab_icon"), "Ctrl+Shift+T", QStringLiteral(":/images/tab_icon") );
     addMenuItem( items, Actions::Tabs_NextTab, QObject::tr("Ne&xt Tab"),
-                  QStringLiteral("next_tab"), QObject::tr("Right", "Default shortcut to focus next tab"),
+                  QStringLiteral("next_tab"), "Right",
                   QStringLiteral("go-next"), IconArrowRight );
     addMenuItem( items, Actions::Tabs_PreviousTab, QObject::tr("&Previous Tab"),
-                  QStringLiteral("previous_tab"), QObject::tr("Left", "Default shortcut to focus previous tab"),
+                  QStringLiteral("previous_tab"), "Left",
                   QStringLiteral("go-previous"), IconArrowLeft );
 
     addMenuItem( items, Actions::Help_Help, QObject::tr("&Help"), QStringLiteral("help"), QKeySequence::HelpContents,
                   QStringLiteral("help-contents"), IconCircleQuestion );
-    addMenuItem( items, Actions::Help_ShowLog, QObject::tr("&Show Log"), QStringLiteral("show-log"), QObject::tr("F12"),
+    addMenuItem( items, Actions::Help_ShowLog, QObject::tr("&Show Log"), QStringLiteral("show-log"), "F12",
                   QStringLiteral("help-about"), IconCircleExclamation );
     addMenuItem( items, Actions::Help_About, QObject::tr("&About"), QStringLiteral("about"), QKeySequence::WhatsThis,
                   QStringLiteral("help-about"), IconCircleInfo );
 
     addMenuItem( items, Actions::ItemMenu, QObject::tr("Open Item Context Menu"), QStringLiteral("item-menu"),
-                 QObject::tr("Shift+F10", "Default shortcut to open item context menu"),
+                 "Shift+F10",
                  QStringLiteral(""), IconRectangleList );
 
     return items;

--- a/src/gui/selectiondata.cpp
+++ b/src/gui/selectiondata.cpp
@@ -26,9 +26,12 @@ void addSelectionData(
 QVariantMap selectionData(
         const ClipboardBrowser &c,
         const QModelIndex &currentIndex,
-        const QModelIndexList &selectedIndexes)
+        const QModelIndexList &selectedIndexes,
+        QString *error)
 {
-    auto result = c.copyIndexes(selectedIndexes);
+    auto result = c.copyIndexes(selectedIndexes, error);
+    if (error && !error->isEmpty())
+        return {};
 
     result.insert(mimeCurrentTab, c.tabName());
 
@@ -44,9 +47,9 @@ QVariantMap selectionData(
     return result;
 }
 
-QVariantMap selectionData(const ClipboardBrowser &c)
+QVariantMap selectionData(const ClipboardBrowser &c, QString *error)
 {
     const QModelIndexList selectedIndexes = c.selectionModel()->selectedIndexes();
     const auto current = c.selectionModel()->currentIndex();
-    return selectionData(c, current, selectedIndexes);
+    return selectionData(c, current, selectedIndexes, error);
 }

--- a/src/gui/selectiondata.h
+++ b/src/gui/selectiondata.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <QModelIndexList>
+#include <QString>
 #include <QVariantMap>
 #include <QtContainerFwd>
 
@@ -19,6 +20,7 @@ void addSelectionData(
 QVariantMap selectionData(
         const ClipboardBrowser &c,
         const QModelIndex &currentIndex,
-        const QModelIndexList &selectedIndexes);
+        const QModelIndexList &selectedIndexes,
+        QString *error = nullptr);
 
-QVariantMap selectionData(const ClipboardBrowser &c);
+QVariantMap selectionData(const ClipboardBrowser &c, QString *error = nullptr);

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -67,6 +67,9 @@ bool ItemDelegate::eventFilter(QObject *obj, QEvent *event)
     if ( event->type() == QEvent::Resize ) {
         const int row = findWidgetRow(obj);
         Q_ASSERT(row != -1);
+        if (row == -1)
+            return QItemDelegate::eventFilter(obj, event);
+
         const auto index = m_view->index(row);
         updateLater();
         const auto ev = static_cast<QResizeEvent*>(event);
@@ -78,8 +81,15 @@ bool ItemDelegate::eventFilter(QObject *obj, QEvent *event)
 
 void ItemDelegate::dataChanged(const QModelIndex &a, const QModelIndex &b)
 {
-    for ( int row = a.row(); row <= b.row(); ++row )
-        m_items[row].item.reset();
+    const int last = qMin<int>(b.row(), static_cast<int>(m_items.size()) - 1);
+    for (int row = qMax(0, a.row()); row <= last; ++row) {
+        if (!m_items[row])
+            continue;
+
+        const auto index = m_view->index(row);
+        m_items[row]->widget()->removeEventFilter(this);
+        setIndexWidget(index, nullptr);
+    }
 
     updateLater();
 }
@@ -87,9 +97,6 @@ void ItemDelegate::dataChanged(const QModelIndex &a, const QModelIndex &b)
 void ItemDelegate::rowsRemoved(const QModelIndex &, int start, int end)
 {
     for (int row = start; row <= end; ++row) {
-        if ( m_view->isRowHidden(row) )
-            continue;
-
         if (m_items[row]) {
             const auto index = m_view->index(row);
             m_items[row]->widget()->removeEventFilter(this);
@@ -150,6 +157,9 @@ QWidget *ItemDelegate::createPreviewNoEmit(const QVariantMap &data, QWidget *par
 
 void ItemDelegate::rowsInserted(const QModelIndex &, int start, int end)
 {
+    if (end < start)
+        return;
+
     const auto count = static_cast<size_t>(end - start + 1);
     const auto oldSize = m_items.size();
     m_items.resize(oldSize + count);
@@ -207,8 +217,10 @@ void ItemDelegate::setItemSizes(int maxWidth, int idealWidth)
     m_idealWidth = idealWidth - margin;
     m_fontHeight = m_view->viewport()->fontMetrics().height();
 
-    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
-        if (m_items[row])
+    const auto indexes = m_widgetIndexes.values();
+    for (const auto &index : indexes) {
+        const int row = index.row();
+        if (index.isValid() && row >= 0 && static_cast<size_t>(row) < m_items.size())
             updateItemWidgetSize(row);
     }
 }
@@ -345,35 +357,51 @@ void ItemDelegate::updateAllRows()
 {
     const auto margins = m_sharedData->theme.margins();
     const int s = m_view->spacing();
-    const int space = 2 * s;
-    int y = -m_view->verticalOffset() + s + margins.height();
 
-    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
+    // Only widgets near the viewport are materialized. Walking the complete
+    // model here made every resize, tab activation and filter update scale with
+    // the total history size rather than the number of visible widgets.
+    const auto indexes = m_widgetIndexes.values();
+    for (const auto &persistentIndex : indexes) {
+        if (!persistentIndex.isValid())
+            continue;
+
+        const QModelIndex index = persistentIndex;
+        const int row = index.row();
+        if (row < 0 || static_cast<size_t>(row) >= m_items.size())
+            continue;
+
         const bool hide = m_view->isRowHidden(row);
         auto &item = m_items[row];
-        if (item) {
-            QWidget *ww = item->widget();
-            if (hide) {
-                ww->removeEventFilter(this);
-                ww->hide();
-            } else {
-                if (item.appliedFilterId != m_filterId) {
-                    highlightMatches(item.get());
-                    item.appliedFilterId = m_filterId;
-                }
-                ww->move( QPoint(ww->x(), y) );
-                if ( ww->isHidden() ) {
-                    ww->show();
-                    updateItemWidgetSize(row);
-                    ww->installEventFilter(this);
-                    const auto index = m_view->index(row);
-                    updateItemSize(index, ww->size());
-                }
-            }
+        if (!item)
+            continue;
+
+        QWidget *ww = item->widget();
+        if (hide) {
+            ww->removeEventFilter(this);
+            ww->hide();
+            continue;
         }
 
-        if (!hide)
-            y += m_items[row].size.height() + space;
+        if (item.appliedFilterId != m_filterId) {
+            highlightMatches(item.get());
+            item.appliedFilterId = m_filterId;
+        }
+
+        const QRect itemRect = m_view->visualRect(index);
+        if (itemRect.isValid()) {
+            const int rowNumberWidth = m_sharedData->theme.rowNumberSize(row).width();
+            ww->move(QPoint(
+                s + margins.width() + rowNumberWidth,
+                itemRect.top() + margins.height()));
+        }
+
+        if ( ww->isHidden() ) {
+            ww->show();
+            updateItemWidgetSize(row);
+            ww->installEventFilter(this);
+            updateItemSize(index, ww->size());
+        }
     }
 }
 
@@ -428,14 +456,24 @@ void ItemDelegate::setItemWidgetSelected(const QModelIndex &index, bool isSelect
 void ItemDelegate::setIndexWidget(const QModelIndex &index, ItemWidget *w)
 {
     const int row = index.row();
+    Q_ASSERT(0 <= row && static_cast<size_t>(row) < m_items.size());
+    if (row < 0 || static_cast<size_t>(row) >= m_items.size()) {
+        delete w;
+        return;
+    }
+
     const QPoint pos = w ? findPositionForWidget(index) : QPoint();
     const bool show = w && !m_view->isIndexHidden(index);
 
     auto &item = m_items[row];
+    if (item)
+        m_widgetIndexes.remove(item->widget());
+
     item.item.reset(w);
     item.appliedFilterId = 0;
     if (w) {
         QWidget *ww = w->widget();
+        m_widgetIndexes.insert(ww, QPersistentModelIndex(index));
 
         // Make background transparent.
         ww->setAttribute(Qt::WA_NoSystemBackground);
@@ -469,6 +507,13 @@ QPoint ItemDelegate::findPositionForWidget(const QModelIndex &index) const
     const QSize margins = m_sharedData->theme.margins();
     const QSize rowNumberSize = m_sharedData->theme.rowNumberSize(index.row());
     const int s = m_view->spacing();
+
+    const QRect itemRect = m_view->visualRect(index);
+    if (itemRect.isValid()) {
+        return QPoint(
+            s + margins.width() + rowNumberSize.width(),
+            itemRect.top() + margins.height());
+    }
 
     int y = 0;
     int skipped = 0;
@@ -519,13 +564,12 @@ void ItemDelegate::setWidgetSelected(QWidget *ww, bool selected)
 
 int ItemDelegate::findWidgetRow(const QObject *obj) const
 {
-    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
-        auto w = m_items[row].get();
-        if (w && w->widget() == obj)
-            return row;
-    }
-
-    return -1;
+    // Persistent indexes follow insertions and moves, avoiding a linear scan
+    // through every row for each item-widget resize event.
+    const auto it = m_widgetIndexes.constFind(obj);
+    return it == m_widgetIndexes.cend() || !it.value().isValid()
+        ? -1
+        : it.value().row();
 }
 
 ItemWidget *ItemDelegate::updateWidget(const QModelIndex &index, const QVariantMap &data)
@@ -582,9 +626,17 @@ void ItemDelegate::invalidateAllHiddenNow()
         return minY < g.bottom() && g.top() < maxY;
     };
 
-    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
-        if (!m_items[row] || row == currentRow)
+    const auto indexes = m_widgetIndexes.values();
+    for (const auto &persistentIndex : indexes) {
+        if (!persistentIndex.isValid())
             continue;
+
+        const int row = persistentIndex.row();
+        if (row < 0 || static_cast<size_t>(row) >= m_items.size()
+            || row == currentRow || !m_items[row])
+        {
+            continue;
+        }
 
         if ( isRowAlmostVisible(row) )
             continue;
@@ -592,7 +644,7 @@ void ItemDelegate::invalidateAllHiddenNow()
         if ( isRowAlmostVisible(row + 1) || isRowAlmostVisible(row - 1) )
             continue;
 
-        const auto index = m_view->index(row);
+        const QModelIndex index = persistentIndex;
         m_items[row]->widget()->removeEventFilter(this);
         setIndexWidget(index, nullptr);
     }

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -67,9 +67,6 @@ bool ItemDelegate::eventFilter(QObject *obj, QEvent *event)
     if ( event->type() == QEvent::Resize ) {
         const int row = findWidgetRow(obj);
         Q_ASSERT(row != -1);
-        if (row == -1)
-            return QItemDelegate::eventFilter(obj, event);
-
         const auto index = m_view->index(row);
         updateLater();
         const auto ev = static_cast<QResizeEvent*>(event);
@@ -81,15 +78,8 @@ bool ItemDelegate::eventFilter(QObject *obj, QEvent *event)
 
 void ItemDelegate::dataChanged(const QModelIndex &a, const QModelIndex &b)
 {
-    const int last = qMin<int>(b.row(), static_cast<int>(m_items.size()) - 1);
-    for (int row = qMax(0, a.row()); row <= last; ++row) {
-        if (!m_items[row])
-            continue;
-
-        const auto index = m_view->index(row);
-        m_items[row]->widget()->removeEventFilter(this);
-        setIndexWidget(index, nullptr);
-    }
+    for ( int row = a.row(); row <= b.row(); ++row )
+        m_items[row].item.reset();
 
     updateLater();
 }
@@ -97,12 +87,13 @@ void ItemDelegate::dataChanged(const QModelIndex &a, const QModelIndex &b)
 void ItemDelegate::rowsRemoved(const QModelIndex &, int start, int end)
 {
     for (int row = start; row <= end; ++row) {
+        if ( m_view->isRowHidden(row) )
+            continue;
+
         if (m_items[row]) {
-            QWidget *widget = m_items[row]->widget();
-            widget->removeEventFilter(this);
-            m_widgetIndexes.remove(widget);
-            m_items[row].item.reset();
-            m_items[row].appliedFilterId = 0;
+            const auto index = m_view->index(row);
+            m_items[row]->widget()->removeEventFilter(this);
+            setIndexWidget(index, nullptr);
         }
     }
 
@@ -159,9 +150,6 @@ QWidget *ItemDelegate::createPreviewNoEmit(const QVariantMap &data, QWidget *par
 
 void ItemDelegate::rowsInserted(const QModelIndex &, int start, int end)
 {
-    if (end < start)
-        return;
-
     const auto count = static_cast<size_t>(end - start + 1);
     const auto oldSize = m_items.size();
     m_items.resize(oldSize + count);
@@ -219,10 +207,8 @@ void ItemDelegate::setItemSizes(int maxWidth, int idealWidth)
     m_idealWidth = idealWidth - margin;
     m_fontHeight = m_view->viewport()->fontMetrics().height();
 
-    const auto indexes = m_widgetIndexes.values();
-    for (const auto &index : indexes) {
-        const int row = index.row();
-        if (index.isValid() && row >= 0 && static_cast<size_t>(row) < m_items.size())
+    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
+        if (m_items[row])
             updateItemWidgetSize(row);
     }
 }
@@ -359,51 +345,35 @@ void ItemDelegate::updateAllRows()
 {
     const auto margins = m_sharedData->theme.margins();
     const int s = m_view->spacing();
+    const int space = 2 * s;
+    int y = -m_view->verticalOffset() + s + margins.height();
 
-    // Only widgets near the viewport are materialized. Walking the complete
-    // model here made every resize, tab activation and filter update scale with
-    // the total history size rather than the number of visible widgets.
-    const auto indexes = m_widgetIndexes.values();
-    for (const auto &persistentIndex : indexes) {
-        if (!persistentIndex.isValid())
-            continue;
-
-        const QModelIndex index = persistentIndex;
-        const int row = index.row();
-        if (row < 0 || static_cast<size_t>(row) >= m_items.size())
-            continue;
-
+    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
         const bool hide = m_view->isRowHidden(row);
         auto &item = m_items[row];
-        if (!item)
-            continue;
-
-        QWidget *ww = item->widget();
-        if (hide) {
-            ww->removeEventFilter(this);
-            ww->hide();
-            continue;
+        if (item) {
+            QWidget *ww = item->widget();
+            if (hide) {
+                ww->removeEventFilter(this);
+                ww->hide();
+            } else {
+                if (item.appliedFilterId != m_filterId) {
+                    highlightMatches(item.get());
+                    item.appliedFilterId = m_filterId;
+                }
+                ww->move( QPoint(ww->x(), y) );
+                if ( ww->isHidden() ) {
+                    ww->show();
+                    updateItemWidgetSize(row);
+                    ww->installEventFilter(this);
+                    const auto index = m_view->index(row);
+                    updateItemSize(index, ww->size());
+                }
+            }
         }
 
-        if (item.appliedFilterId != m_filterId) {
-            highlightMatches(item.get());
-            item.appliedFilterId = m_filterId;
-        }
-
-        const QRect itemRect = m_view->visualRect(index);
-        if (itemRect.isValid()) {
-            const int rowNumberWidth = m_sharedData->theme.rowNumberSize(row).width();
-            ww->move(QPoint(
-                s + margins.width() + rowNumberWidth,
-                itemRect.top() + margins.height()));
-        }
-
-        if ( ww->isHidden() ) {
-            ww->show();
-            updateItemWidgetSize(row);
-            ww->installEventFilter(this);
-            updateItemSize(index, ww->size());
-        }
+        if (!hide)
+            y += m_items[row].size.height() + space;
     }
 }
 
@@ -458,24 +428,14 @@ void ItemDelegate::setItemWidgetSelected(const QModelIndex &index, bool isSelect
 void ItemDelegate::setIndexWidget(const QModelIndex &index, ItemWidget *w)
 {
     const int row = index.row();
-    Q_ASSERT(0 <= row && static_cast<size_t>(row) < m_items.size());
-    if (row < 0 || static_cast<size_t>(row) >= m_items.size()) {
-        delete w;
-        return;
-    }
-
     const QPoint pos = w ? findPositionForWidget(index) : QPoint();
     const bool show = w && !m_view->isIndexHidden(index);
 
     auto &item = m_items[row];
-    if (item)
-        m_widgetIndexes.remove(item->widget());
-
     item.item.reset(w);
     item.appliedFilterId = 0;
     if (w) {
         QWidget *ww = w->widget();
-        m_widgetIndexes.insert(ww, QPersistentModelIndex(index));
 
         // Make background transparent.
         ww->setAttribute(Qt::WA_NoSystemBackground);
@@ -509,13 +469,6 @@ QPoint ItemDelegate::findPositionForWidget(const QModelIndex &index) const
     const QSize margins = m_sharedData->theme.margins();
     const QSize rowNumberSize = m_sharedData->theme.rowNumberSize(index.row());
     const int s = m_view->spacing();
-
-    const QRect itemRect = m_view->visualRect(index);
-    if (itemRect.isValid()) {
-        return QPoint(
-            s + margins.width() + rowNumberSize.width(),
-            itemRect.top() + margins.height());
-    }
 
     int y = 0;
     int skipped = 0;
@@ -566,12 +519,13 @@ void ItemDelegate::setWidgetSelected(QWidget *ww, bool selected)
 
 int ItemDelegate::findWidgetRow(const QObject *obj) const
 {
-    // Persistent indexes follow insertions and moves, avoiding a linear scan
-    // through every row for each item-widget resize event.
-    const auto it = m_widgetIndexes.constFind(obj);
-    return it == m_widgetIndexes.cend() || !it.value().isValid()
-        ? -1
-        : it.value().row();
+    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
+        auto w = m_items[row].get();
+        if (w && w->widget() == obj)
+            return row;
+    }
+
+    return -1;
 }
 
 ItemWidget *ItemDelegate::updateWidget(const QModelIndex &index, const QVariantMap &data)
@@ -628,17 +582,9 @@ void ItemDelegate::invalidateAllHiddenNow()
         return minY < g.bottom() && g.top() < maxY;
     };
 
-    const auto indexes = m_widgetIndexes.values();
-    for (const auto &persistentIndex : indexes) {
-        if (!persistentIndex.isValid())
+    for (int row = 0; static_cast<size_t>(row) < m_items.size(); ++row) {
+        if (!m_items[row] || row == currentRow)
             continue;
-
-        const int row = persistentIndex.row();
-        if (row < 0 || static_cast<size_t>(row) >= m_items.size()
-            || row == currentRow || !m_items[row])
-        {
-            continue;
-        }
 
         if ( isRowAlmostVisible(row) )
             continue;
@@ -646,7 +592,7 @@ void ItemDelegate::invalidateAllHiddenNow()
         if ( isRowAlmostVisible(row + 1) || isRowAlmostVisible(row - 1) )
             continue;
 
-        const QModelIndex index = persistentIndex;
+        const auto index = m_view->index(row);
         m_items[row]->widget()->removeEventFilter(this);
         setIndexWidget(index, nullptr);
     }
@@ -661,15 +607,6 @@ void ItemDelegate::setItemFilter(const ItemFilterPtr &filter)
 void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
                          const QModelIndex &index) const
 {
-    const int row = index.row();
-    if (row >= 0 && static_cast<size_t>(row) < m_items.size() && !m_items[row]) {
-        // Preloading uses provisional row heights and can miss rows that only
-        // become visible after batched layout refines the geometry. Painting
-        // is the final authority on visibility, so never leave a painted row
-        // without its item widget.
-        const_cast<ItemDelegate *>(this)->createItemWidget(index);
-    }
-
     const bool isSelected = option.state & QStyle::State_Selected;
 
     // Draw the list widget background clipped to the item rect so that

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -98,9 +98,11 @@ void ItemDelegate::rowsRemoved(const QModelIndex &, int start, int end)
 {
     for (int row = start; row <= end; ++row) {
         if (m_items[row]) {
-            const auto index = m_view->index(row);
-            m_items[row]->widget()->removeEventFilter(this);
-            setIndexWidget(index, nullptr);
+            QWidget *widget = m_items[row]->widget();
+            widget->removeEventFilter(this);
+            m_widgetIndexes.remove(widget);
+            m_items[row].item.reset();
+            m_items[row].appliedFilterId = 0;
         }
     }
 

--- a/src/item/itemdelegate.cpp
+++ b/src/item/itemdelegate.cpp
@@ -661,6 +661,15 @@ void ItemDelegate::setItemFilter(const ItemFilterPtr &filter)
 void ItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
                          const QModelIndex &index) const
 {
+    const int row = index.row();
+    if (row >= 0 && static_cast<size_t>(row) < m_items.size() && !m_items[row]) {
+        // Preloading uses provisional row heights and can miss rows that only
+        // become visible after batched layout refines the geometry. Painting
+        // is the final authority on visibility, so never leave a painted row
+        // without its item widget.
+        const_cast<ItemDelegate *>(this)->createItemWidget(index);
+    }
+
     const bool isSelected = option.state & QStyle::State_Selected;
 
     // Draw the list widget background clipped to the item rect so that

--- a/src/item/itemdelegate.h
+++ b/src/item/itemdelegate.h
@@ -6,9 +6,7 @@
 #include "gui/clipboardbrowsershared.h"
 #include "item/persistentdisplayitem.h"
 
-#include <QHash>
 #include <QItemDelegate>
-#include <QPersistentModelIndex>
 #include <QTimer>
 
 #include <memory>
@@ -158,7 +156,4 @@ class ItemDelegate final : public QItemDelegate
         QTimer m_timerInvalidateHidden;
 
         std::vector<Item> m_items;
-        // Materialized item widgets are sparse; persistent indexes keep this
-        // lookup valid across model insertions and moves.
-        QHash<const QObject *, QPersistentModelIndex> m_widgetIndexes;
 };

--- a/src/item/itemdelegate.h
+++ b/src/item/itemdelegate.h
@@ -6,7 +6,9 @@
 #include "gui/clipboardbrowsershared.h"
 #include "item/persistentdisplayitem.h"
 
+#include <QHash>
 #include <QItemDelegate>
+#include <QPersistentModelIndex>
 #include <QTimer>
 
 #include <memory>
@@ -156,4 +158,7 @@ class ItemDelegate final : public QItemDelegate
         QTimer m_timerInvalidateHidden;
 
         std::vector<Item> m_items;
+        // Materialized item widgets are sparse; persistent indexes keep this
+        // lookup valid across model insertions and moves.
+        QHash<const QObject *, QPersistentModelIndex> m_widgetIndexes;
 };

--- a/src/item/itemsaverwrapper.cpp
+++ b/src/item/itemsaverwrapper.cpp
@@ -32,9 +32,11 @@ void ItemSaverWrapper::itemsRemovedByUser(const QList<QPersistentModelIndex> &in
     return m_saver->itemsRemovedByUser(indexList);
 }
 
-QVariantMap ItemSaverWrapper::copyItem(const QAbstractItemModel &model, const QVariantMap &itemData)
+bool ItemSaverWrapper::copyItem(
+    const QAbstractItemModel &model, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *error)
 {
-    return m_saver->copyItem(model, itemData);
+    return m_saver->copyItem(model, itemData, copiedItemData, error);
 }
 
 void ItemSaverWrapper::setFocus(bool focus)

--- a/src/item/itemsaverwrapper.h
+++ b/src/item/itemsaverwrapper.h
@@ -17,7 +17,11 @@ public:
 
     void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList) override;
 
-    QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData) override;
+    bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error) override;
 
     void setFocus(bool focus) override;
 

--- a/src/item/itemwidget.cpp
+++ b/src/item/itemwidget.cpp
@@ -200,9 +200,13 @@ void ItemSaverInterface::itemsRemovedByUser(const QList<QPersistentModelIndex> &
     /* No-op default: subclasses override to handle user-initiated removal */
 }
 
-QVariantMap ItemSaverInterface::copyItem(const QAbstractItemModel &, const QVariantMap &itemData)
+bool ItemSaverInterface::copyItem(
+    const QAbstractItemModel &, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *)
 {
-    return itemData;
+    Q_ASSERT(copiedItemData);
+    *copiedItemData = itemData;
+    return true;
 }
 
 void ItemSaverInterface::setFocus(bool)

--- a/src/item/itemwidget.h
+++ b/src/item/itemwidget.h
@@ -203,9 +203,17 @@ public:
     virtual void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList);
 
     /**
-     * Return copy of items data.
+     * Create a self-contained copy of item data.
+     *
+     * Implementations with lazy or externally owned values must materialize
+     * them before reporting success. On failure, @a copiedItemData is left
+     * unchanged and callers must leave the source item unchanged.
      */
-    virtual QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData);
+    virtual bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error);
 
     virtual void setFocus(bool focus);
 

--- a/src/platform/dummy/dummyclipboard.cpp
+++ b/src/platform/dummy/dummyclipboard.cpp
@@ -2,6 +2,7 @@
 
 #include "dummyclipboard.h"
 
+#include "common/clipboarddataguard.h"
 #include "common/common.h"
 #include "common/log.h"
 #include "common/mimetypes.h"
@@ -9,6 +10,8 @@
 #include <QGuiApplication>
 #include <QMimeData>
 #include <QStringList>
+
+#include <algorithm>
 
 QClipboard::Mode modeToQClipboardMode(ClipboardMode mode)
 {
@@ -35,18 +38,67 @@ void DummyClipboard::stopMonitoringBackend()
                this, &DummyClipboard::onClipboardChanged);
 }
 
-QVariantMap DummyClipboard::data(ClipboardMode mode, const QStringList &formats) const
+namespace {
+
+bool isImageFormat(const QString &format)
 {
-    const QMimeData *data = mimeData(mode);
-    if (data == nullptr)
-        return {};
+    return format == QLatin1String("application/x-qt-image")
+        || format.startsWith(QLatin1String("image/"));
+}
 
-    const bool isDataSecret = isHidden(*data);
-    QVariantMap dataMap = cloneData(data, formats, clipboardSequenceNumber(mode));
+bool containsNonEmptyFormat(const QVariantMap &data, bool (*predicate)(const QString &))
+{
+    for (auto it = data.constBegin(); it != data.constEnd(); ++it) {
+        if (predicate(it.key()) && !it.value().toByteArray().isEmpty())
+            return true;
+    }
+    return false;
+}
+
+bool hasMaterializedText(const QVariantMap &data)
+{
+    return !data.value(mimeText).toByteArray().isEmpty()
+        || !data.value(mimeTextUtf8).toByteArray().isEmpty()
+        || !data.value(mimeHtml).toByteArray().isEmpty();
+}
+
+bool imageReadIsComplete(
+        const QStringList &requestedFormats,
+        const QStringList &availableFormats,
+        const QVariantMap &data)
+{
+    const bool imageRequested = std::any_of(
+        requestedFormats.cbegin(), requestedFormats.cend(), isImageFormat);
+    const bool imageAdvertised = std::any_of(
+        availableFormats.cbegin(), availableFormats.cend(), isImageFormat);
+
+    // cloneData() intentionally skips binary images when useful text is
+    // present, so that case is complete even if image formats are advertised.
+    return !imageRequested || !imageAdvertised || hasMaterializedText(data)
+        || containsNonEmptyFormat(data, isImageFormat);
+}
+
+} // namespace
+
+ClipboardReadResult DummyClipboard::readData(
+        ClipboardMode mode, const QStringList &formats) const
+{
+    ClipboardReadResult result;
+    const QMimeData *mime = mimeData(mode);
+    if (mime == nullptr)
+        return result;
+
+    const bool isDataSecret = isHidden(*mime);
+    ClipboardDataGuard guard(mime, clipboardSequenceNumber(mode));
+    result.availableFormats = guard.formats();
+    result.data = cloneData(guard, formats);
+    result.isComplete = !guard.hasFailed()
+        && (guard.imageWasOmitted()
+            || imageReadIsComplete(formats, result.availableFormats, result.data));
     if (isDataSecret)
-        dataMap[mimeSecret] = QByteArrayLiteral("1");
+        result.data[mimeSecret] = QByteArrayLiteral("1");
 
-    return dataMap;
+    return result;
 }
 
 void DummyClipboard::setData(ClipboardMode mode, const QVariantMap &dataMap)

--- a/src/platform/dummy/dummyclipboard.h
+++ b/src/platform/dummy/dummyclipboard.h
@@ -13,7 +13,8 @@ QClipboard::Mode modeToQClipboardMode(ClipboardMode mode);
 class DummyClipboard : public PlatformClipboard
 {
 public:
-    QVariantMap data(ClipboardMode mode, const QStringList &formats) const override;
+    ClipboardReadResult readData(
+            ClipboardMode mode, const QStringList &formats) const override;
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
     void setRawData(ClipboardMode mode, QMimeData *mimeData) override;

--- a/src/platform/platformclipboard.h
+++ b/src/platform/platformclipboard.h
@@ -7,6 +7,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QStringList>
 #include <QVariantMap>
 #include <memory>
 
@@ -45,6 +46,12 @@ private:
 
 using ClipboardConnectionPtr = std::unique_ptr<ClipboardConnection>;
 
+struct ClipboardReadResult {
+    QVariantMap data;
+    QStringList availableFormats;
+    bool isComplete = false;
+};
+
 /**
  * Interface for clipboard.
  */
@@ -57,9 +64,20 @@ public:
     ClipboardConnectionPtr createConnection(const QStringList &formats, ClipboardModeMask modes);
 
     /**
-     * Return clipboard data containing specified @a formats if available.
+     * Read clipboard data containing specified @a formats if available.
+     *
+     * A read can fail even when the clipboard advertises data (for example,
+     * while another Windows process temporarily locks the clipboard).  Keep
+     * that state separate from a successfully read, genuinely empty
+     * clipboard so callers do not erase their last valid snapshot.
      */
-    virtual QVariantMap data(ClipboardMode mode, const QStringList &formats) const = 0;
+    virtual ClipboardReadResult readData(
+            ClipboardMode mode, const QStringList &formats) const = 0;
+
+    QVariantMap data(ClipboardMode mode, const QStringList &formats) const
+    {
+        return readData(mode, formats).data;
+    }
 
     /**
      * Set data to clipboard.

--- a/src/platform/win/winplatformclipboard.cpp
+++ b/src/platform/win/winplatformclipboard.cpp
@@ -12,7 +12,55 @@ bool contains(const QStringList &formats, const QMimeData &data, const QString &
     return formats.contains(format) && data.data(format) == value;
 }
 
+enum class NativeClipboardState {
+    Unavailable,
+    Empty,
+    HasFormats,
+    Unknown,
+};
+
+NativeClipboardState nativeClipboardState()
+{
+    if (!OpenClipboard(nullptr))
+        return NativeClipboardState::Unavailable;
+
+    SetLastError(ERROR_SUCCESS);
+    const int formatCount = CountClipboardFormats();
+    const DWORD countError = GetLastError();
+    const bool closed = CloseClipboard();
+    if (!closed || (formatCount == 0 && countError != ERROR_SUCCESS))
+        return NativeClipboardState::Unknown;
+
+    return formatCount > 0 ? NativeClipboardState::HasFormats
+                           : NativeClipboardState::Empty;
+}
+
 } // namespace
+
+ClipboardReadResult WinPlatformClipboard::readData(
+        ClipboardMode mode, const QStringList &formats) const
+{
+    const NativeClipboardState state = nativeClipboardState();
+    if (state == NativeClipboardState::Unavailable
+        || state == NativeClipboardState::Unknown)
+    {
+        return {};
+    }
+
+    ClipboardReadResult result = DummyClipboard::readData(mode, formats);
+
+    // QWindowsClipboardRetrievalMimeData can successfully enumerate formats,
+    // then fail to reacquire the IDataObject while materializing the data.  A
+    // native object with formats and no Qt formats is the same transient read
+    // failure at an earlier point in that sequence, not an empty clipboard.
+    if (state == NativeClipboardState::HasFormats
+        && result.availableFormats.isEmpty())
+    {
+        result.isComplete = false;
+    }
+
+    return result;
+}
 
 void WinPlatformClipboard::startMonitoringBackend(const QStringList &formats, ClipboardModeMask modes)
 {

--- a/src/platform/win/winplatformclipboard.h
+++ b/src/platform/win/winplatformclipboard.h
@@ -9,6 +9,8 @@
 class WinPlatformClipboard final : public DummyClipboard
 {
 public:
+    ClipboardReadResult readData(
+            ClipboardMode mode, const QStringList &formats) const override;
     bool isHidden(const QMimeData &data) const override;
 
 protected:

--- a/src/platform/x11/x11platformclipboard.cpp
+++ b/src/platform/x11/x11platformclipboard.cpp
@@ -582,21 +582,28 @@ void X11PlatformClipboard::stopMonitoringBackend()
     DummyClipboard::stopMonitoringBackend();
 }
 
-QVariantMap X11PlatformClipboard::data(ClipboardMode mode, const QStringList &formats) const
+ClipboardReadResult X11PlatformClipboard::readData(
+        ClipboardMode mode, const QStringList &formats) const
 {
     if (!m_monitoring) {
         if (isGnomeExtensionAvailable()) {
-            return m_gnomeClipboardExtensionClient->fetchClipboardData(mode, formats);
+            ClipboardReadResult result;
+            result.data = m_gnomeClipboardExtensionClient->fetchClipboardData(mode, formats);
+            result.isComplete = true;
+            return result;
         }
-        return DummyClipboard::data(mode, formats);
+        return DummyClipboard::readData(mode, formats);
     }
 
     const auto &clipboardData = mode == ClipboardMode::Clipboard ? m_clipboardData : m_selectionData;
 
-    auto data = clipboardData.data;
-    if ( !data.contains(mimeOwner) )
-        data[mimeWindowTitle] = clipboardData.owner.toUtf8();
-    return data;
+    ClipboardReadResult result;
+    result.data = clipboardData.data;
+    result.availableFormats = clipboardData.formats;
+    result.isComplete = true;
+    if ( !result.data.contains(mimeOwner) )
+        result.data[mimeWindowTitle] = clipboardData.owner.toUtf8();
+    return result;
 }
 
 const QMimeData *X11PlatformClipboard::mimeData(ClipboardMode mode) const

--- a/src/platform/x11/x11platformclipboard.h
+++ b/src/platform/x11/x11platformclipboard.h
@@ -19,7 +19,8 @@ public:
     X11PlatformClipboard();
     ~X11PlatformClipboard() override;
 
-    QVariantMap data(ClipboardMode mode, const QStringList &formats) const override;
+    ClipboardReadResult readData(
+            ClipboardMode mode, const QStringList &formats) const override;
 
     void setData(ClipboardMode mode, const QVariantMap &dataMap) override;
     void setRawData(ClipboardMode mode, QMimeData *mimeData) override;

--- a/src/scriptable/scriptable.cpp
+++ b/src/scriptable/scriptable.cpp
@@ -2223,13 +2223,12 @@ QJSValue Scriptable::loadTheme()
 
 void Scriptable::onClipboardChanged()
 {
-    if (!call(QStringLiteral("hasData")).toBool()) {
-        call(QStringLiteral("updateClipboardData"));
-    } else if (call(QStringLiteral("runAutomaticCommands")).toBool()) {
-        call(QStringLiteral("saveData"));
-        call(QStringLiteral("updateClipboardData"));
-    } else {
+    if (!call(QStringLiteral("runAutomaticCommands")).toBool()) {
         call(QStringLiteral("clearClipboardData"));
+    } else {
+        if (call(QStringLiteral("hasData")).toBool())
+            call(QStringLiteral("saveData"));
+        call(QStringLiteral("updateClipboardData"));
     }
 }
 

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -1875,7 +1875,8 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
     widgets.reserve(values.items.size());
 
     QString styleSheet;
-    QRect geometry(-1, -1, 0, 0);
+    QPoint position(-1, -1);
+    QSize requestedSize;
 
     auto area = new QScrollArea(&dialog);
     area->setFocusPolicy(Qt::NoFocus);
@@ -1896,13 +1897,13 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
         else if (value.name == ".style")
             styleSheet = value.value.toString();
         else if (value.name == ".height")
-            geometry.setHeight( pointsToPixels(value.value.toInt()) );
+            requestedSize.setHeight( pointsToPixels(value.value.toInt()) );
         else if (value.name == ".width")
-            geometry.setWidth( pointsToPixels(value.value.toInt()) );
+            requestedSize.setWidth( pointsToPixels(value.value.toInt()) );
         else if (value.name == ".x")
-            geometry.setX(value.value.toInt());
+            position.setX(value.value.toInt());
         else if (value.name == ".y")
-            geometry.setY(value.value.toInt());
+            position.setY(value.value.toInt());
         else if (value.name == ".label")
             createAndSetWidget<QLabel>("text", value.value, parent);
         else if (value.name == ".defaultChoice")
@@ -1921,31 +1922,34 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
         WindowGeometryGuard::create(&dialog);
     }
 
-    // WORKAROUND for broken initial focus in Qt 6.6 (QTBUG-121514)
-    if (!widgets.isEmpty())
-        widgets.first()->setFocus();
-
-    if (geometry.height() == 0)
-        geometry.setHeight(dialog.height());
-    if (geometry.width() == 0)
-        geometry.setWidth(dialog.width());
-
-    if (geometry.isValid())
-        dialog.resize(geometry.size());
-    else
-        dialog.adjustSize();
-
-    if (geometry.x() >= 0 && geometry.y() >= 0)
-        dialog.move(geometry.topLeft());
-
-    if ( !styleSheet.isEmpty() )
-        dialog.setStyleSheet(styleSheet);
-
     auto buttons = new QDialogButtonBox(
                 QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
     QObject::connect( buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept );
     QObject::connect( buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject );
     dialog.layout()->addWidget(buttons);
+
+    if ( !styleSheet.isEmpty() )
+        dialog.setStyleSheet(styleSheet);
+
+    // Size the complete, styled dialog. Previously, missing dimensions were
+    // replaced with dialog.width()/height() before the button box was added and
+    // before the layout had computed the contents' size. This made the default
+    // size depend on the widget's provisional geometry instead of its controls.
+    dialog.adjustSize();
+    QSize dialogSize = dialog.size();
+    if (requestedSize.width() > 0)
+        dialogSize.setWidth(requestedSize.width());
+    if (requestedSize.height() > 0)
+        dialogSize.setHeight(requestedSize.height());
+    if (dialogSize != dialog.size())
+        dialog.resize(dialogSize);
+
+    if (position.x() >= 0 && position.y() >= 0)
+        dialog.move(position);
+
+    // WORKAROUND for broken initial focus in Qt 6.6 (QTBUG-121514)
+    if (!widgets.isEmpty())
+        widgets.first()->setFocus();
 
     installShortcutToCloseDialog(&dialog, &dialog, QKeyCombination(Qt::ControlModifier, Qt::Key_Enter).toCombined());
     installShortcutToCloseDialog(&dialog, &dialog, QKeyCombination(Qt::ControlModifier, Qt::Key_Return).toCombined());

--- a/src/tests/itemimagetests.cpp
+++ b/src/tests/itemimagetests.cpp
@@ -101,3 +101,28 @@ void ItemImageTests::saveWebp()
     TEST( m_test->setClipboard(data, "image/webp") );
     WAIT_ON_OUTPUT("read('image/png', 0).length > 0", "true\n");
 }
+
+void ItemImageTests::activateAnimatedWebp()
+{
+    SKIP_ON_ENV("COPYQ_TESTS_SKIP_WEBP");
+    QVERIFY(QImageReader::supportedImageFormats().contains("webp"));
+
+    // Two-frame animated WebP. The encoded animation must remain available,
+    // while activation also provides a static image fallback for applications
+    // that do not accept image/webp directly.
+    const auto data = QByteArray::fromBase64(
+        "UklGRoQAAABXRUJQVlA4WAoAAAACAAAAAwAAAwAAQU5JTQYAAAAAAAAAAABBTk1GKAAAAAAAAAAAAAMAAAMAAGQAAAJWUDhMDwAAAC8DwAAABxD9j/4HIqL/AQBBTk1GKAAAAAAAAAAAAAMAAAMAAGQAAABWUDhMDwAAAC8DwAAAB9D/iP4HIqL/AQA=");
+
+    TEST( m_test->setClipboard(data, "image/webp") );
+    RUN_WITH_INPUT("eval" << "read('image/webp', 0) == input()", data, "true\n");
+    WAIT_ON_OUTPUT("read('image/png', 0).length > 0", "true\n");
+
+    RUN_WITH_INPUT("write" << "image/webp" << "-", data, "");
+    WAIT_ON_OUTPUT("read('image/webp', 0).length > 0", "true\n");
+
+    RUN("show", "");
+    KEYS(clipboardBrowserId << "ENTER");
+
+    WAIT_FOR_CLIPBOARD2(data, "image/webp");
+    WAIT_ON_OUTPUT("clipboard('image/png').length > 0", "true\n");
+}

--- a/src/tests/itemimagetests.h
+++ b/src/tests/itemimagetests.h
@@ -21,6 +21,7 @@ private slots:
     void saveBmp();
     void saveGif();
     void saveWebp();
+    void activateAnimatedWebp();
 
 private:
     TestInterfacePtr m_test;

--- a/src/tests/itemsynctests.cpp
+++ b/src/tests/itemsynctests.cpp
@@ -952,6 +952,59 @@ void ItemSyncTests::moveLargeItemsToNonSyncTabKeepsData()
     RUN(args2 << "read(0).length + ',' + read(1).length", "3072,4096\n");
 }
 
+void ItemSyncTests::removeCommandLeavesUnreadableItem()
+{
+    TestDir dir1(1);
+    const QString tab1 = testTab(1);
+    const Args args = Args() << "tab" << tab1;
+
+    // Keep reconciliation out of the failure window so the command itself is
+    // responsible for deciding whether an unreadable lazy item can be removed.
+    m_test->setEnv("COPYQ_SYNC_UPDATE_INTERVAL_MS", "10000");
+    RUN("show" << tab1, "");
+    RUN(args << "add('A'.repeat(4096))", "");
+    QCOMPARE(dir1.files().size(), 1);
+
+    RUN("unload" << tab1, "");
+    RUN(args << "size", "1\n");
+    m_test->setEnv("COPYQ_SYNC_UPDATE_INTERVAL_MS", "100");
+    RUN("settings('test.itemsync_unreadable_command_ran', false)", "");
+
+    RUN(R"(
+        setCommands([{
+            name: 'Process and remove synchronized item',
+            inMenu: true,
+            shortcuts: ['Ctrl+F1'],
+            cmd: 'copyq settings test.itemsync_unreadable_command_ran true',
+            remove: true
+        }])
+        )", "");
+    RUN(args << "selectItems" << "0", "true\n");
+
+    QVERIFY(dir1.remove(dir1.files().constFirst()));
+    KEYS("CTRL+F1");
+
+    // A failed materialization cancels the command instead of deleting the
+    // only remaining model record of the item.
+    RUN(args << "size", "1\n");
+    RUN("settings('test.itemsync_unreadable_command_ran')", "false\n");
+
+    // Remove-only commands do not build action data, but must enforce the same
+    // ownership precondition before deleting the source row.
+    RUN(R"(
+        setCommands([{
+            name: 'Remove synchronized item',
+            inMenu: true,
+            shortcuts: ['Ctrl+F1'],
+            remove: true
+        }])
+        )", "");
+    KEYS("CTRL+F1");
+    RUN(args << "size", "1\n");
+
+    RUN("unload" << tab1, "");
+}
+
 void ItemSyncTests::avoidDuplicateItemsAddedFromClipboard()
 {
     TestDir dir1(1);

--- a/src/tests/itemsynctests.cpp
+++ b/src/tests/itemsynctests.cpp
@@ -783,6 +783,31 @@ void ItemSyncTests::addItemsWhenFullOmitDeletingNotOwned()
     QVERIFY(f1->exists());
 }
 
+void ItemSyncTests::prioritizeNewFilesWhenItemLimitIsReached()
+{
+    TestDir dir1(1);
+    const QString tab1 = testTab(1);
+    const Args args = Args() << "separator" << "," << "tab" << tab1;
+    RUN("config" << "maxitems" << "2", "2\n");
+    RUN("show" << tab1, "");
+
+    TEST(createFile(dir1, "b.txt", "B"));
+    TEST(createFile(dir1, "c.txt", "C"));
+    WAIT_ON_OUTPUT(args << "read(0,1)", "B,C");
+
+    // The complete directory listing now contains three files, while the
+    // synchronized model may contain only the first two. The existing c.txt
+    // row must be retired from the model without deleting the file, allowing
+    // the newly higher-priority a.txt item to enter.
+    TEST(createFile(dir1, "a.txt", "A"));
+    WAIT_ON_OUTPUT(args << "read(0,1)", "A,B");
+    QCOMPARE(dir1.files().join(sep), QString("a.txt") + sep + "b.txt" + sep + "c.txt");
+
+    // Once a higher-priority file disappears, the retained file re-enters.
+    QVERIFY(dir1.remove("a.txt"));
+    WAIT_ON_OUTPUT(args << "read(0,1)", "B,C");
+}
+
 void ItemSyncTests::moveOwnItemsSortsBaseNames()
 {
     TestDir dir1(1);
@@ -866,6 +891,65 @@ void ItemSyncTests::moveOwnItemsKeepsLargeTextData()
 
     RUN(args << "read(0).length + ',' + read(1).length", "4096,3072\n");
     RUN(args << "getItem(0)[mimeText].length + ',' + getItem(1)[mimeText].length", "4096,3072\n");
+}
+
+void ItemSyncTests::moveLargeItemsToNonSyncTabKeepsData()
+{
+    TestDir dir1(1);
+    TestDir dir2(2);
+    const QString tab1 = testTab(1);
+    const QString tab2 = testTab(2);
+    const QString localTab = QString(clipboardTabName);
+    const Args args1 = Args() << "separator" << "," << "tab" << tab1;
+    const Args args2 = Args() << "separator" << "," << "tab" << tab2;
+    const Args localArgs = Args() << "separator" << "," << "tab" << localTab;
+
+    RUN("show" << tab1, "");
+    RUN(args1 << R"(
+        add('A'.repeat(4096), 'B'.repeat(3072));
+        read(0).length + ',' + read(1).length;
+    )", "3072,4096\n");
+    QCOMPARE(dir1.files().size(), 2);
+
+    // Reload so the synchronized tab holds lazy SyncDataFile values.
+    RUN("unload" << tab1, "");
+    RUN(args1 << "read(0).length + ',' + read(1).length", "3072,4096\n");
+
+    const QString moveCommand = QString(R"(
+        setCommands([{
+            name: 'Move synchronized items to local tab',
+            inMenu: true,
+            shortcuts: ['Ctrl+F1'],
+            tab: '%1',
+            remove: true
+        }])
+        )").arg(localTab);
+    RUN(moveCommand, "");
+    RUN(args1 << "selectItems" << "0" << "1", "true\n");
+    KEYS("CTRL+F1");
+
+    WAIT_ON_OUTPUT(args1 << "size", "0\n");
+    RUN(localArgs << "read(0).length + ',' + read(1).length", "3072,4096\n");
+    QCOMPARE(dir1.files().size(), 0);
+
+    // The destination must remain valid after the source files are gone and
+    // after its model has been unloaded and restored.
+    RUN("unload" << localTab, "");
+    RUN(localArgs << "read(0).length + ',' + read(1).length", "3072,4096\n");
+
+    // Copy the detached local items into another synchronized tab. The stale
+    // source routing metadata must fall back to the owned payload rather than
+    // creating blank entries when the original files no longer exist.
+    RUN("setCurrentTab" << localTab, "");
+    RUN(localArgs << "selectItems" << "0" << "1", "true\n");
+    KEYS(clipboardBrowserId << keyNameFor(QKeySequence::Copy));
+    RUN("setCurrentTab" << tab2, "");
+    KEYS(clipboardBrowserId << keyNameFor(QKeySequence::Paste));
+
+    RUN(args2 << "read(0).length + ',' + read(1).length", "3072,4096\n");
+    QCOMPARE(dir2.files().size(), 2);
+    RUN("unload" << tab2, "");
+    RUN(args2 << "read(0).length + ',' + read(1).length", "3072,4096\n");
 }
 
 void ItemSyncTests::avoidDuplicateItemsAddedFromClipboard()
@@ -1055,6 +1139,35 @@ void ItemSyncTests::copyFiles()
     RUN("tab" << tab3 << "size", "2\n");
     RUN("tab" << tab3 << getFirstItemFormats, "text/plain\n");
     QCOMPARE(dir3.files().join(" "), "test-0001.txt test.txt");
+}
+
+void ItemSyncTests::copyFilesFromUriListIsAllOrNothing()
+{
+    TestDir syncDir(1);
+    TestDir sourceDir(9);
+    const QString tab1 = testTab(1);
+    const Args args = Args() << "tab" << tab1;
+    RUN("show" << tab1, "");
+
+    TEST(createFile(sourceDir, "valid.txt", "VALID"));
+    const QString validUrl = QUrl::fromLocalFile(sourceDir.filePath("valid.txt")).toString();
+    const QString missingUrl = QUrl::fromLocalFile(sourceDir.filePath("missing.txt")).toString();
+    const QString uriData = validUrl + "\\n" + missingUrl;
+
+    RUN(args << "add({[mimeUriList]: '" + uriData + "'})", "");
+    WAIT_ON_OUTPUT(args << "size", "1\n");
+
+    // A partial import must not remove the original URI item or leave a copy
+    // of only the successful subset in the synchronized directory.
+    const QString inspect = QString(
+        "const uris = str(read(mimeUriList, 0)); "
+        "uris.includes('%1') && uris.includes('%2')")
+        .arg(validUrl, missingUrl);
+    RUN(args << inspect, "true\n");
+    QVERIFY(sourceDir.file("valid.txt")->exists());
+    const QStringList synchronizedFiles = syncDir.files();
+    QVERIFY(!synchronizedFiles.contains("valid.txt"));
+    QVERIFY(!synchronizedFiles.isEmpty());
 }
 
 void ItemSyncTests::encryptionShouldNotAffectFiles()

--- a/src/tests/itemsynctests.h
+++ b/src/tests/itemsynctests.h
@@ -47,9 +47,11 @@ private slots:
     void addItemsWhenFull();
 
     void addItemsWhenFullOmitDeletingNotOwned();
+    void prioritizeNewFilesWhenItemLimitIsReached();
 
     void moveOwnItemsSortsBaseNames();
     void moveOwnItemsKeepsLargeTextData();
+    void moveLargeItemsToNonSyncTabKeepsData();
 
     void avoidDuplicateItemsAddedFromClipboard();
 
@@ -58,6 +60,7 @@ private slots:
     void sortItems();
 
     void copyFiles();
+    void copyFilesFromUriListIsAllOrNothing();
 
     void encryptionShouldNotAffectFiles();
 

--- a/src/tests/itemsynctests.h
+++ b/src/tests/itemsynctests.h
@@ -52,6 +52,7 @@ private slots:
     void moveOwnItemsSortsBaseNames();
     void moveOwnItemsKeepsLargeTextData();
     void moveLargeItemsToNonSyncTabKeepsData();
+    void removeCommandLeavesUnreadableItem();
 
     void avoidDuplicateItemsAddedFromClipboard();
 

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -4,12 +4,14 @@
 
 #include <QAbstractItemView>
 #include <QCheckBox>
+#include <QDialog>
 #include <QDrag>
 #include <QItemSelectionModel>
 #include <QListWidget>
 #include <QListView>
 #include <QLoggingCategory>
 #include <QRegularExpression>
+#include <QScreen>
 #include <QTest>
 #include <QTimer>
 
@@ -512,6 +514,50 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
                 .arg(geometry.height());
         }
         return QStringLiteral("Missing");
+    }
+
+    if (cmd == "activeDialogSizing") {
+        const QString mode = arguments.value(1).toString();
+        const int requestedPoints = arguments.value(2).toInt();
+
+        QDialog *dialog = nullptr;
+        for (QWidget *window : qApp->topLevelWidgets()) {
+            auto candidate = qobject_cast<QDialog*>(window);
+            if (candidate && candidate->isVisible()) {
+                dialog = candidate;
+                break;
+            }
+        }
+
+        if (!dialog)
+            return QStringLiteral("Missing active dialog");
+
+        const QSize actual = dialog->size();
+        const QSize hint = dialog->sizeHint();
+        bool valid = actual.width() >= hint.width()
+            && actual.height() >= hint.height();
+
+        if (mode == QLatin1String("width")) {
+            const auto screen = dialog->screen();
+            if (!screen)
+                return QStringLiteral("Missing dialog screen");
+            const int expectedWidth = static_cast<int>(
+                requestedPoints * screen->physicalDotsPerInchX() / 72.0);
+            valid = actual.width() == expectedWidth
+                && actual.height() >= hint.height();
+        } else if (mode != QLatin1String("auto")) {
+            return QStringLiteral("Unexpected sizing mode: %1").arg(mode);
+        }
+
+        if (valid)
+            return {};
+
+        return QStringLiteral("Actual %1x%2, hint %3x%4, mode %5")
+            .arg(actual.width())
+            .arg(actual.height())
+            .arg(hint.width())
+            .arg(hint.height())
+            .arg(mode);
     }
 
     if (cmd == "selectImportTab") {

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -6,6 +6,7 @@
 #include <QCheckBox>
 #include <QDrag>
 #include <QItemSelectionModel>
+#include <QListWidget>
 #include <QListView>
 #include <QLoggingCategory>
 #include <QRegularExpression>
@@ -511,6 +512,28 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
                 .arg(geometry.height());
         }
         return QStringLiteral("Missing");
+    }
+
+    if (cmd == "selectImportTab") {
+        const QString tabName = arguments.value(1).toString();
+        for (QWidget *window : qApp->topLevelWidgets()) {
+            if (window->objectName() != QLatin1String("ImportExportDialog"))
+                continue;
+
+            auto list = window->findChild<QListWidget*>(QStringLiteral("listTabs"));
+            if (!list)
+                return QStringLiteral("Missing tab list");
+
+            list->clearSelection();
+            const auto items = list->findItems(tabName, Qt::MatchExactly);
+            if (items.size() != 1)
+                return QStringLiteral("Missing tab: %1").arg(tabName);
+
+            items.first()->setSelected(true);
+            list->setCurrentItem(items.first());
+            return {};
+        }
+        return QStringLiteral("Missing import dialog");
     }
 
     return QStringLiteral("Unexpected command: %1").arg(cmd);

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -6,6 +6,7 @@
 #include <QCheckBox>
 #include <QDrag>
 #include <QItemSelectionModel>
+#include <QListView>
 #include <QLoggingCategory>
 #include <QRegularExpression>
 #include <QTest>
@@ -478,6 +479,24 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
 
     if (cmd == "sendKeysStatus")
         return keyClicker()->status(arguments.value(1).toBool());
+
+    if (cmd == "clipboardBrowserLayout") {
+        for (QWidget *window : qApp->topLevelWidgets()) {
+            if (window->objectName() != QLatin1String("MainWindow"))
+                continue;
+
+            const auto browser = window->findChild<QListView*>(
+                QStringLiteral("ClipboardBrowser"));
+            if (!browser)
+                return QStringLiteral("Missing");
+
+            const auto mode = browser->layoutMode() == QListView::Batched
+                ? QStringLiteral("Batched")
+                : QStringLiteral("SinglePass");
+            return QStringLiteral("%1:%2").arg(mode).arg(browser->batchSize());
+        }
+        return QStringLiteral("Missing");
+    }
 
     return QStringLiteral("Unexpected command: %1").arg(cmd);
 }

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -498,6 +498,21 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
         return QStringLiteral("Missing");
     }
 
+    if (cmd == "mainWindowFrameGeometry") {
+        for (QWidget *window : qApp->topLevelWidgets()) {
+            if (window->objectName() != QLatin1String("MainWindow"))
+                continue;
+
+            const QRect geometry = window->frameGeometry();
+            return QStringLiteral("%1,%2,%3,%4")
+                .arg(geometry.x())
+                .arg(geometry.y())
+                .arg(geometry.width())
+                .arg(geometry.height());
+        }
+        return QStringLiteral("Missing");
+    }
+
     return QStringLiteral("Unexpected command: %1").arg(cmd);
 }
 

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -8,7 +8,6 @@
 #include <QDrag>
 #include <QItemSelectionModel>
 #include <QListWidget>
-#include <QListView>
 #include <QLoggingCategory>
 #include <QRegularExpression>
 #include <QScreen>
@@ -482,24 +481,6 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
 
     if (cmd == "sendKeysStatus")
         return keyClicker()->status(arguments.value(1).toBool());
-
-    if (cmd == "clipboardBrowserLayout") {
-        for (QWidget *window : qApp->topLevelWidgets()) {
-            if (window->objectName() != QLatin1String("MainWindow"))
-                continue;
-
-            const auto browser = window->findChild<QListView*>(
-                QStringLiteral("ClipboardBrowser"));
-            if (!browser)
-                return QStringLiteral("Missing");
-
-            const auto mode = browser->layoutMode() == QListView::Batched
-                ? QStringLiteral("Batched")
-                : QStringLiteral("SinglePass");
-            return QStringLiteral("%1:%2").arg(mode).arg(browser->batchSize());
-        }
-        return QStringLiteral("Missing");
-    }
 
     if (cmd == "mainWindowFrameGeometry") {
         for (QWidget *window : qApp->topLevelWidgets()) {

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -11,6 +11,7 @@
 #include "itemsynctests.h"
 #include "itemtagstests.h"
 #include "tests_clipboarddataguard.h"
+#include "tests_clipboardmonitor.h"
 
 #include "app/app.h"
 #include "common/client_server.h"
@@ -844,6 +845,7 @@ private:
 
     IMPL_TEST_GROUP(Core)
     IMPL_TEST_GROUP(ClipboardDataGuard)
+    IMPL_TEST_GROUP(ClipboardMonitor)
     IMPL_TEST_GROUP(ItemEncrypted)
     IMPL_TEST_GROUP(ItemFakeVim)
     IMPL_TEST_GROUP(ItemImage)

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -245,6 +245,8 @@ private slots:
 
     void selectedItems();
 
+    void applicationShortcutDefaultsIgnoreUiTranslations();
+
     void shortcutCommand();
     void shortcutCommandOverrideEnter();
     void shortcutCommandMatchInput();

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -178,7 +178,6 @@ private slots:
     void searchItemsAndCopy();
     void searchRowNumber();
     void searchAccented();
-    void largeTabUsesBatchedLayout();
     void searchManyItems();
     void copyItems();
     void selectAndCopyOrder();

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -373,6 +373,7 @@ private slots:
     void exportImportPasswordTab();
     void exportImportPasswordSettingsOnly();
     void exportImportPasswordCommandsOnly();
+    void importV3SelectedTabs();
     void exportImportErrors();
 
 private:

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -178,6 +178,7 @@ private slots:
     void searchItemsAndCopy();
     void searchRowNumber();
     void searchAccented();
+    void largeTabUsesBatchedLayout();
     void searchManyItems();
     void copyItems();
     void selectAndCopyOrder();
@@ -258,6 +259,7 @@ private slots:
 
     void automaticCommandIgnore();
     void automaticCommandRemove();
+    void automaticCommandRemoveWhitespace();
     void automaticCommandInput();
     void automaticCommandRegExp();
     void automaticCommandSetData();

--- a/src/tests/tests_clipboarddataguard.cpp
+++ b/src/tests/tests_clipboarddataguard.cpp
@@ -2,7 +2,10 @@
 #include "tests_clipboarddataguard.h"
 
 #include "common/clipboarddataguard.h"
+#include "common/mimetypes.h"
+#include "platform/dummy/dummyclipboard.h"
 
+#include <QImage>
 #include <QMimeData>
 #include <QSet>
 #include <QTest>
@@ -29,6 +32,17 @@ private:
     QSet<QString> m_throwMimes;
 };
 
+class TestClipboard final : public DummyClipboard {
+public:
+    void setMimeData(const QMimeData *data) { m_data = data; }
+
+protected:
+    const QMimeData *rawMimeData(ClipboardMode) const override { return m_data; }
+
+private:
+    const QMimeData *m_data = nullptr;
+};
+
 void ClipboardDataGuardTests::badAllocData()
 {
     qputenv("COPYQ_CLIPBOARD_MIME_SIZE_LIMIT", ".*:-1");
@@ -37,6 +51,7 @@ void ClipboardDataGuardTests::badAllocData()
     md.setThrowFor("text/plain");
     ClipboardDataGuard guard(&md);
     QVERIFY(guard.data("text/plain").isEmpty());
+    QVERIFY(guard.hasFailed());
     qunsetenv("COPYQ_CLIPBOARD_MIME_SIZE_LIMIT");
 }
 
@@ -91,10 +106,110 @@ void ClipboardDataGuardTests::normalDataStillWorks()
     qunsetenv("COPYQ_CLIPBOARD_MIME_SIZE_LIMIT");
 }
 
+void ClipboardDataGuardTests::failedImageReadIsIncomplete()
+{
+    QMimeData md;
+    md.setData(QStringLiteral("application/x-qt-image"), QByteArrayLiteral("not-an-image"));
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(
+        ClipboardMode::Clipboard, {QStringLiteral("image/png")});
+
+    QVERIFY(result.availableFormats.contains(QStringLiteral("application/x-qt-image")));
+    QVERIFY(!result.isComplete);
+    QVERIFY(result.data.isEmpty());
+}
+
+void ClipboardDataGuardTests::validImageReadIsComplete()
+{
+    QMimeData md;
+    QImage image(2, 2, QImage::Format_ARGB32);
+    image.fill(Qt::black);
+    md.setImageData(image);
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(
+        ClipboardMode::Clipboard, {QStringLiteral("image/png")});
+
+    QVERIFY(result.isComplete);
+    QVERIFY(!result.data.value(QStringLiteral("image/png")).toByteArray().isEmpty());
+}
+
+void ClipboardDataGuardTests::emptyTextDoesNotHideImage()
+{
+    QMimeData md;
+    md.setData(mimeText, {});
+    QImage image(2, 2, QImage::Format_ARGB32);
+    image.fill(Qt::black);
+    md.setImageData(image);
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(
+        ClipboardMode::Clipboard, {mimeText, QStringLiteral("image/png")});
+
+    QVERIFY(result.isComplete);
+    QVERIFY(!result.data.value(QStringLiteral("image/png")).toByteArray().isEmpty());
+}
+
+void ClipboardDataGuardTests::textSuppressesImageRead()
+{
+    ThrowingMimeData md;
+    md.setData(mimeText, QByteArrayLiteral("text wins"));
+    md.setData(QStringLiteral("application/x-qt-image"), QByteArrayLiteral("image"));
+    md.setThrowFor(QStringLiteral("application/x-qt-image"));
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(
+        ClipboardMode::Clipboard, {mimeText, QStringLiteral("image/png")});
+
+    QVERIFY(result.isComplete);
+    QCOMPARE(result.data.value(mimeText).toByteArray(), QByteArray("text wins"));
+}
+
+void ClipboardDataGuardTests::emptyTextReadIsComplete()
+{
+    QMimeData md;
+    md.setData(mimeText, {});
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(ClipboardMode::Clipboard, {mimeText});
+
+    QVERIFY(result.isComplete);
+    QVERIFY(result.availableFormats.contains(mimeText));
+    QVERIFY(result.data.isEmpty());
+}
+
 static void bumpConfigGeneration()
 {
     const int gen = qApp->property("CopyQ_config_generation").toInt();
     qApp->setProperty("CopyQ_config_generation", gen + 1);
+}
+
+void ClipboardDataGuardTests::omittedImageReadIsComplete()
+{
+    qputenv("COPYQ_CLIPBOARD_MIME_SIZE_LIMIT", "image/.*:0;.*:100M");
+    bumpConfigGeneration();
+
+    QMimeData md;
+    QImage image(2, 2, QImage::Format_ARGB32);
+    image.fill(Qt::black);
+    md.setImageData(image);
+
+    TestClipboard clipboard;
+    clipboard.setMimeData(&md);
+    const auto result = clipboard.readData(
+        ClipboardMode::Clipboard, {QStringLiteral("image/png")});
+
+    QVERIFY(result.isComplete);
+    QVERIFY(result.data.isEmpty());
+
+    qunsetenv("COPYQ_CLIPBOARD_MIME_SIZE_LIMIT");
+    bumpConfigGeneration();
 }
 
 void ClipboardDataGuardTests::overflowTreatedAsNoLimit()

--- a/src/tests/tests_clipboarddataguard.h
+++ b/src/tests/tests_clipboarddataguard.h
@@ -16,6 +16,12 @@ private slots:
     void badAllocImageData();
     void badAllocGetUtf8Data();
     void normalDataStillWorks();
+    void failedImageReadIsIncomplete();
+    void validImageReadIsComplete();
+    void emptyTextDoesNotHideImage();
+    void textSuppressesImageRead();
+    void omittedImageReadIsComplete();
+    void emptyTextReadIsComplete();
     void overflowTreatedAsNoLimit();
     void emptyRulesIgnored();
     void negativeValueMeansNoLimit();

--- a/src/tests/tests_clipboardmonitor.cpp
+++ b/src/tests/tests_clipboardmonitor.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "tests_clipboardmonitor.h"
+
+#include "app/clipboardmonitor.h"
+#include "common/mimetypes.h"
+#include "platform/platformclipboard.h"
+
+#include <QMimeData>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <memory>
+#include <utility>
+
+namespace {
+
+class FakeClipboard final : public PlatformClipboard {
+public:
+    ClipboardReadResult readData(ClipboardMode, const QStringList &) const override
+    {
+        ++m_readCount;
+        if (m_results.isEmpty()) {
+            ClipboardReadResult result;
+            result.isComplete = true;
+            return result;
+        }
+
+        return m_results.takeFirst();
+    }
+
+    void appendResult(ClipboardReadResult result)
+    {
+        m_results.append(std::move(result));
+    }
+
+    void notifyChanged()
+    {
+        emitConnectionChanged(ClipboardMode::Clipboard);
+    }
+
+    int readCount() const { return m_readCount; }
+
+    void setData(ClipboardMode, const QVariantMap &) override {}
+    void setRawData(ClipboardMode, QMimeData *) override {}
+    const QMimeData *mimeData(ClipboardMode) const override { return nullptr; }
+    bool isSelectionSupported() const override { return false; }
+    bool isHidden(const QMimeData &) const override { return false; }
+    void setClipboardOwner(const QString &) override {}
+
+protected:
+    void startMonitoringBackend(const QStringList &, ClipboardModeMask) override {}
+    void stopMonitoringBackend() override {}
+
+private:
+    mutable QList<ClipboardReadResult> m_results;
+    mutable int m_readCount = 0;
+};
+
+ClipboardReadResult failedRead()
+{
+    return {};
+}
+
+ClipboardReadResult textRead(const QByteArray &text)
+{
+    ClipboardReadResult result;
+    result.data.insert(mimeText, text);
+    result.availableFormats.append(mimeText);
+    result.isComplete = true;
+    return result;
+}
+
+} // namespace
+
+ClipboardMonitorTests::ClipboardMonitorTests(const TestInterfacePtr &, QObject *parent)
+    : QObject(parent)
+{
+    setProperty("CopyQ_test_id", QStringLiteral("clipboardmonitor"));
+}
+
+void ClipboardMonitorTests::incompleteReadRetriesBeforePublishing()
+{
+    auto clipboard = std::make_shared<FakeClipboard>();
+    clipboard->appendResult(failedRead());
+    clipboard->appendResult(textRead("screenshot"));
+
+    ClipboardMonitor monitor({mimeText}, clipboard);
+    QSignalSpy changed(&monitor, &ClipboardMonitor::clipboardChanged);
+    monitor.startMonitoring();
+
+    clipboard->notifyChanged();
+    QCOMPARE(changed.count(), 0);
+    QTRY_COMPARE_WITH_TIMEOUT(changed.count(), 1, 1000);
+    QCOMPARE(clipboard->readCount(), 2);
+    QCOMPARE(changed.first().first().toMap().value(mimeText).toByteArray(), QByteArray("screenshot"));
+}
+
+void ClipboardMonitorTests::newerChangeCancelsOlderRetry()
+{
+    auto clipboard = std::make_shared<FakeClipboard>();
+    clipboard->appendResult(failedRead());
+    clipboard->appendResult(textRead("newer"));
+
+    ClipboardMonitor monitor({mimeText}, clipboard);
+    QSignalSpy changed(&monitor, &ClipboardMonitor::clipboardChanged);
+    monitor.startMonitoring();
+
+    clipboard->notifyChanged();
+    clipboard->notifyChanged();
+
+    QTRY_COMPARE_WITH_TIMEOUT(changed.count(), 1, 1000);
+    QTest::qWait(100);
+    QCOMPARE(changed.count(), 1);
+    QCOMPARE(clipboard->readCount(), 2);
+    QCOMPARE(changed.first().first().toMap().value(mimeText).toByteArray(), QByteArray("newer"));
+}

--- a/src/tests/tests_clipboardmonitor.cpp
+++ b/src/tests/tests_clipboardmonitor.cpp
@@ -61,11 +61,16 @@ ClipboardReadResult failedRead()
     return {};
 }
 
-ClipboardReadResult textRead(const QByteArray &text)
+ClipboardReadResult textRead(
+        const QByteArray &text, const QByteArray &owner = QByteArray())
 {
     ClipboardReadResult result;
     result.data.insert(mimeText, text);
     result.availableFormats.append(mimeText);
+    if (!owner.isEmpty()) {
+        result.data.insert(mimeOwner, owner);
+        result.availableFormats.append(mimeOwner);
+    }
     result.isComplete = true;
     return result;
 }
@@ -113,4 +118,28 @@ void ClipboardMonitorTests::newerChangeCancelsOlderRetry()
     QCOMPARE(changed.count(), 1);
     QCOMPARE(clipboard->readCount(), 2);
     QCOMPARE(changed.first().first().toMap().value(mimeText).toByteArray(), QByteArray("newer"));
+}
+
+void ClipboardMonitorTests::ownerMetadataChangeDoesNotRepublishContent()
+{
+    auto clipboard = std::make_shared<FakeClipboard>();
+    clipboard->appendResult(textRead("activated item", "COPYQ OWNER"));
+    clipboard->appendResult(textRead("activated item"));
+
+    ClipboardMonitor monitor({mimeText}, clipboard);
+    QSignalSpy ownChanged(&monitor, &ClipboardMonitor::ownClipboardChanged);
+    QSignalSpy externalChanged(&monitor, &ClipboardMonitor::clipboardChanged);
+    QSignalSpy unchanged(&monitor, &ClipboardMonitor::clipboardUnchanged);
+    monitor.startMonitoring();
+
+    clipboard->notifyChanged();
+    QCOMPARE(ownChanged.count(), 1);
+    QCOMPARE(externalChanged.count(), 0);
+
+    // Simulate a paste target republishing the same bytes without CopyQ's
+    // private owner MIME. This must not become a new external copy event.
+    clipboard->notifyChanged();
+    QCOMPARE(ownChanged.count(), 1);
+    QCOMPARE(externalChanged.count(), 0);
+    QCOMPARE(unchanged.count(), 1);
 }

--- a/src/tests/tests_clipboardmonitor.h
+++ b/src/tests/tests_clipboardmonitor.h
@@ -13,4 +13,5 @@ public:
 private slots:
     void incompleteReadRetriesBeforePublishing();
     void newerChangeCancelsOlderRetry();
+    void ownerMetadataChangeDoesNotRepublishContent();
 };

--- a/src/tests/tests_clipboardmonitor.h
+++ b/src/tests/tests_clipboardmonitor.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "testinterface.h"
+
+#include <QObject>
+
+class ClipboardMonitorTests final : public QObject {
+    Q_OBJECT
+public:
+    explicit ClipboardMonitorTests(const TestInterfacePtr &test = {}, QObject *parent = nullptr);
+
+private slots:
+    void incompleteReadRetriesBeforePublishing();
+    void newerChangeCancelsOlderRetry();
+};

--- a/src/tests/tests_commands.cpp
+++ b/src/tests/tests_commands.cpp
@@ -265,6 +265,28 @@ void CoreTests::automaticCommandRemove()
     RUN("separator" << "," << "read" << "0" << "1" << "2", "OK,OK,");
 }
 
+void CoreTests::automaticCommandRemoveWhitespace()
+{
+    RUN("add" << "KEPT", "");
+
+    const auto script = R"(
+        setCommands([{
+            automatic: true,
+            remove: true,
+            re: '^\\r?\\n\\x00?$',
+            cmd: 'copyq settings test.crlf_filter_ran true'
+        }])
+        )";
+    RUN(script, "");
+    WAIT_ON_OUTPUT("commands().length", "1\n");
+
+    TEST( m_test->setClipboard("\r\n") );
+    WAIT_ON_OUTPUT("settings" << "test.crlf_filter_ran", "true\n");
+
+    RUN("size", "1\n");
+    RUN("read" << "0", "KEPT");
+}
+
 void CoreTests::automaticCommandInput()
 {
     const auto script = R"(

--- a/src/tests/tests_import_export.cpp
+++ b/src/tests/tests_import_export.cpp
@@ -4,7 +4,11 @@
 #include "tests.h"
 
 #include "common/temporaryfile.h"
+#include "common/mimetypes.h"
+#include "item/serialize.h"
 
+#include <QDataStream>
+#include <QFile>
 #include <QRegularExpression>
 
 namespace {
@@ -119,6 +123,52 @@ void CoreTests::exportImportNoPasswordCommandsOnly() { exportImport(ExportComman
 void CoreTests::exportImportPasswordTab() { exportImport(ExportWithPassword | ExportTab); }
 void CoreTests::exportImportPasswordSettingsOnly() { exportImport(ExportWithPassword | ExportSettings); }
 void CoreTests::exportImportPasswordCommandsOnly() { exportImport(ExportWithPassword | ExportCommands); }
+
+void CoreTests::importV3SelectedTabs()
+{
+    const QString selectedTab = QStringLiteral("V3 Selected");
+    const QString omittedTab = QStringLiteral("V3 Omitted");
+    const QString fileName = exportFilePath(QStringLiteral("v3-selection"));
+
+    const auto serializedTab = [](const QByteArray &text) {
+        QByteArray bytes;
+        QDataStream out(&bytes, QIODevice::WriteOnly);
+        out.setVersion(QDataStream::Qt_4_7);
+        out << qint32(1);
+        serializeData(&out, {{mimeText, text}});
+        return bytes;
+    };
+
+    QVariantList tabs;
+    tabs.append(QVariantMap{
+        {QStringLiteral("name"), selectedTab},
+        {QStringLiteral("data"), serializedTab("selected")},
+    });
+    tabs.append(QVariantMap{
+        {QStringLiteral("name"), omittedTab},
+        {QStringLiteral("data"), serializedTab("omitted")},
+    });
+
+    QFile file(fileName);
+    QVERIFY2(file.open(QIODevice::WriteOnly | QIODevice::Truncate),
+             file.errorString().toUtf8());
+    QDataStream out(&file);
+    out.setVersion(QDataStream::Qt_4_7);
+    out << QByteArray("CopyQ v3") << QVariantMap{{QStringLiteral("tabs"), tabs}};
+    QCOMPARE(out.status(), QDataStream::Ok);
+    file.close();
+
+    KEYS("Ctrl+Shift+I" << fileNameEditId << ":" + fileName);
+    KEYS("ENTER");
+    KEYS(importDialogId);
+    RUN("callPlugin('itemtests', 'selectImportTab', '" + selectedTab + "')", "");
+    KEYS("ENTER");
+    KEYS(clipboardBrowserId);
+
+    QVERIFY(hasTab(selectedTab));
+    QVERIFY(!hasTab(omittedTab));
+    RUN(Args("tab") << selectedTab << "read" << "0", "selected\n");
+}
 
 void CoreTests::exportImportErrors()
 {

--- a/src/tests/tests_items.cpp
+++ b/src/tests/tests_items.cpp
@@ -207,11 +207,6 @@ void CoreTests::searchAccented()
     WAIT_ON_OUTPUT("testSelected", QByteArray(clipboardTabName) + " 1 1\n");
 }
 
-void CoreTests::largeTabUsesBatchedLayout()
-{
-    RUN("callPlugin('itemtests', 'clipboardBrowserLayout')", "Batched:1");
-}
-
 void CoreTests::searchManyItems()
 {
     RUN("config"

--- a/src/tests/tests_items.cpp
+++ b/src/tests/tests_items.cpp
@@ -207,6 +207,11 @@ void CoreTests::searchAccented()
     WAIT_ON_OUTPUT("testSelected", QByteArray(clipboardTabName) + " 1 1\n");
 }
 
+void CoreTests::largeTabUsesBatchedLayout()
+{
+    RUN("callPlugin('itemtests', 'clipboardBrowserLayout')", "Batched:1");
+}
+
 void CoreTests::searchManyItems()
 {
     RUN("config"

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -457,6 +457,45 @@ void CoreTests::commandDialog()
         [&]{ KEYS("focus::QLineEdit<:QDialog" << "ENTER"); }
     );
 
+    // The automatic size must be computed from all controls, not from the
+    // provisional QDialog geometry or the title width.
+    KEYS(clipboardBrowserId);
+    const QByteArray autoSizeScript = R"(
+        dialog(
+            '.title', 'x',
+            '.label', 'This label is deliberately wide enough to determine the dialog width.',
+            'text', 'DEFAULT',
+        )
+    )";
+    RUN_MULTIPLE(
+        [&]{ RUN(autoSizeScript, "DEFAULT\n"); },
+        [&]{
+            RUN("callPlugin('itemtests', 'activeDialogSizing', 'auto')", "");
+            KEYS("focus::QLineEdit<dialog_x:QDialog" << "ENTER");
+        }
+    );
+
+    // Supplying one dimension must preserve it while the other dimension is
+    // still derived from the completed layout.
+    KEYS(clipboardBrowserId);
+    const QByteArray partialSizeScript = R"(
+        dialog(
+            '.title', 'partial',
+            '.width', 400,
+            '.x', 10,
+            '.y', 10,
+            '.label', 'Automatic height still includes the input and button box.',
+            'text', 'DEFAULT',
+        )
+    )";
+    RUN_MULTIPLE(
+        [&]{ RUN(partialSizeScript, "DEFAULT\n"); },
+        [&]{
+            RUN("callPlugin('itemtests', 'activeDialogSizing', 'width', 400)", "");
+            KEYS("focus::QLineEdit<dialog_partial:QDialog" << "ENTER");
+        }
+    );
+
     KEYS(clipboardBrowserId);
     RUN_MULTIPLE(
         [&]{ RUN("dialog('.title', 'Remove Items', '.label', 'Remove all items?') === true", "true\n"); },

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -8,6 +8,7 @@
 #include "common/commandstatus.h"
 
 #include <QElapsedTimer>
+#include <QGuiApplication>
 #include <QRegularExpression>
 #include <QTemporaryFile>
 #include <algorithm>
@@ -207,15 +208,29 @@ void CoreTests::commandShowHide()
 void CoreTests::commandShowHideRapid()
 {
     // Verify the main window can be hidden and reshown reliably in
-    // rapid succession.  Regression test for #3445: deferred platform
-    // raise in raiseWindow() could prevent the window from appearing.
+    // rapid succession. Regression tests for #3445 (deferred platform raise)
+    // and #3643 (normal X11 windows being placed again on each show).
+    RUN("visible", "true\n");
+
+    QByteArray initialGeometry;
+    const bool verifyX11Geometry = QGuiApplication::platformName() == QLatin1String("xcb");
+    if (verifyX11Geometry) {
+        TEST(m_test->getClientOutput(
+            Args("callPlugin('itemtests', 'mainWindowFrameGeometry')"),
+            &initialGeometry));
+        QVERIFY(!initialGeometry.isEmpty());
+    }
+
     for (int i = 0; i < 3; ++i) {
-        RUN("visible", "true\n");
         RUN("hide", "");
         WAIT_ON_OUTPUT("visible", "false\n");
 
         RUN("show", "");
         WAIT_ON_OUTPUT("visible", "true\n");
+
+        if (verifyX11Geometry) {
+            RUN("callPlugin('itemtests', 'mainWindowFrameGeometry')", initialGeometry);
+        }
     }
 }
 void CoreTests::commandShowAt()

--- a/src/tests/tests_shortcuts.cpp
+++ b/src/tests/tests_shortcuts.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "tests.h"
+
+#include "common/shortcuts.h"
+#include "gui/menuitems.h"
+
+#include <QCoreApplication>
+#include <QKeySequence>
+#include <QSet>
+#include <QString>
+#include <QTest>
+#include <QTranslator>
+
+namespace {
+
+class InvalidShortcutTranslator final : public QTranslator
+{
+public:
+    QString translate(
+        const char *context, const char *sourceText,
+        const char *disambiguation = nullptr, int n = -1) const override
+    {
+        Q_UNUSED(disambiguation)
+        Q_UNUSED(n)
+
+        if (qstrcmp(context, "QObject") != 0)
+            return {};
+
+        const QString source = QString::fromLatin1(sourceText);
+        if (source.contains('+')
+            || source == QLatin1String("Escape")
+            || source == QLatin1String("Delete")
+            || source == QLatin1String("Backspace")
+            || source == QLatin1String("Left")
+            || source == QLatin1String("Right")
+            || (source.size() >= 2 && source.at(0) == QLatin1Char('F')))
+        {
+            return QStringLiteral("Not a valid shortcut");
+        }
+
+        return {};
+    }
+};
+
+} // namespace
+
+void CoreTests::applicationShortcutDefaultsIgnoreUiTranslations()
+{
+    InvalidShortcutTranslator translator;
+    QVERIFY(QCoreApplication::installTranslator(&translator));
+    const auto items = menuItems();
+    QVERIFY(QCoreApplication::removeTranslator(&translator));
+
+    const QSet<Actions::Id> intentionallyEmpty{
+        Actions::Editor_Font,
+        Actions::Editor_Strikethrough,
+        Actions::Editor_Foreground,
+        Actions::Editor_Background,
+        Actions::Editor_EraseStyle,
+        Actions::Item_MoveToClipboard,
+    };
+
+    for (int i = 0; i < Actions::Count; ++i) {
+        const auto id = static_cast<Actions::Id>(i);
+        const auto &item = items[id];
+        if (intentionallyEmpty.contains(id)) {
+            QVERIFY2(item.defaultShortcut.isEmpty(), qPrintable(item.settingsKey));
+        } else {
+            QVERIFY2(!item.defaultShortcut.isEmpty(), qPrintable(item.settingsKey));
+        }
+    }
+
+    QCOMPARE(
+        items[Actions::Edit_SortSelectedItems].defaultShortcut,
+        QKeySequence(QStringLiteral("Ctrl+Shift+S"), QKeySequence::PortableText));
+    QCOMPARE(
+        items[Actions::Editor_Cancel].defaultShortcut,
+        QKeySequence(QStringLiteral("Escape"), QKeySequence::PortableText));
+    QCOMPARE(
+        items[Actions::Item_MoveUp].defaultShortcut,
+        QKeySequence(QStringLiteral("Ctrl+Up"), QKeySequence::PortableText));
+    QCOMPARE(
+        items[Actions::Tabs_NextTab].defaultShortcut,
+        QKeySequence(QStringLiteral("Right"), QKeySequence::PortableText));
+    QVERIFY(!QKeySequence(shortcutToRemove(), QKeySequence::PortableText).isEmpty());
+}


### PR DESCRIPTION
## Summary

This draft consolidates the CopyQ bugfix pass described in the supplied sync-bug exports and rebases it onto the current upstream `master` with normal ancestry.

It:

- makes ItemSync ownership, lazy materialization, atomic writes, URI imports, and filesystem reconciliation failure-aware
- prevents destructive item commands from deleting synchronized items whose backing data cannot be read
- hardens clipboard reads and retries, including Windows native format checks and WebP/GIF handling
- improves large-tab responsiveness with batched placeholder/layout work and sparse item-widget tracking
- fixes move-to-top-after-paste behavior, translation-independent shortcuts, window-state restoration, tag sizing, selected-tab v3 imports, and script-dialog sizing
- adds focused regression coverage for the affected sync, clipboard, image, import/export, shortcut, command, item, and script paths

## Why

The original failure mode combined network-backed synchronized items, transient or permanent read failures, and code paths that treated missing data as an empty item. That could allow later command/removal paths to discard an item even though its synchronized payload had never been materialized successfully. Related clipboard and large-tab behavior amplified the reliability and responsiveness problems documented in the reproduction exports.

During review, two additional holes were found and fixed:

1. command actions using `remove` still ignored typed selection-copy failures, including remove-only commands
2. trailing-row deletion could leave stale entries in the sparse item-widget index map

## Validation

- `git diff --check` passes
- the supplied Git bundle verifies as complete
- CMake was run with the repository required Debug/Ninja/test configuration under an initialized MSVC environment
- configuration reached dependency discovery but cannot complete on this machine because the Qt 6 development package (`Qt6WidgetsConfig.cmake`, Qt >= 6.2) is not installed
- runtime tests were therefore not run locally; the focused tests in this branch and Windows/SMB reproduction still need CI or a Qt-enabled environment

This is intentionally a draft while CI and maintainer review establish whether the broad bugfix pass should remain together or be split into smaller PRs.