### PR TITLE
Fix initial script dialog sizing from its completed layout

### DIFF
--- a/src/scriptable/scriptableproxy.cpp
+++ b/src/scriptable/scriptableproxy.cpp
@@ -1915,6 +1915,18 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
             widgets.append( createWidget(value.name, value.value, &inputDialog) );
     }
 
+    if ( !styleSheet.isEmpty() )
+        dialog.setStyleSheet(styleSheet);
+
+    auto buttons = new QDialogButtonBox(
+                QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
+    QObject::connect( buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept );
+    QObject::connect( buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject );
+    dialog.layout()->addWidget(buttons);
+
+    // Use the contents as the default size before restoring or overriding geometry.
+    dialog.adjustSize();
+
     if ( !dialogTitle.isNull() ) {
         dialog.setWindowTitle(dialogTitle);
         dialog.setObjectName(QStringLiteral("dialog_") + dialogTitle);
@@ -1937,15 +1949,6 @@ int ScriptableProxy::inputDialog(const NamedValueList &values)
 
     if (geometry.x() >= 0 && geometry.y() >= 0)
         dialog.move(geometry.topLeft());
-
-    if ( !styleSheet.isEmpty() )
-        dialog.setStyleSheet(styleSheet);
-
-    auto buttons = new QDialogButtonBox(
-                QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
-    QObject::connect( buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept );
-    QObject::connect( buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject );
-    dialog.layout()->addWidget(buttons);
 
     installShortcutToCloseDialog(&dialog, &dialog, QKeyCombination(Qt::ControlModifier, Qt::Key_Enter).toCombined());
     installShortcutToCloseDialog(&dialog, &dialog, QKeyCombination(Qt::ControlModifier, Qt::Key_Return).toCombined());

--- a/src/tests/itemtests/itemtests.cpp
+++ b/src/tests/itemtests/itemtests.cpp
@@ -8,6 +8,8 @@
 #include <QItemSelectionModel>
 #include <QLoggingCategory>
 #include <QRegularExpression>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QTest>
 #include <QTimer>
 
@@ -478,6 +480,27 @@ QVariant ItemTestsLoader::scriptCallback(const QVariantList &arguments)
 
     if (cmd == "sendKeysStatus")
         return keyClicker()->status(arguments.value(1).toBool());
+
+    if (cmd == "dialogGeometry" || cmd == "resizeDialog") {
+        for (auto window : QApplication::topLevelWidgets()) {
+            if (window->isVisible() && window->objectName() == arguments.value(1).toString()) {
+                if (cmd == "resizeDialog") {
+                    window->resize(arguments.value(2).toInt(), arguments.value(3).toInt());
+                    return {};
+                }
+                const auto area = window->findChild<QScrollArea*>();
+                if (area) {
+                    return QVariantMap{
+                        {"width", window->width()},
+                        {"height", window->height()},
+                        {"horizontalScrollMaximum", area->horizontalScrollBar()->maximum()},
+                        {"verticalScrollMaximum", area->verticalScrollBar()->maximum()},
+                    };
+                }
+            }
+        }
+        return {};
+    }
 
     return QStringLiteral("Unexpected command: %1").arg(cmd);
 }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -71,6 +71,8 @@ private slots:
     void commandToggleConfig();
 
     void commandDialog();
+    void commandDialogFitsContents();
+    void commandDialogRestoreGeometry();
     void commandDialogCloseOnDisconnect();
 
     void commandMenuItems();

--- a/src/tests/tests_scripts.cpp
+++ b/src/tests/tests_scripts.cpp
@@ -6,6 +6,7 @@
 
 #include "common/mimetypes.h"
 #include "common/commandstatus.h"
+#include "common/display.h"
 
 #include <QElapsedTimer>
 #include <QRegularExpression>
@@ -460,6 +461,53 @@ void CoreTests::commandDialog()
         [&]{ RUN(script2, "DEFAULT\n"); },
         [&]{ KEYS("focus::QLineEdit<:QDialog" << "ENTER"); }
     );
+}
+
+void CoreTests::commandDialogFitsContents()
+{
+    KEYS(clipboardBrowserId);
+    RUN_MULTIPLE(
+        [&]{ RUN("dialog('.title', 'size hint', '.label', "
+                 "'This label should fit in the initial dialog width.', 'text', 'DEFAULT')",
+                 "DEFAULT\n"); },
+        [&]{
+            KEYS("focus::QLineEdit<dialog_size hint:QDialog");
+            const auto errors = m_test->runClient(
+                Args() << "print(callPlugin('itemtests', 'dialogGeometry', 'dialog_size hint').horizontalScrollMaximum)",
+                "0");
+            KEYS("focus::QLineEdit<dialog_size hint:QDialog" << "ENTER");
+            TEST(errors);
+        }
+    );
+}
+
+void CoreTests::commandDialogRestoreGeometry()
+{
+    auto expectedSize = QByteArray::number(pointsToPixels(360)) + 'x'
+        + QByteArray::number(pointsToPixels(180));
+    const auto sizeScript =
+        "var g = callPlugin('itemtests', 'dialogGeometry', 'dialog_saved size');"
+        "print(g.width + 'x' + g.height);";
+
+    for (const auto script : {
+             "dialog('.title', 'saved size', '.width', 360, '.height', 180, 'text', 'DEFAULT')",
+             "dialog('.title', 'saved size', 'text', 'DEFAULT')"}) {
+        KEYS(clipboardBrowserId);
+        RUN_MULTIPLE(
+            [&]{ RUN(script, "DEFAULT\n"); },
+            [&]{
+                KEYS("focus::QLineEdit<dialog_saved size:QDialog");
+                const auto errors = m_test->runClient(Args() << sizeScript, expectedSize);
+                // Let the geometry guard unlock before simulating a user resize.
+                RUN("sleep(350)", "");
+                RUN("callPlugin('itemtests', 'resizeDialog', 'dialog_saved size', 420, 240)", "");
+                RUN("sleep(350)", "");
+                KEYS("focus::QLineEdit<dialog_saved size:QDialog" << "ENTER");
+                TEST(errors);
+            }
+        );
+        expectedSize = "420x240";
+    }
 }
 
 void CoreTests::commandDialogCloseOnDisconnect()


