### PR TITLE
Store tab data and state files in XDG-compliant directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Always use the following environment variables for all `build/copyq` and
     export COPYQ_SESSION_NAME="test"
     export COPYQ_SETTINGS_PATH="build/copyq-test-conf"
     export COPYQ_ITEM_DATA_PATH="build/copyq-test-data"
+    export COPYQ_STATE_PATH="build/copyq-test-conf"
     export COPYQ_PLUGINS=""
     export COPYQ_DEFAULT_ICON="1"
     export COPYQ_SESSION_COLOR="#f90"

--- a/docs/backup.rst
+++ b/docs/backup.rst
@@ -18,40 +18,76 @@ To install the command see `the description in the repository
 Back Up Manually
 ----------------
 
-To back up all the data, **exit the application** first and **copy
-the configuration directory** and **the data directory**.
+To back up all the data, **exit the application** first and copy
+the configuration, data and state directories.
 
-Path to the configuration is usually:
+.. versionchanged:: 17.0.0
+   Tab data and state files were previously stored in the configuration
+   directory. They are migrated automatically on first startup.
 
--  Windows: ``%APPDATA%\copyq``
--  Portable version for Windows: ``config`` sub-folder in unzipped
-   application directory
--  Linux: ``~/.config/copyq``
+Default paths since version 17.0.0:
 
-Path to the data is usually:
+.. list-table::
+   :header-rows: 1
 
--  Windows: ``%APPDATA%\copyq\items``
--  Portable version for Windows: ``items`` sub-folder in unzipped
-   application directory
--  Linux: ``~/.local/share/copyq/copyq/items``
+   * - Platform
+     - Configuration
+     - Data
+     - State
+   * - Linux
+     - ``~/.config/copyq``
+     - ``~/.local/share/copyq``
+     - ``~/.local/state/copyq``
+   * - macOS
+     - ``~/Library/Preferences/copyq``
+     - ``~/Library/Application Support/copyq``
+     - ``~/Library/Application Support/copyq``
+   * - Windows
+     - ``%APPDATA%\copyq``
+     - ``%LOCALAPPDATA%\copyq``
+     - ``%LOCALAPPDATA%\copyq``
+   * - Windows (portable)
+     - ``config``
+     - ``config``
+     - ``config``
 
-To copy the configuration path to clipboard from CopyQ:
+Default paths before version 17.0.0:
 
-1. Open Action dialog (``F5`` shortcut).
-2. Enter the command:
+.. list-table::
+   :header-rows: 1
+
+   * - Platform
+     - Configuration, tab data, state
+     - Item data
+     - Logs
+   * - Linux
+     - ``~/.config/copyq``
+     - ``~/.local/share/copyq/items``
+     - ``~/.local/share/copyq``
+   * - macOS
+     - ``~/Library/Preferences/copyq``
+     - ``~/Library/Application Support/copyq/items``
+     - ``~/Library/Application Support/copyq``
+   * - Windows
+     - ``%APPDATA%\copyq``
+     - ``%APPDATA%\copyq\items``
+     - ``%APPDATA%\copyq``
+   * - Windows (portable)
+     - ``config``
+     - ``config\items``
+     - ``logs``
+
+To copy a directory path to clipboard:
 
 .. code-block:: js
 
     copyq:
-    dir = Dir(info('config') + '/..')
-    copy(dir.absolutePath())
+    copy(Dir(info('config') + '/..').absolutePath())
 
-3. Click OK dialog button.
-
-To copy the data path, change ``'config'`` to ``'data'``.
+Replace ``'config'`` with ``'data'`` or ``'state'`` for the other directories.
 
 To restore the backup, exit the application and replace the
-configuration directory.
+directories.
 
 .. warning::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -415,15 +415,20 @@ Here is the correct command to use for some editors::
 Where to find saved items and configuration?
 --------------------------------------------
 
-You can find configuration and saved items in:
+Configuration is stored in:
 
 a. Windows folder ``%APPDATA%\copyq`` for installed version of CopyQ.
 b. Windows sub-folder ``config`` in unzipped portable version of CopyQ.
 c. Linux directory ``~/.config/copyq``.
-d. In a directory specific to a given CopyQ instance - see :ref:`sessions`.
+d. In a directory specific to a given CopyQ instance — see :ref:`sessions`.
 
-Run ``copyq info config`` to get absolute path to the configuration file
-(parent directory contains saved items).
+Run ``copyq info config`` to get absolute path to the configuration file.
+
+.. versionchanged:: 17.0.0
+   Tab data files and item data are in the data directory, and UI state
+   files and logs are in the state directory. Use ``copyq info data``,
+   ``copyq info state`` and ``copyq info log`` to find the exact paths.
+   See :ref:`sessions` for details.
 
 Why are items and configuration not saved?
 ------------------------------------------

--- a/docs/scripting-api.rst
+++ b/docs/scripting-api.rst
@@ -750,6 +750,9 @@ unlike in GUI, where row numbers start from 1 by default.
    When called without arguments, non-path entries are listed first,
    followed by paths at the end.
 
+   .. versionchanged:: 17.0.0
+      Added ``state`` path identifier.
+
    :returns: Path for given identifier.
    :rtype: string
 

--- a/docs/sessions.rst
+++ b/docs/sessions.rst
@@ -74,36 +74,50 @@ outside the application.
 Item Data Path
 --------------
 
-Item data path can be overridden with ``COPYQ_ITEM_DATA_PATH``
-environment variable.
+.. versionchanged:: 17.0.0
+   Tab data files (``copyq_tab_*.dat``) moved from the configuration
+   directory to the data directory. Existing files are migrated
+   automatically on first startup.
+
+Tab data files and item data are stored in the data directory.
+The path can be overridden with ``COPYQ_ITEM_DATA_PATH``.
 
 ::
 
     $ copyq info data
-    /home/user/.local/share/copyq/copyq
+    /home/user/.local/share/copyq/items
 
-    $ COPYQ_ITEM_DATA_PATH=$HOME/copyq-data copyq info data
-    /home/user/copyq-data/copyq/copyq.conf
+Item data that exceeds a size threshold is stored in separate files
+(in a directory structure based on data checksum) and only referenced
+from the tab data files. The default threshold can be overridden with
+``item_data_threshold`` option. Setting it to a negative value disables
+the separate storage and keeps everything in the tab data files.
 
-The directory contains data for items that exceeds 4096 bytes. The default
-threshold can be overridden with ``item_data_threshold`` option.
+State Path
+----------
+
+.. versionchanged:: 17.0.0
+   State files were previously stored in the configuration directory.
+   They are migrated automatically on first startup.
+
+UI state files (window geometry, collapsed tabs, filter history, action
+dialog history) and logs are stored in the state directory. On Linux this
+follows ``$XDG_STATE_HOME`` (default ``~/.local/state/copyq``). On Windows
+and macOS state files are stored alongside data.
+
+The path can be overridden with ``COPYQ_STATE_PATH``.
+The log directory can be overridden separately with ``COPYQ_LOG_DIR``.
 
 ::
 
-    $ copyq config item_data_threshold
-    4096
+    $ copyq info state
+    /home/user/.local/state/copyq
 
-To disable using the data directory and store everything into tab data files,
-set the threshold to a negative value. The tab data file will be updated only
-after the items in the tab change.
+    $ copyq info log
+    /home/user/.local/state/copyq/logs/copyq-20250101-12345.log
 
-::
-
-    $ copyq config item_data_threshold -1
-    -1
-
-Note: Using data directory ensure that the application is fast even if there
-are a lot of large items in tabs.
+Existing state files and logs are migrated automatically from the
+previous locations on first startup of version 17.0.0 or later.
 
 Icon Color
 ----------

--- a/plugins/itemencrypted/itemencrypted.cpp
+++ b/plugins/itemencrypted/itemencrypted.cpp
@@ -126,7 +126,7 @@ public:
 
             const bool needsSecring = version.major == 2 && version.minor == 0;
 
-            const QString path = getConfigurationFilePath("");
+            const QString path = configurationFilePath("");
             m_pubring = path + ".pub";
             m_pubringNative = QDir::toNativeSeparators(m_pubring);
             if (needsSecring) {

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -106,7 +106,7 @@ void initSession(QCoreApplication *app, const QString &sessionName)
         if ( !app->property("CopyQ_item_data_path").isValid() ) {
             app->setProperty(
                 "CopyQ_item_data_path",
-                QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
                 + QLatin1String("/items"));
         }
     } else {
@@ -114,6 +114,25 @@ void initSession(QCoreApplication *app, const QString &sessionName)
             "CopyQ_item_data_path",
             qEnvironmentVariable("COPYQ_ITEM_DATA_PATH")
         );
+    }
+
+    if ( qEnvironmentVariableIsEmpty("COPYQ_STATE_PATH") ) {
+        if ( !app->property("CopyQ_state_path").isValid() ) {
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+            const QString stateHome = qEnvironmentVariable("XDG_STATE_HOME");
+            const QString base = (!stateHome.isEmpty() && stateHome.startsWith(QLatin1Char('/')))
+                ? stateHome
+                : QDir::homePath() + QLatin1String("/.local/state");
+            app->setProperty("CopyQ_state_path",
+                base + QLatin1Char('/') + QCoreApplication::organizationName());
+#else
+            app->setProperty("CopyQ_state_path",
+                QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
+#endif
+        }
+    } else {
+        app->setProperty("CopyQ_state_path",
+            qEnvironmentVariable("COPYQ_STATE_PATH"));
     }
 }
 

--- a/src/app/clipboardserver.cpp
+++ b/src/app/clipboardserver.cpp
@@ -154,6 +154,8 @@ ClipboardServer::ClipboardServer(QApplication *app, const QString &sessionName)
     QApplication::setQuitOnLastWindowClosed(false);
 
     ensureSettingsDirectoryExists();
+    ensureStateDirectoryExists();
+    migrateDataFiles();
 
     m_sharedData->itemFactory = new ItemFactory(m_sharedData, this);
     m_sharedData->notifications = new NotificationDaemon(this);

--- a/src/common/commandstore.cpp
+++ b/src/common/commandstore.cpp
@@ -172,13 +172,13 @@ Commands importCommands(QSettings *settings)
 
 Commands loadAllCommands()
 {
-    const QString commandConfigPath = getConfigurationFilePath("-commands.ini");
+    const QString commandConfigPath = configurationFilePath("-commands.ini");
     return importCommandsFromFile(commandConfigPath);
 }
 
 void saveCommands(const Commands &commands)
 {
-    Settings settings(getConfigurationFilePath("-commands.ini"));
+    Settings settings(configurationFilePath("-commands.ini"));
     saveCommands(commands, &settings);
 }
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -5,8 +5,10 @@
 #include <QApplication>
 #include <QByteArray>
 #include <QDir>
+#include <QFileInfo>
 #include <QLoggingCategory>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QString>
 
 namespace {
@@ -38,15 +40,15 @@ bool ensureSettingsDirectoryExists()
     return true;
 }
 
-const QString &getConfigurationFilePath()
+const QString &configurationFilePath()
 {
     static const QString path = getConfigurationFilePathHelper();
     return path;
 }
 
-QString getConfigurationFilePath(const char *suffix)
+QString configurationFilePath(const char *suffix)
 {
-    QString path = getConfigurationFilePath();
+    QString path = configurationFilePath();
     // Replace suffix.
     const int i = path.lastIndexOf(QLatin1Char('.'));
     Q_ASSERT(i != -1);
@@ -57,7 +59,7 @@ QString getConfigurationFilePath(const char *suffix)
 const QString &settingsDirectoryPath()
 {
     static const QString path =
-        QDir::cleanPath( getConfigurationFilePath() + QLatin1String("/..") );
+        QDir::cleanPath( configurationFilePath() + QLatin1String("/..") );
     return path;
 }
 
@@ -68,6 +70,53 @@ QString applicationLaunchPath()
         return appImage;
 #endif
     return QCoreApplication::applicationFilePath();
+}
+
+QString itemDataPath()
+{
+    return qApp->property("CopyQ_item_data_path").toString();
+}
+
+QString tabDataFileBasePath()
+{
+    const QFileInfo info(itemDataPath());
+    return info.path() + QLatin1Char('/')
+        + QCoreApplication::applicationName() + QLatin1String("_tab_");
+}
+
+QString statePath()
+{
+    const QVariant prop = qApp->property("CopyQ_state_path");
+    if (prop.isValid())
+        return prop.toString();
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+    const QString stateHome = qEnvironmentVariable("XDG_STATE_HOME");
+    const QString base = (!stateHome.isEmpty() && stateHome.startsWith(QLatin1Char('/')))
+        ? stateHome
+        : QDir::homePath() + QLatin1String("/.local/state");
+    return base + QLatin1Char('/') + QCoreApplication::organizationName();
+#else
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+#endif
+}
+
+QString stateFilePath(const char *suffix)
+{
+    return statePath() + QLatin1Char('/')
+        + QCoreApplication::applicationName() + QLatin1String(suffix);
+}
+
+bool ensureStateDirectoryExists()
+{
+    QDir dir(statePath());
+    if (!dir.mkpath(QStringLiteral("."))) {
+        qCCritical(logCategory)
+            << "Failed to create the directory for state:"
+            << dir.path();
+        return false;
+    }
+    return true;
 }
 
 QString adjustedInstallPath(const QString &compiledPath)

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -6,11 +6,21 @@ class QString;
 
 bool ensureSettingsDirectoryExists();
 
-const QString &getConfigurationFilePath();
+const QString &configurationFilePath();
 
-QString getConfigurationFilePath(const char *suffix);
+QString configurationFilePath(const char *suffix);
 
 const QString &settingsDirectoryPath();
+
+QString itemDataPath();
+
+QString tabDataFileBasePath();
+
+QString statePath();
+
+QString stateFilePath(const char *suffix);
+
+bool ensureStateDirectoryExists();
 
 /**
  * Returns the path to launch CopyQ from outside the current process.

--- a/src/common/diagnostics.cpp
+++ b/src/common/diagnostics.cpp
@@ -81,6 +81,7 @@ QMap<QString, QString> pathMap()
     return {
         {"config", QSettings().fileName()},
         {"data", itemDataPath()},
+        {"state", statePath()},
 #ifdef COPYQ_DESKTOP_FILE
         {"desktop", QStringLiteral(COPYQ_DESKTOP_FILE)},
 #endif

--- a/src/common/encryption.cpp
+++ b/src/common/encryption.cpp
@@ -41,8 +41,8 @@ constexpr int hkdfSha256HashLength = 32;
 constexpr int hkdfSha256MaxLength = 255 * hkdfSha256HashLength;
 constexpr int pbkdf2IterationCount = 100'000;
 
-QString dekFilePath() { return getConfigurationFilePath("wrapped_dek.dat"); }
-QString saltFilePath() { return getConfigurationFilePath("kek_salt.dat"); }
+QString dekFilePath() { return configurationFilePath("wrapped_dek.dat"); }
+QString saltFilePath() { return configurationFilePath("kek_salt.dat"); }
 
 void logFeatures()
 {

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -2,6 +2,8 @@
 
 #include "log.h"
 
+#include "common/config.h"
+
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
@@ -9,8 +11,6 @@
 #include <QString>
 #include <QtGlobal>
 #include <QVariant>
-
-#include <QStandardPaths>
 
 namespace {
 
@@ -131,10 +131,10 @@ QFileInfoList logFileNames()
 QString getDefaultLogFilePath()
 {
     const QString dir = qEnvironmentVariable("COPYQ_LOG_DIR");
-    if (!dir.isEmpty()) {
+    if (!dir.isEmpty())
         return dir;
-    }
-    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+
+    return statePath() + QLatin1String("/logs");
 }
 
 const QString &logFileName()

--- a/src/common/server.cpp
+++ b/src/common/server.cpp
@@ -25,7 +25,7 @@ bool serverIsRunning(const QString &serverName)
 
 QString lockFilePath()
 {
-    const QString lockFilePath = getConfigurationFilePath(".lock");
+    const QString lockFilePath = configurationFilePath(".lock");
 
     // Ensure parent dir exists.
     const QString path = QDir::cleanPath( lockFilePath + QLatin1String("/..") );

--- a/src/gui/actiondialog.cpp
+++ b/src/gui/actiondialog.cpp
@@ -129,7 +129,7 @@ void ActionDialog::restoreHistory()
 
 const QString ActionDialog::dataFilename() const
 {
-    return getConfigurationFilePath("_cmds.dat");
+    return stateFilePath("_cmds.dat");
 }
 
 void ActionDialog::saveHistory()

--- a/src/gui/filterlineedit.cpp
+++ b/src/gui/filterlineedit.cpp
@@ -311,7 +311,7 @@ private:
 class FilterHistory final {
 public:
     FilterHistory()
-        : m_settings( getConfigurationFilePath("-filter.ini"), QSettings::IniFormat )
+        : m_settings( stateFilePath("-filter.ini"), QSettings::IniFormat )
     {
     }
 

--- a/src/gui/geometry.cpp
+++ b/src/gui/geometry.cpp
@@ -82,7 +82,7 @@ QString geometryOptionName(const QWidget &widget, bool openOnCurrentScreen)
 
 QString getGeometryConfigurationFilePath()
 {
-    return getConfigurationFilePath("_geometry.ini");
+    return stateFilePath("_geometry.ini");
 }
 
 QString resolutionTagForScreen(int i)
@@ -202,6 +202,7 @@ void saveWindowGeometry(QWidget *w, bool openOnCurrentScreen)
 
     const QString optionName = geometryOptionName(*w, openOnCurrentScreen);
     const QString tag = resolutionTag(*w, openOnCurrentScreen);
+    ensureStateDirectoryExists();
     QSettings geometrySettings( getGeometryConfigurationFilePath(), QSettings::IniFormat );
     const auto geometry = w->saveGeometry();
     geometrySettings.setValue(optionName + tag, geometry);
@@ -219,6 +220,7 @@ QByteArray mainWindowState(const QString &mainWindowObjectName)
 
 void saveMainWindowState(const QString &mainWindowObjectName, const QByteArray &state)
 {
+    ensureStateDirectoryExists();
     const QString optionName = QStringLiteral("Options/%1_state").arg(mainWindowObjectName);
     setGeometryOptionValue(optionName, state);
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -547,7 +547,7 @@ QVariantMap exportSettings(const QStringList &tabs, bool exportConfiguration, bo
     QVariantList commandsList;
     if (exportCommands) {
         log("Exporting commands");
-        Settings settings(getConfigurationFilePath("-commands.ini"));
+        Settings settings(configurationFilePath("-commands.ini"));
         const int commandCount = settings.beginReadArray(QLatin1String("Commands"));
         commandsList.reserve(commandCount);
         for (int i = 0; i < commandCount; ++i) {
@@ -2414,7 +2414,7 @@ void MainWindow::importSelected(const ImportSelection &sel)
             m_commandDialog = nullptr;
         }
 
-        Settings settings(getConfigurationFilePath("-commands.ini"));
+        Settings settings(configurationFilePath("-commands.ini"));
 
         const QString commandGroup = QStringLiteral("Command");
         const QString commandsGroup = QStringLiteral("Commands");

--- a/src/gui/tabicons.cpp
+++ b/src/gui/tabicons.cpp
@@ -8,6 +8,8 @@
 #include "common/textdata.h"
 #include "gui/iconfactory.h"
 
+#include <QFileInfo>
+
 #include <QComboBox>
 #include <QDir>
 #include <QHash>
@@ -28,11 +30,11 @@ QList<QString> savedTabs()
 {
     QList<QString> tabs = AppConfig().option<Config::tabs>();
 
-    const QString configPath = settingsDirectoryPath();
-
-    QDir configDir(configPath);
-    QList<QString> files = configDir.entryList({QStringLiteral("*_tab_*.dat")});
-    files.append(configDir.entryList({QStringLiteral("*_tab_*.dat.tmp")}));
+    const QFileInfo baseInfo(tabDataFileBasePath());
+    QDir dir = baseInfo.dir();
+    const QString prefix = baseInfo.fileName();
+    QList<QString> files = dir.entryList({prefix + QLatin1String("*.dat")});
+    files.append(dir.entryList({prefix + QLatin1String("*.dat.tmp")}));
 
     QRegularExpression re("_tab_([^.]*)");
 

--- a/src/gui/tabwidget.cpp
+++ b/src/gui/tabwidget.cpp
@@ -18,9 +18,9 @@
 
 namespace {
 
-QString getTabWidgetConfigurationFilePath()
+QString tabWidgetConfigurationFilePath()
 {
-    return getConfigurationFilePath("_tabs.ini");
+    return stateFilePath("_tabs.ini");
 }
 
 template <typename Receiver, typename Slot>
@@ -183,7 +183,7 @@ void TabWidget::addToolBars(QMainWindow *mainWindow)
 
 void TabWidget::saveTabInfo()
 {
-    QSettings settings(getTabWidgetConfigurationFilePath(), QSettings::IniFormat);
+    QSettings settings(tabWidgetConfigurationFilePath(), QSettings::IniFormat);
 
     m_tabs->updateCollapsedTabs(&m_collapsedTabs);
     settings.setValue("TabWidget/collapsed_tabs", m_collapsedTabs);
@@ -199,7 +199,7 @@ void TabWidget::saveTabInfo()
 
 void TabWidget::loadTabInfo()
 {
-    QSettings settings(getTabWidgetConfigurationFilePath(), QSettings::IniFormat);
+    QSettings settings(tabWidgetConfigurationFilePath(), QSettings::IniFormat);
 
     m_collapsedTabs = settings.value("TabWidget/collapsed_tabs").toStringList();
 

--- a/src/item/itemstore.cpp
+++ b/src/item/itemstore.cpp
@@ -9,8 +9,11 @@
 #include "item/serialize.h"
 
 #include <QAbstractItemModel>
+#include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
 #include <QSaveFile>
 #include <QSet>
 
@@ -21,7 +24,7 @@ QString itemFileName(const QString &id)
 {
     QString part( id.toUtf8().toBase64() );
     part.replace( QChar('/'), QChar('-') );
-    return getConfigurationFilePath("_tab_") + part + QLatin1String(".dat");
+    return tabDataFileBasePath() + part + QLatin1String(".dat");
 }
 
 void printItemFileError(
@@ -88,6 +91,53 @@ void cleanDataDir(QDir *dir)
         QDir().rmdir( dir->absolutePath() );
 }
 
+bool migrateFiles(const QString &oldDir, const QString &newDir, const QStringList &patterns,
+                  LogLevel successLogLevel = LogNote)
+{
+    if (oldDir == newDir)
+        return true;
+
+    QDir src(oldDir);
+    QDir dst(newDir);
+
+    QStringList files;
+    for (const auto &pattern : patterns)
+        files.append(src.entryList({pattern}, QDir::Files));
+    if (files.isEmpty())
+        return true;
+
+    bool ok = true;
+    for (const QString &fileName : files) {
+        const QString oldPath = src.absoluteFilePath(fileName);
+        const QString newPath = dst.absoluteFilePath(fileName);
+
+        if (QFile::exists(newPath)) {
+            log(QStringLiteral("Migration: Skipping %1 — destination already exists: %2")
+                .arg(oldPath, newPath), LogWarning);
+            continue;
+        }
+
+        QFile file(oldPath);
+        if (file.rename(newPath)) {
+            log(QStringLiteral("Migration: Moved %1 to %2")
+                .arg(oldPath, newPath), successLogLevel);
+        } else {
+            const QString renameError = file.errorString();
+            // Cross-device fallback
+            if (file.copy(newPath)) {
+                QFile::remove(oldPath);
+                log(QStringLiteral("Migration: Copied %1 to %2 (cross-device)")
+                    .arg(oldPath, newPath), successLogLevel);
+            } else {
+                log(QStringLiteral("Migration: Failed to move %1 to %2: rename: %3, copy: %4")
+                    .arg(oldPath, newPath, renameError, file.errorString()), LogWarning);
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
 } // namespace
 
 ItemSaverPtr loadItems(const QString &tabName, QAbstractItemModel &model, ItemFactory *itemFactory, int maxItems)
@@ -113,7 +163,7 @@ bool saveItems(const QString &tabName, const QAbstractItemModel &model, const It
 {
     const QString tabFileName = itemFileName(tabName);
 
-    if ( !ensureSettingsDirectoryExists() )
+    if ( !QFileInfo(itemDataPath()).dir().mkpath(QStringLiteral(".")) )
         return false;
 
     // Save tab data to a new temporary file.
@@ -216,5 +266,68 @@ void cleanDataFiles(const QStringList &tabNames, const Encryption::EncryptionKey
             cleanDataDir(&d2);
         }
         cleanDataDir(&d1);
+    }
+}
+
+void migrateDataFiles()
+{
+    const QString oldDir = settingsDirectoryPath();
+    const QString sentinelPath = statePath() + QLatin1String("/copyq_migrated");
+    if (QFile::exists(sentinelPath))
+        return;
+
+    const QString dataDir = QFileInfo(itemDataPath()).path();
+    QDir(dataDir).mkpath(QStringLiteral("."));
+    if ( !ensureStateDirectoryExists() )
+        return;
+
+    const QString appName = QCoreApplication::applicationName();
+
+    bool ok = true;
+
+    // Tab data -> data directory
+    if ( !migrateFiles(oldDir, dataDir, {
+             appName + QLatin1String("_tab_*.dat"),
+             appName + QLatin1String("_tab_*.dat.tmp")}) )
+    {
+        ok = false;
+    }
+
+    // State files -> state directory
+    if ( !migrateFiles(oldDir, statePath(), {
+             appName + QLatin1String("_geometry.ini"),
+             appName + QLatin1String("_tabs.ini"),
+             appName + QLatin1String("-filter.ini"),
+             appName + QLatin1String("-monitor.ini"),
+             appName + QLatin1String("_cmds.dat")}) )
+    {
+        ok = false;
+    }
+
+    // Log files -> logs subdirectory (previously in data directory)
+    const QString logDir = statePath() + QLatin1String("/logs");
+    QDir(logDir).mkpath(QStringLiteral("."));
+    if ( !migrateFiles(
+             QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation),
+             logDir, {
+                 QStringLiteral("copyq-*.log"),
+                 QStringLiteral("copyq-*.log.*")},
+             LogDebug) )
+    {
+        ok = false;
+    }
+
+    if (!ok) {
+        log(QStringLiteral("Migration: Some files failed to migrate; will retry on next startup"),
+            LogWarning);
+        return;
+    }
+
+    QFile sentinel(sentinelPath);
+    if (sentinel.open(QIODevice::WriteOnly)) {
+        sentinel.close();
+    } else {
+        log(QStringLiteral("Migration: Failed to create sentinel file %1: %2")
+            .arg(sentinelPath, sentinel.errorString()), LogWarning);
     }
 }

--- a/src/item/itemstore.h
+++ b/src/item/itemstore.h
@@ -33,3 +33,5 @@ bool moveItems(
         );
 
 void cleanDataFiles(const QStringList &tabNames, const Encryption::EncryptionKey *encryptionKey = nullptr);
+
+void migrateDataFiles();

--- a/src/item/serialize.cpp
+++ b/src/item/serialize.cpp
@@ -2,6 +2,7 @@
 
 #include "serialize.h"
 
+#include "common/config.h"
 #include "common/contenttype.h"
 #include "common/encryption.h"
 #include "common/mimetypes.h"
@@ -770,11 +771,6 @@ bool itemDataFiles(QIODevice *file, QStringList *files, const Encryption::Encryp
     }
 
     return out.status() == QDataStream::Ok;
-}
-
-QString itemDataPath()
-{
-    return qApp->property("CopyQ_item_data_path").toString();
 }
 
 qint64 estimateDataSize(const QVariantMap &data)

--- a/src/item/serialize.h
+++ b/src/item/serialize.h
@@ -28,7 +28,6 @@ bool deserializeData(QAbstractItemModel *model, QDataStream *stream, const Encry
 bool serializeData(const QAbstractItemModel &model, QIODevice *file, int itemDataThreshold = -1, const Encryption::EncryptionKey *encryptionKey = nullptr);
 bool deserializeData(QAbstractItemModel *model, QIODevice *file, const Encryption::EncryptionKey *encryptionKey = nullptr);
 
-QString itemDataPath();
 bool itemDataFiles(QIODevice *file, QStringList *files, const Encryption::EncryptionKey *encryptionKey = nullptr);
 
 qint64 estimateDataSize(const QVariantMap &data);

--- a/src/platform/win/winplatform.cpp
+++ b/src/platform/win/winplatform.cpp
@@ -184,6 +184,7 @@ void initApplication(QCoreApplication *app)
         if ( qEnvironmentVariableIsEmpty("COPYQ_LOG_DIR") )
             qputenv("COPYQ_LOG_DIR", folder.toLocal8Bit() + "/logs");
         app->setProperty("CopyQ_item_data_path", configFolder + QLatin1String("/items"));
+        app->setProperty("CopyQ_state_path", configFolder);
     }
 }
 

--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -2661,18 +2661,14 @@ bool ScriptableProxy::getSelectionData()
 void setClipboardMonitorRunning(bool running)
 {
     QSettings settings(
-          QSettings::IniFormat,
-          QSettings::UserScope,
-          QCoreApplication::organizationName(),
-          QCoreApplication::applicationName() + "-monitor");
+          stateFilePath("-monitor.ini"),
+          QSettings::IniFormat);
     settings.setValue(QStringLiteral("running"), running);
 }
 bool isClipboardMonitorRunning()
 {
     const QSettings settings(
-          QSettings::IniFormat,
-          QSettings::UserScope,
-          QCoreApplication::organizationName(),
-          QCoreApplication::applicationName() + "-monitor");
+          stateFilePath("-monitor.ini"),
+          QSettings::IniFormat);
     return settings.value(QStringLiteral("running")).toBool();
 }

--- a/src/tests/tests_drag_n_drop.cpp
+++ b/src/tests/tests_drag_n_drop.cpp
@@ -143,7 +143,7 @@ void CoreTests::dragNDropTreeTabPartialRenameFailure()
     // Plant a blocker file at the destination path for 'b/a/y'.
     // QFile::copy() will refuse to overwrite the existing file, making
     // moveItems() fail for that one tab while 'a/x' -> 'b/a/x' succeeds.
-    const QString blockerPath = getConfigurationFilePath("_tab_")
+    const QString blockerPath = tabDataFileBasePath()
         + QString::fromUtf8(QByteArray("b/a/y").toBase64()).replace('/', '-')
         + QStringLiteral(".dat");
     QVERIFY(QFile(blockerPath).open(QIODevice::WriteOnly));
@@ -187,7 +187,7 @@ void CoreTests::dragNDropTreeTabKeepsCollapsedState()
     WAIT_ON_OUTPUT("tab", "a/b\na/c\nx\nCLIPBOARD\n");
 
     // Stop the server, inject collapsed state for group 'a', and restart.
-    const QString tabsIniPath = getConfigurationFilePath("_tabs.ini");
+    const QString tabsIniPath = stateFilePath("_tabs.ini");
     TEST( m_test->stopServer() );
     {
         QSettings settings(tabsIniPath, QSettings::IniFormat);


### PR DESCRIPTION
Move tab item data files (`_tab_*.dat`) to the data directory
and UI state files (geometry, collapsed tabs, filter history,
action history, monitor state) to the state directory. Log files
move to a `logs` subdirectory of the state directory.

Only actual configuration (`copyq.ini`, commands, encryption keys)
remains in the config directory.

Default paths on Linux:
- Config: `~/.config/copyq`
- Data: `~/.local/share/copyq`
- State: `~/.local/state/copyq` (follows `$XDG_STATE_HOME`)

On Windows, data and state move from `%APPDATA%` (roaming) to
`%LOCALAPPDATA%` (local). On macOS, data and state use
`~/Library/Application Support`. Windows portable mode is unchanged.

Existing files are automatically migrated on first server startup,
with a cross-device copy+delete fallback.

New environment variables: `COPYQ_STATE_PATH`, `COPYQ_LOG_DIR`.
New diagnostic path: `copyq info state`.

Fixes #3692
Fixes #3693

Assisted-by: Claude (Anthropic)