### PR TITLE
Fix ItemSync data loss when moving lazy items

### DIFF
--- a/plugins/itemsync/filewatcher.cpp
+++ b/plugins/itemsync/filewatcher.cpp
@@ -144,27 +144,51 @@ public:
         return QStringLiteral("%1\n%2").arg(m_path, m_format);
     }
 
+    bool tryReadAll(QByteArray *bytes, int retryCount) const
+    {
+        Q_ASSERT(bytes);
+
+        const int attempts = 1 + retryCount;
+        QString lastError;
+        for (int attempt = 0; attempt < attempts; ++attempt) {
+            QFile f(m_path);
+            if ( !f.open(QIODevice::ReadOnly) ) {
+                lastError = f.errorString();
+            } else if ( m_format.isEmpty() ) {
+                const QByteArray result = f.readAll();
+                if (f.error() == QFileDevice::NoError) {
+                    *bytes = result;
+                    return true;
+                }
+                lastError = f.errorString();
+            } else {
+                QDataStream stream(&f);
+                QVariantMap dataMap;
+                if ( deserializeData(&stream, &dataMap) && dataMap.contains(m_format) ) {
+                    *bytes = dataMap.value(m_format).toByteArray();
+                    return true;
+                }
+                lastError = QStringLiteral("incomplete or invalid synchronized item data");
+            }
+
+            if (attempt + 1 < attempts) {
+                qCDebug(fileWatcher)
+                    << "Retrying read of" << m_path
+                    << "(attempt" << (attempt + 2) << "of" << attempts << ")"
+                    << lastError;
+                QThread::msleep(fileOpRetryDelayMs);
+            }
+        }
+
+        logFailedToOpenForReading(m_path, lastError);
+        return false;
+    }
+
     QByteArray readAll() const
     {
-        QFile f(m_path);
-        const bool opened = retryFileOp([&f]{ return f.open(QIODevice::ReadOnly); }, "open for reading", f, /*retryCount=*/0);
-        if (!opened) {
-            logFailedToOpenForReading(m_path, f.errorString());
-            return QByteArray();
-        }
-
-        if ( m_format.isEmpty() )
-            return f.readAll();
-
-        QDataStream stream(&f);
-        QVariantMap dataMap;
-        if ( !deserializeData(&stream, &dataMap) ) {
-            qCCritical(fileWatcher)
-                << "Failed to read file" << m_path << f.errorString();
-            return QByteArray();
-        }
-
-        return dataMap.value(m_format).toByteArray();
+        QByteArray bytes;
+        tryReadAll(&bytes, /*retryCount=*/0);
+        return bytes;
     }
 
     bool operator==(const SyncDataFile &other) const {
@@ -198,6 +222,33 @@ void registerSyncDataFileConverter()
     QMetaType::registerConverter(&SyncDataFile::readAll);
     QMetaType::registerConverter(&SyncDataFile::toString);
     qRegisterMetaType<SyncDataFile>("SyncDataFile");
+}
+
+bool FileWatcher::materializeItemDataForCopy(QVariantMap *data, QString *error)
+{
+    Q_ASSERT(data);
+
+    QVariantMap detached = *data;
+    const int syncDataFileType = qMetaTypeId<SyncDataFile>();
+    for (auto it = detached.begin(); it != detached.end(); ++it) {
+        if (it.value().typeId() != syncDataFileType)
+            continue;
+
+        const SyncDataFile source = it.value().value<SyncDataFile>();
+        QByteArray bytes;
+        if ( !source.tryReadAll(&bytes, maxFileOpRetries) ) {
+            if (error) {
+                *error = QStringLiteral("Failed to read synchronized item data from %1")
+                    .arg(source.path());
+            }
+            return false;
+        }
+
+        it.value() = bytes;
+    }
+
+    *data = detached;
+    return true;
 }
 
 struct Ext {

--- a/plugins/itemsync/filewatcher.h
+++ b/plugins/itemsync/filewatcher.h
@@ -64,6 +64,15 @@ public:
      */
     static bool isOwnBaseName(const QString &baseName);
 
+    /**
+     * Replace lazy file-backed values with detached byte arrays.
+     *
+     * Returns false without modifying @a data if any source file cannot be
+     * read. This must happen before copied item data can outlive files owned
+     * by the synchronized source tab.
+     */
+    static bool materializeItemDataForCopy(QVariantMap *data, QString *error);
+
     static void removeFilesForRemovedIndexes(
         const QString &tabPath, const QList<QPersistentModelIndex> &indexes,
         bool ownOnly = false);

--- a/plugins/itemsync/itemsync.cpp
+++ b/plugins/itemsync/itemsync.cpp
@@ -472,22 +472,33 @@ void ItemSyncSaver::itemsRemovedByUser(const QList<QPersistentModelIndex> &index
     FileWatcher::removeFilesForRemovedIndexes(m_tabPath, indexList);
 }
 
-QVariantMap ItemSyncSaver::copyItem(const QAbstractItemModel &, const QVariantMap &itemData)
+bool ItemSyncSaver::copyItem(
+    const QAbstractItemModel &, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *error)
 {
-    if (m_watcher)
-        m_watcher->updateItemsIfNeeded();
+    Q_ASSERT(copiedItemData);
 
-    QVariantMap copiedItemData;
-    for (auto it = itemData.begin(); it != itemData.constEnd(); ++it) {
+    QVariantMap detachedItemData;
+    for (auto it = itemData.constBegin(); it != itemData.constEnd(); ++it) {
         const auto &format = it.key();
         if ( !format.startsWith(mimePrivateSyncPrefix) )
-            copiedItemData[format] = it.value();
+            detachedItemData.insert(format, it.value());
     }
 
-    copiedItemData.insert(mimeSyncPath, m_tabPath);
+    QString materializeError;
+    if ( !FileWatcher::materializeItemDataForCopy(&detachedItemData, &materializeError) ) {
+        qCWarning(plugin) << materializeError;
+        if (error) {
+            *error = tr("Failed to read synchronized item data. "
+                        "The source item was left unchanged.");
+        }
+        return false;
+    }
+
+    detachedItemData.insert(mimeSyncPath, m_tabPath);
 
     // Add text/uri-list if no data are present.
-    if ( hasOnlyInternalData(copiedItemData) ) {
+    if ( hasOnlyInternalData(detachedItemData) ) {
         QByteArray uriData;
 
         const QVariantMap mimeToExtension = itemData.value(mimeExtensionMap).toMap();
@@ -503,11 +514,12 @@ QVariantMap ItemSyncSaver::copyItem(const QAbstractItemModel &, const QVariantMa
 
         QVariantMap noSaveData;
         noSaveData.insert(mimeUriList, FileWatcher::calculateHash(uriData));
-        copiedItemData.insert(mimeUriList, uriData);
-        copiedItemData.insert(mimeNoSave, noSaveData);
+        detachedItemData.insert(mimeUriList, uriData);
+        detachedItemData.insert(mimeNoSave, noSaveData);
     }
 
-    return copiedItemData;
+    *copiedItemData = detachedItemData;
+    return true;
 }
 
 void ItemSyncSaver::setFocus(bool focus)

--- a/plugins/itemsync/itemsync.h
+++ b/plugins/itemsync/itemsync.h
@@ -52,7 +52,11 @@ public:
 
     void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList) override;
 
-    QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData) override;
+    bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error) override;
 
     void setFocus(bool focus) override;
 

--- a/src/gui/clipboardbrowser.cpp
+++ b/src/gui/clipboardbrowser.cpp
@@ -638,16 +638,44 @@ void ClipboardBrowser::dragDropScroll()
     }
 }
 