### PR DESCRIPTION
Script dialogs without saved geometry can open at a narrow default width even when their labels need more space. In #3583, a short title leaves much of the form behind scrollbars. `inputDialog()` fills unspecified dimensions from the dialog's current size before it has adjusted to its contents, and adds the button box after sizing.

Create the button box and apply the stylesheet before calculating the default size with `adjustSize()`. Restore saved geometry and apply explicit `.width` / `.height` afterwards. This preserves user sizing and the scroll area's existing size limits for large forms.

Add integration tests for initial content fitting and for explicit dimensions followed by restoring a user-resized dialog. The test plugin exposes dialog geometry and a resize action to exercise these behaviors in the real application.

Related to #3583.

Validation on Windows 11 build 22631, MSVC 19.44, Qt 6.10.2, Debug:

- New content-fitting test fails on `81c5c21b60a3bc81c242eb0625a827e68470ad55`: horizontal scroll maximum is 124 instead of 0. It passes with the fix.
- `commandDialogFitsContents`, `commandDialogRestoreGeometry`, `commandDialog`, and `commandDialogCloseOnDisconnect` pass (6 passed including suite setup/cleanup, 0 failed).
- Running the form reconstructed from the issue attachment changes its initial size from 190×107 to 562×413 on this display. Large content remains scrollable.
- `git diff --check` passes.

Optional encryption, keychain, audio, native notifications and regular plugins were disabled for this local build. The test plugin was built and loaded. Full upstream CI, Linux/macOS and Qt 6.10.3 (currently used by Windows CI) have not been run. Existing saved small geometry is intentionally retained.
