### PR TITLE
Wayland: always rebind global shortcuts on startup

### DIFF
--- a/qxt/qxtglobalshortcut_x11.cpp
+++ b/qxt/qxtglobalshortcut_x11.cpp
@@ -225,12 +225,29 @@ private:
             return a.first < b.first;
         });
 
-        if (shortcuts.isEmpty() || shortcuts == m_boundShortcuts)
+        if (shortcuts.isEmpty())
             return;
+
+        // Bind the shortcuts even if ListShortcuts() already reports the same
+        // set. That call is a read-only query returning "the shortcuts that
+        // were successfully bound in a previous session by this application" -
+        // it does not re-establish the key grab. The grab is released together
+        // with the portal session of the previous app instance, while the
+        // approval is persisted by the backend, so the shortcuts have to be
+        // bound again on each start.
+        //
+        // Rebinding an unchanged, already approved set is silent in
+        // xdg-desktop-portal-kde since "Improve the global shortcuts workflow"
+        // (merge request !368). This was verified only with that backend; a
+        // backend asking for confirmation on each start would still be better
+        // than not binding at all, which leaves the shortcuts listed as
+        // registered but inactive.
 
         // Shortcuts can be bound only once per session.
         // Notify user to restart the app.
         if (m_bound) {
+            if (shortcuts == m_boundShortcuts)
+                return;
             qCDebug(qxtCategory) << "Can bind portal global shortcuts only once per session";
             if (m_notifyRestart) {
                 m_notifyRestart = false;


### PR DESCRIPTION
## Problem

On Wayland (KDE Plasma), global shortcuts stop working after a plain restart of CopyQ — no reboot, no logout, same KWin/portal session:

```
copyq exit
copyq --start-server show
```

No error is shown, and the entry in *System Settings → Shortcuts → Applications* still looks perfectly normal — the shortcuts are simply dead.

With `COPYQ_LOG_LEVEL=DEBUG` the log stops right after listing:

```
DEBUG: [copyq.globalshortcut] Portal global shortcut session: "..."
DEBUG: [copyq.globalshortcut] Previously registered shortcuts: QList(...)
```

There is no `Binding portal global shortcuts:` line after it. `xdg-desktop-portal-kde` confirms it from the other side — `CreateSession` and `ListShortcuts` are called, but `BindShortcuts` never is.

Wiping the registration with
`qdbus6 org.kde.kglobalaccel /component/com_github_hluk_copyq org.kde.kglobalaccel.Component.cleanUp`
and restarting makes everything work again, because `ListShortcuts` then comes back empty.

## Cause

`bindPortalGlobalShortcuts()` treated a non-empty `ListShortcuts()` result as "nothing to do":

```cpp
if (shortcuts.isEmpty() || shortcuts == m_boundShortcuts)
    return;
```

But `ListShortcuts` is a read-only query and does not establish anything. The portal interface documentation says so directly:

> If `BindShortcuts` was called for `session` all active shortcuts for `session` are returned.
> **Otherwise returns the shortcuts that were successfully bound in a previous session by this application.**

When the previous CopyQ process exits, its portal session — and the live grab with it — is closed, while the persisted "approved" record in kglobalaccel remains. So on the next start `ListShortcuts` keeps happily reporting the shortcuts as registered even though nothing is actually grabbing keys, and CopyQ skipped `BindShortcuts` on that basis.

The one-bind-per-session limit is per *session*, not per application lifetime, and a new session is created on every start:

> Bind the shortcuts. […] An application can only attempt bind shortcuts of a session once.

## Fix

Call `BindShortcuts` unconditionally on every session start, regardless of what `ListShortcuts` returns. The `ListShortcuts` result is still used — for the existing `OBSOLETE||` override workaround and for the debug log — it just no longer decides whether to bind.

The set comparison is kept for repeat bind requests *within* one session, so re-applying an unchanged configuration still does not produce a spurious "restart needed" notification.

Rebinding an unchanged, already-approved set is silent: `xdg-desktop-portal-kde` skips the confirmation dialog in that case since [MR !368 "Improve the global shortcuts workflow"](https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/merge_requests/368).

## Testing

Tested on KDE Plasma Wayland, `xdg-desktop-portal` 1.22.1 / `xdg-desktop-portal-kde` 6.7.4, using an isolated app id so an existing CopyQ registration was not touched. Both a pre-fix and a post-fix build were run through the same scenario.

Restarting with an unchanged shortcut set:

| | before | after |
|---|---|---|
| `BindShortcuts` reaches the portal | no | yes |
| `kglobalaccel` `Component.isActive()` | `false` | `true` |
| shortcut actually fires | no | yes |

- **First registration** — consent dialog shown, shortcuts work.
- **`copyq exit` + restart, same set** — no dialog, `BindShortcuts` called silently, shortcuts keep working. This is the case that was broken.
- **Changed set + restart** — rebound correctly, including the `OBSOLETE||` entry for the removed trigger, and the new trigger works.
- **Re-applying an unchanged set in a running instance** — still silent, no "restart needed" notification.

Shortcut activation was driven through `org.kde.kglobalaccel.Component.invokeShortcut` and verified by the `Portal global shortcut activated:` log line.

**Not tested on other portal backends.** Idempotent rebinding of an approved set is the specified behaviour, but I have only verified it live against `xdg-desktop-portal-kde` — I have no GNOME or wlroots/Hyprland setup to check. Should a backend re-prompt on every start, that is still better than the current situation, where shortcuts are listed as registered but completely inactive. This is noted in a comment next to the change.

The X11 path is untouched.