-QVariantMap ClipboardBrowser::copyIndex(const QModelIndex &index) const
+QVariantMap ClipboardBrowser::copyIndex(
+    const QModelIndex &index, QString *error) const
 {
-    auto data = index.data(contentType::data).toMap();
-    return m_itemSaver ? m_itemSaver->copyItem(m, data) : data;
+    if (error)
+        error->clear();
+
+    const auto data = index.data(contentType::data).toMap();
+    if (!m_itemSaver)
+        return data;
+
+    QVariantMap copiedData;
+    if ( !m_itemSaver->copyItem(m, data, &copiedData, error) ) {
+        if (error && error->isEmpty())
+            *error = tr("Failed to copy item data.");
+        return {};
+    }
+
+    return copiedData;
 }
 
-QVariantMap ClipboardBrowser::copyIndexes(const QModelIndexList &indexes) const
+QVariantMap ClipboardBrowser::copyIndexes(
+    const QModelIndexList &indexes, QString *error) const
 {
+    QString localError;
+    QString *copyError = error ? error : &localError;
+    copyError->clear();
+
     if (indexes.size() == 1)
-        return copyIndex( indexes.first() );
+        return copyIndex(indexes.first(), copyError);
+
+    QVector<QVariantMap> copiedItems;
+    copiedItems.reserve(indexes.size());
+    for (const auto &index : indexes) {
+        const auto itemData = copyIndex(index, copyError);
+        if ( !copyError->isEmpty() )
+            return {};
+        copiedItems.append(itemData);
+    }
 
     QByteArray bytes;
     QByteArray text;
@@ -658,10 +686,7 @@ QVariantMap ClipboardBrowser::copyIndexes(const QModelIndexList &indexes) const
     {
         QDataStream stream(&bytes, QIODevice::WriteOnly);
 
-        for (const auto &index : indexes) {
-            auto itemData = index.data(contentType::data).toMap();
-            itemData = m_itemSaver ? m_itemSaver->copyItem(m, itemData) : itemData;
-
+        for (const auto &itemData : copiedItems) {
             stream << itemData;
 
             appendTextData(itemData, mimeText, &text);
@@ -855,9 +880,18 @@ void ClipboardBrowser::onEditorInvalidate()
 
 void ClipboardBrowser::setClipboardFromEditor()
 {
-    QModelIndex index = m_editor->index();
-    if (index.isValid())
-        emit changeClipboard( copyIndex(index) );
+    const QModelIndex index = m_editor->index();
+    if ( !index.isValid() )
+        return;
+
+    QString errorString;
+    const auto data = copyIndex(index, &errorString);
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
+
+    emit changeClipboard(data);
 }
 
 void ClipboardBrowser::onEditorNeedsChangeClipboard(const QByteArray &bytes, const QString &mime)
@@ -1052,9 +1086,14 @@ void ClipboardBrowser::mouseMoveEvent(QMouseEvent *event)
         selected.append(targetIndex);
     }
 
-    QVariantMap data = copyIndexes(selected);
+    QString errorString;
+    const QVariantMap data = copyIndexes(selected, &errorString);
 
     m_dragStartPosition = QPoint();
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
     auto drag = new QDrag(this);
     drag->setMimeData( createMimeData(data) );
     drag->setPixmap( renderItemPreview(selected, 150, 150) );
@@ -1338,7 +1377,12 @@ void ClipboardBrowser::moveToClipboard(const QModelIndex &ind)
 
 void ClipboardBrowser::moveToClipboard(const QModelIndexList &indexes)
 {
-    const auto data = copyIndexes(indexes);
+    QString errorString;
+    const auto data = copyIndexes(indexes, &errorString);
+    if ( !errorString.isEmpty() ) {
+        emit error(errorString);
+        return;
+    }
 
     if ( m_sharedData->moveItemOnReturnKey
          && m_itemSaver && m_itemSaver->canMoveItems(indexes) )
@@ -1658,11 +1702,11 @@ bool ClipboardBrowser::addAndSelect(const QVariantMap &data, int row)
     return added;
 }
 
-void ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
+bool ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
 {
     if ( moveToTop(hash(data)) ) {
         COPYQ_LOG("New item: Moving existing to top");
-        return;
+        return true;
     }
 
     // When selecting text under X11, clipboard data may change whenever selection changes.
@@ -1689,16 +1733,14 @@ void ClipboardBrowser::addUnique(const QVariantMap &data, ClipboardMode mode)
                 for (auto it = data.constBegin(); it != data.constEnd(); ++it)
                     newData.insert(it.key(), it.value());
 
-                m.setData(firstIndex, newData, contentType::data);
-
-                return;
+                return m.setData(firstIndex, newData, contentType::data);
             }
         }
     }
 
     COPYQ_LOG("New item: Adding");
 
-    add(data);
+    return add(data);
 }
 
 void ClipboardBrowser::setItemsData(const QMap<QPersistentModelIndex, QVariantMap> &itemsData)

