### PR TITLE
Fix ~1s delay reopening window with Close When Unfocused

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -95,6 +95,7 @@ Q_LOGGING_CATEGORY(logCategory, "copyq.wnd")
 
 const int contextMenuUpdateIntervalMsec = 100;
 const int itemPreviewUpdateIntervalMsec = 100;
+const int showWindowGracePeriodMsec = 1000;
 
 constexpr auto dataStreamImportVersionDefault = QDataStream::Qt_4_7;
 constexpr auto dataStreamImportVersionForV5 = QDataStream::Qt_5_15;
@@ -2722,10 +2723,19 @@ void MainWindow::enableHideWindowOnUnfocus()
 
 void MainWindow::hideWindowIfNotActive()
 {
-    if ( isVisible() && !hasDialogOpen(this) && !isAnyApplicationWindowActive() ) {
-        COPYQ_LOG("Auto-hiding unfocused main window");
-        hideWindow();
+    if ( !isVisible() || hasDialogOpen(this) || isAnyApplicationWindowActive() )
+        return;
+
+    if ( m_showWindowTime.isValid() && m_showWindowTime.elapsed() <= showWindowGracePeriodMsec ) {
+        // Window lost focus during the show grace period. Recheck after it expires
+        // so the window doesn't stay open and unfocused indefinitely.
+        const int remaining = showWindowGracePeriodMsec - m_showWindowTime.elapsed() + 100;
+        m_timerHideWindowIfNotActive.start(remaining);
+        return;
     }
+
+    COPYQ_LOG("Auto-hiding unfocused main window");
+    hideWindow();
 }
 
 void MainWindow::hideWindowOnUnfocus(int intervalMsec)
@@ -3232,6 +3242,13 @@ void MainWindow::showWindow()
     if ( isWindowVisible() )
         return;
 
+    // Record show time so hideWindowIfNotActive() can apply a grace period.
+    // Transient WindowDeactivate events during the show/raise process
+    // (e.g. another app holds focus) must not trigger close-on-unfocus.
+    m_showWindowTime.start();
+
+    COPYQ_LOG("Showing main window");
+
     m_trayMenu->close();
     m_menu->close();
 
@@ -3295,8 +3312,11 @@ bool MainWindow::toggleVisible()
 
 void MainWindow::toggleVisibleFromTray()
 {
-    if (!isMinimized() && isVisible()) {
+    if (!isMinimized() && isVisible() && (m_isActiveWindow || !m_options.closeOnUnfocus)) {
         hideWindow();
+    } else if (!isMinimized() && isVisible()) {
+        COPYQ_LOG("Tray toggle: reactivating deactivated window");
+        showWindow();
     } else {
         showWindow();
     }

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -16,6 +16,7 @@
 #include <QPersistentModelIndex>
 #include <QPointer>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QtContainerFwd>
 
 enum class PasswordSource;
@@ -719,6 +720,8 @@ private:
     QTimer m_timerSaveTabPositions;
     QTimer m_timerHideWindowIfNotActive;
     QTimer m_timerRaiseLastWindowAfterMenuClosed;
+
+    QElapsedTimer m_showWindowTime;
 
     bool m_trayMenuDirty = true;
 


### PR DESCRIPTION
When another application holds focus, showing the main window triggers a transient deactivation event that starts the close-on-unfocus timer, re-hiding the window almost immediately. Users experience a flash then disappear, perceived as a delay before the window can be reopened.

Add a 1-second grace period after an explicit show so that transient focus loss during the show/raise process does not trigger auto-hide. Close-on-unfocus resumes normally after the grace period.

Also fix tray toggle: when the window is visible but deactivated during the close-on-unfocus delay, a tray click now reactivates instead of hiding, avoiding the need for a second click.

Fixes: https://github.com/hluk/CopyQ/issues/3634
Assisted-by: Claude (Anthropic)