--- a/src/gui/clipboardbrowser.h
+++ b/src/gui/clipboardbrowser.h
@@ -92,9 +92,9 @@ class ClipboardBrowser final : public QListView
          */
         void keyboardSearch(const QString &text) override;
 
-        QVariantMap copyIndex(const QModelIndex &index) const;
+        QVariantMap copyIndex(const QModelIndex &index, QString *error = nullptr) const;
 
-        QVariantMap copyIndexes(const QModelIndexList &indexes) const;
+        QVariantMap copyIndexes(const QModelIndexList &indexes, QString *error = nullptr) const;
 
         void removeIndexes(const QModelIndexList &indexes, QString *error = nullptr);
 
@@ -128,7 +128,7 @@ class ClipboardBrowser final : public QListView
         /**
          * Add item and remove duplicates.
          */
-        void addUnique(const QVariantMap &data, ClipboardMode mode);
+        bool addUnique(const QVariantMap &data, ClipboardMode mode);
 
         void setItemsData(const QMap<QPersistentModelIndex, QVariantMap> &itemsData);
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1352,11 +1352,30 @@ void MainWindow::onItemCommandActionTriggered(CommandAction *commandAction, cons
 
     if ( !command.tab.isEmpty() && command.tab != c->tabName() ) {
         auto c2 = tab(command.tab);
-        if (c2) {
-            for (int i = selected.size() - 1; i >= 0; --i) {
-                const auto data = c->copyIndex(selected[i]);
-                if ( !data.isEmpty() )
-                    c2->addUnique(data, ClipboardMode::Clipboard);
+        if (!c2) {
+            showError( tr("Target tab %1 is not available.").arg(quoteString(command.tab)) );
+            return;
+        }
+
+        QVector<QVariantMap> copiedItems;
+        copiedItems.reserve(selected.size());
+        for (int i = selected.size() - 1; i >= 0; --i) {
+            QString errorString;
+            const auto data = c->copyIndex(selected[i], &errorString);
+            if ( !errorString.isEmpty() ) {
+                showError(errorString);
+                return;
+            }
+            copiedItems.append(data);
+        }
+
+        for (const auto &data : copiedItems) {
+            if ( !c2->addUnique(data, ClipboardMode::Clipboard) ) {
+                showError(
+                    tr("Failed to add copied items to tab %1. "
+                       "The source items were left unchanged.")
+                    .arg(quoteString(command.tab)) );
+                return;
             }
         }
     }
@@ -4351,7 +4370,13 @@ void MainWindow::copyItems()
     if ( indexes.isEmpty() )
         return;
 
-    const auto data = c->copyIndexes(indexes);
+    QString errorString;
+    const auto data = c->copyIndexes(indexes, &errorString);
+    if ( !errorString.isEmpty() ) {
+        showError(errorString);
+        return;
+    }
+
     setClipboard(data);
 }
 

--- a/src/item/itemsaverwrapper.cpp
+++ b/src/item/itemsaverwrapper.cpp
@@ -32,9 +32,11 @@ void ItemSaverWrapper::itemsRemovedByUser(const QList<QPersistentModelIndex> &in
     return m_saver->itemsRemovedByUser(indexList);
 }
 
-QVariantMap ItemSaverWrapper::copyItem(const QAbstractItemModel &model, const QVariantMap &itemData)
+bool ItemSaverWrapper::copyItem(
+    const QAbstractItemModel &model, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *error)
 {
-    return m_saver->copyItem(model, itemData);
+    return m_saver->copyItem(model, itemData, copiedItemData, error);
 }
 
 void ItemSaverWrapper::setFocus(bool focus)

--- a/src/item/itemsaverwrapper.h
+++ b/src/item/itemsaverwrapper.h
@@ -17,7 +17,11 @@ public:
 
     void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList) override;
 
-    QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData) override;
+    bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error) override;
 
     void setFocus(bool focus) override;
 

--- a/src/item/itemwidget.cpp
+++ b/src/item/itemwidget.cpp
@@ -200,9 +200,13 @@ void ItemSaverInterface::itemsRemovedByUser(const QList<QPersistentModelIndex> &
     /* No-op default: subclasses override to handle user-initiated removal */
 }
 
-QVariantMap ItemSaverInterface::copyItem(const QAbstractItemModel &, const QVariantMap &itemData)
+bool ItemSaverInterface::copyItem(
+    const QAbstractItemModel &, const QVariantMap &itemData,
+    QVariantMap *copiedItemData, QString *)
 {
-    return itemData;
+    Q_ASSERT(copiedItemData);
+    *copiedItemData = itemData;
+    return true;
 }
 
 void ItemSaverInterface::setFocus(bool)

--- a/src/item/itemwidget.h
+++ b/src/item/itemwidget.h
@@ -203,9 +203,17 @@ public:
     virtual void itemsRemovedByUser(const QList<QPersistentModelIndex> &indexList);
 
     /**
-     * Return copy of items data.
+     * Create a self-contained copy of item data.
+     *
+     * Implementations with lazy or externally owned values must materialize
+     * them before reporting success. On failure, @a copiedItemData is left
+     * unchanged and callers must leave the source item unchanged.
      */
-    virtual QVariantMap copyItem(const QAbstractItemModel &model, const QVariantMap &itemData);
+    virtual bool copyItem(
+        const QAbstractItemModel &model,
+        const QVariantMap &itemData,
+        QVariantMap *copiedItemData,
+        QString *error);
 
     virtual void setFocus(bool focus);
 

--- a/src/tests/itemsynctests.cpp
+++ b/src/tests/itemsynctests.cpp
@@ -868,6 +868,72 @@ void ItemSyncTests::moveOwnItemsKeepsLargeTextData()
     RUN(args << "getItem(0)[mimeText].length + ',' + getItem(1)[mimeText].length", "4096,3072\n");
 }
 
+void ItemSyncTests::moveLargeItemsWithCommandKeepsData()
+{
+    TestDir syncDir(1);
+    const QString syncTab = testTab(1);
+    const QString localTab = QString(clipboardTabName);
+    const Args syncArgs = Args() << "tab" << syncTab;
+    const Args localArgs = Args() << "tab" << localTab;
+
+    RUN("config" << "tab_tree" << "true", "true\n");
+    RUN("config" << "show_simple_items" << "true", "true\n");
+    RUN("show" << syncTab, "");
+    RUN(syncArgs << "add('A'.repeat(4096), 'B'.repeat(3072));"
+                    "read(0).length + ',' + read(1).length", "3072,4096\n");
+    QCOMPARE(syncDir.files().size(), 2);
+
+    // Force both payloads through the lazy SyncDataFile representation.
+    RUN("unload" << syncTab, "");
+    RUN(syncArgs << "read(0).length + ',' + read(1).length", "3072,4096\n");
+    RUN(syncArgs << "selectItems" << "0" << "1", "true\n");
+    RUN("setCurrentTab" << syncTab, "");
+
+    // Exercise the cross-tab command path. The source is removed only after
+    // the ordinary destination accepts a self-contained payload.
+    RUN(QStringLiteral(
+        "setCommands([{name:'Move lazy items',inMenu:true,"
+        "shortcuts:['Ctrl+F1'],tab:'%1',remove:true}])").arg(localTab), "");
+    KEYS("CTRL+F1");
+
+    WAIT_ON_OUTPUT(syncArgs << "size", "0\n");
+    QCOMPARE(syncDir.files().size(), 0);
+    RUN(localArgs << "read(0) == 'B'.repeat(3072) && read(1) == 'A'.repeat(4096)", "true\n");
+
+    // Reload after source destruction to prove the destination owns bytes
+    // rather than dangling references into the synchronized directory.
+    RUN("unload" << localTab, localTab + "\n");
+    RUN(localArgs << "read(0) == 'B'.repeat(3072) && read(1) == 'A'.repeat(4096)", "true\n");
+}
+
+void ItemSyncTests::moveCommandKeepsSourceOnCopyFailure()
+{
+    const QString sourceTab = QStringLiteral("COPY_FAILURE");
+    const QString localTab = QString(clipboardTabName);
+    const Args sourceArgs = Args() << "tab" << sourceTab;
+    const Args localArgs = Args() << "tab" << localTab;
+
+    RUN("show" << sourceTab, "");
+    RUN(sourceArgs << "add" << "SOURCE", "");
+    RUN(sourceArgs << "read(0)", "SOURCE");
+    RUN("show" << localTab, "");
+    RUN("unload" << sourceTab, sourceTab + "\n");
+    RUN(QStringLiteral(
+        "callPlugin('itemtests', 'failNextItemCopy'); show('%1')").arg(sourceTab), "");
+    RUN(sourceArgs << "selectItems" << "0", "true\n");
+    RUN("setCurrentTab" << sourceTab, "");
+    RUN(QStringLiteral(
+        "setCommands([{name:'Move failed item',inMenu:true,"
+        "shortcuts:['Ctrl+F1'],tab:'%1',remove:true}])").arg(localTab), "");
+    KEYS("CTRL+F1");
+
+    WAIT_ON_OUTPUT(sourceArgs << "size", "1\n");
+    RUN("show" << localTab, "");
+    RUN("unload" << sourceTab, sourceTab + "\n");
+    RUN(sourceArgs << "read(0)", "SOURCE");
+    RUN(localArgs << "size", "0\n");
+}
+
 void ItemSyncTests::avoidDuplicateItemsAddedFromClipboard()
 {
     TestDir dir1(1);

--- a/src/tests/itemsynctests.h
+++ b/src/tests/itemsynctests.h
@@ -50,6 +50,8 @@ private slots:
 
     void moveOwnItemsSortsBaseNames();
     void moveOwnItemsKeepsLargeTextData();
+    void moveLargeItemsWithCommandKeepsData();
+    void moveCommandKeepsSourceOnCopyFailure();
 
     void avoidDuplicateItemsAddedFromClipboard();
 

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -13,6 +13,8 @@
 
 namespace {
 
+bool failNextItemCopyRequested = false;
+
 Q_DECLARE_LOGGING_CATEGORY(plugin)
 Q_LOGGING_CATEGORY(plugin, "copyq.keys")
 
@@ -131,6 +133,35 @@ bool checkEventTarget(
         << (target ? "Target widget is no longer visible" : "Target widget no longer exists");
     return false;
 }
+
+class CopyFailureItemSaver final : public ItemSaverInterface
+{
+public:
+    explicit CopyFailureItemSaver(const ItemSaverPtr &saver)
+        : m_saver(saver)
+    {
+    }
+
+    bool saveItems(
+        const QString &tabName,
+        const QAbstractItemModel &model,
+        QIODevice *file) override
+    {
+        return m_saver->saveItems(tabName, model, file);
+    }
+
+    bool copyItem(
+        const QAbstractItemModel &, const QVariantMap &,
+        QVariantMap *, QString *error) override
+    {
+        if (error)
+            *error = QStringLiteral("Injected item copy failure");
+        return false;
+    }
+
+private:
+    ItemSaverPtr m_saver;
+};
 
 } // namespace
 
@@ -455,6 +486,17 @@ void ItemTestsScriptable::keys()
     }
 }
 
+ItemSaverPtr ItemTestsLoader::transformSaver(
+    const ItemSaverPtr &saver,
+    QAbstractItemModel *)
+{
+    if (!failNextItemCopyRequested)
+        return saver;
+
+    failNextItemCopyRequested = false;
+    return std::make_shared<CopyFailureItemSaver>(saver);
+}
+
 ItemScriptable *ItemTestsLoader::scriptableObject()
 {
     return new ItemTestsScriptable();
@@ -478,6 +520,11 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
 
     if (cmd == "sendKeysStatus")
         return keyClicker()->status(arguments.value(1).toBool());
+
+    if (cmd == "failNextItemCopy") {
+        failNextItemCopyRequested = true;
+        return {};
+    }
 
     return QStringLiteral("Unexpected command: %1").arg(cmd);
 }

--- a/src/tests/itemtests/itemtests.h
+++ b/src/tests/itemtests/itemtests.h
@@ -28,6 +28,9 @@ public:
     QString author() const override { return {}; }
     QString description() const override { return {}; }
     QVariant icon() const override { return {}; }
+    ItemSaverPtr transformSaver(
+        const ItemSaverPtr &saver,
+        QAbstractItemModel *model) override;
     ItemScriptable *scriptableObject() override;
     QVariant scriptCallback(const QVariantList &arguments) override;
 


### PR DESCRIPTION
## Summary

- make item-copy preparation fallible so callers can distinguish an empty item from a failed copy
- detach ItemSync's lazy file-backed values before they cross a tab, clipboard, editor, command, or drag boundary
- abort cross-tab removal when materialization or destination insertion fails
- add regressions for large synchronized moves and deterministic copy-preparation failure

## Root cause

Large ItemSync values can be represented in memory by lazy references to files owned by the synchronized source tab. Cross-tab moves previously copied those references into an ordinary tab and then removed the source item and its files. The destination consequently retained references to files that no longer existed and later read as empty data.

## Impact

Transferred items now own their bytes before the source can be removed. If a synchronized value cannot be read, CopyQ reports the failure and leaves the source selection intact instead of manufacturing an empty payload.

## Validation

- full Debug build with Qt 6.10.2 and MSVC
- Windows (Qt 6.10.2/MSVC): `testItemSync:moveOwnItemsKeepsLargeTextData`, `testItemSync:moveLargeItemsWithCommandKeepsData`, `testItemSync:moveCommandKeepsSourceOnCopyFailure`
- Ubuntu 26.04 (Qt 6.10.2/GCC): the same three targeted tests
- the failure regression wraps a normally serialized source saver, injects failure only at `copyItem()`, and verifies after reload that the source remains readable and the destination remains empty